### PR TITLE
chore: organize changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,36 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `Memory` state objects with large values are now stringified much faster.
-- `InputColorizerAnalysis` colorizer_registers now can handle 32-bit cpu.
+- `InputColorizerAnalysis` can now handle 32-bit cpu.
 	
 ### Added
-- `AngrEmulator` based on angr symbolic execution.
-- `AngrNWBTAnalysis` unused value analysis using angr.
-- `ELFImage` state object that loads an ELF file.
 - `Filter` analyses that simply listen to the hint stream.
 - `Instruction` classes that provide information on instruction semantics, with
   methods for capturing concrete values.
-- `ControlFlowTracer` analysis that logs all jumps, calls, and returns.
-- `fuzz()` AFL Unicorn fuzzing harness utility.
-- `CodeCoverage` analysis that maps program counter to hit count.
 - `Value.type` for storing optional type information.
 - `Value.label` for storing optional label information.
+- `Emulator.hook()` for dynamic hooking.
 - `state.models` a collection of python models for library code implemented as
   customizable hooks.
-- `Emulator.hook()` for dynamic hooking.
-- `CodeReachable` analysis that show what code is reachable by symbolic execution.
 - `state.debug` a collection of debug utilities that can be mapped into state.
+- `fuzz()` AFL Unicorn fuzzing harness utility.
+- `AngrEmulator` based on angr symbolic execution.
+- `ELFImage` state object that loads an ELF file.
+- `AngrNWBTAnalysis` unused value analysis using angr.
+- `ControlFlowTracer` analysis that logs all jumps, calls, and returns.
+- `CodeCoverage` analysis that maps program counter to hit count.
+- `CodeReachable` analysis that show what code is reachable by symbolic execution.
 
 ### Changed
-- `State.map()` automatically selects names for mapped objects when not
-  provided.
+- `Value.{get, set}()` changed to `@property` `value`.
 - `UnicornEmulator` captures more detailed error information in single step
   mode.
 - `UnicornEmulator.write_memory()` now supports overlapping writes and no
   longer requires addresses to be page aligned.
-- `Value.{get, set}()` changed to `@property` `value`.
 - `Code.exits` changed to `Code.bounds` - ranges of valid execution rather than
   fixed exit points.
+- `State.map()` automatically selects names for mapped objects when not
+  provided.
 
 ## [0.0.1] - 2024-02-26
 


### PR DESCRIPTION
- sorts the changelog based on (arbitrary) importance
- groups changelog items by type