### PR TITLE
chore: consolidate testing dependencies

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y nasm binutils-aarch64-linux-gnu binutils-arm-linux-gnueabi binutils-arm-linux-gnueabihf binutils-mips-linux-gnu binutils-mips64-linux-gnuabi64 binutils-powerpc-linux-gnu binutils-powerpc64-linux-gnu binutils-riscv64-linux-gnu binutils-sparc64-linux-gnu
+          sudo apt-get install -y $(cat ./tests/dependencies/apt.txt)
           sudo apt-get install -y ./tests/dependencies/*.deb
           python -m pip install ./tests/dependencies/*.whl
       - name: Install

--- a/README.md
+++ b/README.md
@@ -101,10 +101,11 @@ Or other [supported Sphinx output formats](https://www.sphinx-doc.org/en/master/
 
 #### Prerequisites
 
-Building the test binaries requires `nasm`, which can be installed with:
+Building the test binaries requires some dependencies which can be installed
+with:
 
 ```bash
-apt-get install nasm
+apt-get install `cat tests/dependencies/apt.txt`
 ```
 
 You can then build the tests by running:

--- a/tests/dependencies/apt.txt
+++ b/tests/dependencies/apt.txt
@@ -1,0 +1,10 @@
+nasm
+binutils-aarch64-linux-gnu
+binutils-arm-linux-gnueabi
+binutils-arm-linux-gnueabihf
+binutils-mips-linux-gnu
+binutils-mips64-linux-gnuabi64
+binutils-powerpc-linux-gnu
+binutils-powerpc64-linux-gnu
+binutils-riscv64-linux-gnu
+binutils-sparc64-linux-gnu


### PR DESCRIPTION
An alternative to https://github.com/smallworld-re/smallworld/pull/98.

- moves testing dependencies to a text file we can reference
- updates README