### PR TITLE
chore: suppress upstream `DeprecationWarning`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,3 +192,11 @@ epub_exclude_files = ["search.html"]
 autodoc_member_order = "bysource"
 autodoc_default_options = {"members": None, "inherited-members": None}
 autodoc_mock_imports = ["angr", "claripy", "cle", "capstone", "unicorn"]
+
+
+# Suppress upstream deprecation warnings
+import warnings
+
+warnings.filterwarnings(
+    "ignore", category=DeprecationWarning, module="sphinxcontrib.programoutput"
+)


### PR DESCRIPTION
- suppresses warnings like the following during documentation build:

```
/home/centrify/al26435/env/smallworld/lib/python3.8/site-packages/sphinxcontrib/programoutput/__init__.py:267: PendingDeprecationWarning: nodes.Node.traverse() is obsoleted by Node.findall()
```

It seems unlikely that `sphinxcontrib-programoutput` will fix this - their last release was in 2021...