### PR TITLE
perf: skip register alias initialization

### DIFF
--- a/smallworld/state.py
+++ b/smallworld/state.py
@@ -186,6 +186,11 @@ class RegisterAlias(Register):
 
         self.reference.set(result)
 
+    def initialize(
+        self, initializer: initializer.Initializer, override: bool = False
+    ) -> None:
+        logger.debug(f"skipping initialization for {self} (alias)")
+
     def load(self, executor: executor.Executor, override: bool = True) -> None:
         """Register references store no value, so this does nothing."""
 


### PR DESCRIPTION
Fixes duplicate register alias initialization.

Note: this has the side effect of making it impossible to apply an initializer to a register alias... Debate welcome.