### PR TITLE
fix: allow multiple angr analyses

### DIFF
--- a/smallworld/analyses/angr/nwbt.py
+++ b/smallworld/analyses/angr/nwbt.py
@@ -4,6 +4,7 @@ from .divergence import DivergenceExplorationMixin, DivergenceMemoryMixin
 from .memtrack import TrackerMemoryMixin
 from .model import ModelMemoryMixin
 from .terminate import TerminationExplorationMixin
+from .typedefs import TypeDefPlugin
 
 
 class NWBTMemoryPlugin(
@@ -21,3 +22,28 @@ class NWBTExplorationTechnique(
     angr.exploration_techniques.suggestions.Suggestions,
 ):
     pass
+
+
+def configure_nwbt_plugins(emu):
+    """Configure NWBT analysis plugins.
+
+    This creates a new plugin preset that overrides
+    angr's default symbolic memory plugin.
+    This preset is passed to the entry state constructor,
+    and can't be changed afterward.
+    Thus, this needs to get called in a preinit callback.
+    """
+    preset = angr.SimState._presets["default"].copy()
+    preset.add_default_plugin("sym_memory", NWBTMemoryPlugin)
+    preset.add_default_plugin("typedefs", TypeDefPlugin)
+    emu._plugin_preset = preset
+
+
+def configure_nwbt_strategy(emu):
+    """Configure NWBT analysis strategies
+
+    This overrides the default angr exploration strategy.
+    This needs to access the instantiated exploration manager,
+    so it needs to get called in an init callback.
+    """
+    emu.mgr.use_technique(NWBTExplorationTechnique())

--- a/smallworld/analyses/angr_nwbt.py
+++ b/smallworld/analyses/angr_nwbt.py
@@ -2,8 +2,7 @@ import logging
 
 from .. import emulators, hinting, state
 from . import analysis
-from .angr.nwbt import NWBTExplorationTechnique, NWBTMemoryPlugin
-from .angr.typedefs import TypeDefPlugin
+from .angr.nwbt import configure_nwbt_plugins, configure_nwbt_strategy
 from .angr.utils import print_state
 
 log = logging.getLogger(__name__)
@@ -19,11 +18,10 @@ class AngrNWBTAnalysis(analysis.Analysis):
         self.initfunc = initfunc
 
     def analysis_preint(self, emu):
-        NWBTMemoryPlugin.register_default("sym_memory")
-        TypeDefPlugin.register_default("typedefs")
+        configure_nwbt_plugins(emu)
 
     def analysis_init(self, emu):
-        emu.mgr.use_technique(NWBTExplorationTechnique())
+        configure_nwbt_strategy(emu)
         if self.initfunc is not None:
             self.initfunc(self, emu.entry)
 

--- a/smallworld/emulators/angr.py
+++ b/smallworld/emulators/angr.py
@@ -46,6 +46,7 @@ class AngrEmulator(emulator.Emulator):
         self.analysis_init = init
         self._reg_init_values = dict()
         self._mem_init_values = dict()
+        self._plugin_preset = "default"
 
     @property
     def entry(self) -> angr.SimState:
@@ -161,10 +162,11 @@ class AngrEmulator(emulator.Emulator):
 
         # Initialize the entrypoint state.
         self._entry = self.proj.factory.entry_state(
+            plugin_preset=self._plugin_preset,
             add_options={
                 angr.options.SYMBOL_FILL_UNCONSTRAINED_REGISTERS,
                 angr.options.SYMBOL_FILL_UNCONSTRAINED_MEMORY,
-            }
+            },
         )
 
         def handle_exit(state):


### PR DESCRIPTION
This allows multiple angr analysis to coexist.
Previously, each analysis would clobber the
program-wide default plugins.

Now, each analysis passes a unique configuration
to the emulator to create the state.