### PR TITLE
feat: Attempt to break integration tests into a matrix.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -71,5 +71,5 @@ jobs:
         if: ${{ !(contains(needs.*.results, 'failure')) }}
         run: exit 0
       - name: Tests Failed
-        if: ${{ contains(needs.*.results, 'failure')) }}
+        if: ${{ contains(needs.*.results, 'failure') }}
         run: exit 1


### PR DESCRIPTION
Use github matrices to repeat integration tests for each test case in parallel.
This is naive, in that it will run the entire pull test process for each test case.  We will fix that later