### PR TITLE
fix: Repair type mismatch in BumpAllocator.malloc()

### DIFF
--- a/smallworld/state.py
+++ b/smallworld/state.py
@@ -449,7 +449,7 @@ class BumpAllocator(Heap):
 
         address = self.address + self.used
         self.memory.append((allocation, size))
-        self.used += allocation
+        self.used += size
 
         return address
 


### PR DESCRIPTION
Repairs bug introduced in last merge.
Type of `allocation` in `BumpAllocator.malloc()` changed,
but not all uses were updated.