### PR TITLE
feat: Add Xtensa support

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --extra=development --output-file=constraints.txt setup.py
 #
-ailment==9.2.136
+ailment==9.2.137
     # via angr
 alabaster==0.7.13
     # via sphinx
-angr==9.2.136
+angr==9.2.137
     # via smallworld (setup.py)
-archinfo==9.2.136
+archinfo==9.2.137
     # via
     #   angr
     #   pyvex
@@ -44,9 +44,9 @@ cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.3.2
     # via requests
-claripy==9.2.136
+claripy==9.2.137
     # via angr
-cle==9.2.136
+cle==9.2.137
     # via angr
 click==8.1.7
     # via
@@ -155,7 +155,7 @@ pyproject-hooks==1.0.0
     # via build
 pysmt==0.9.5
     # via claripy
-pyvex==9.2.136
+pyvex==9.2.137
     # via
     #   angr
     #   cle

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --extra=development --output-file=constraints.txt setup.py
 #
-ailment==9.2.79
+ailment==9.2.136
     # via angr
 alabaster==0.7.13
     # via sphinx
-angr==9.2.79
+angr==9.2.136
     # via smallworld (setup.py)
-archinfo==9.2.79
+archinfo==9.2.136
     # via
     #   angr
     #   pyvex
@@ -30,7 +30,7 @@ cachetools==5.3.2
     # via
     #   angr
     #   claripy
-capstone==5.0.0.post1
+capstone==5.0.3
     # via
     #   angr
     #   smallworld (setup.py)
@@ -44,9 +44,9 @@ cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.3.2
     # via requests
-claripy==9.2.79
+claripy==9.2.136
     # via angr
-cle==9.2.79
+cle==9.2.136
     # via angr
 click==8.1.7
     # via
@@ -131,7 +131,7 @@ ply==3.11
     # via cppheaderparser
 pre-commit==3.5.0
     # via smallworld (setup.py)
-protobuf==4.25.1
+protobuf==5.28.2
     # via angr
 psutil==5.9.6
     # via angr
@@ -149,13 +149,13 @@ pygments==2.17.2
     # via
     #   rich
     #   sphinx
-pypcode==2.1.0
+pypcode==3.0
     # via smallworld (setup.py)
 pyproject-hooks==1.0.0
     # via build
 pysmt==0.9.5
     # via claripy
-pyvex==9.2.79
+pyvex==9.2.136
     # via
     #   angr
     #   cle
@@ -216,7 +216,7 @@ virtualenv==20.24.7
     # via pre-commit
 wheel==0.42.0
     # via pip-tools
-z3-solver==4.10.2.0
+z3-solver==4.13.0.0
     # via claripy
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/docs/usage/basic_isa_support.csv
+++ b/docs/usage/basic_isa_support.csv
@@ -1,0 +1,16 @@
+,               angr,       panda,      unicorn
+aarch64,        **Yes**,    **Yes**,    **Yes**
+amd64,          **Yes**,    **Yes**,    **Yes**
+arm-v5t,        **Yes**,    **Yes**,    **Yes**
+arm-v6m,        **Yes**,    No,         **Yes**
+arm-v7a,        **Yes**,    **Yes**,    **Yes**
+arm-v7m,        **Yes**,    No,         **Yes**
+arm-v7r,        No,         No,         **Yes**
+i386,           **Yes**,    **Yes**,    **Yes**
+mips32r2-be,    **Yes**,    **Yes**,    **Yes**
+mips32r2-el,    **Yes**,    **Yes**,    **Yes**
+mips64r2-be,    **Yes**,    **Yes**,    No Support
+mips64r2-el,    **Yes**,    No,         No Support
+powerpc32,      **Yes**,    **Yes**,    No Support
+powerpc64,      **Yes**,    No,         No Support
+xtensa,         **Yes**,    No Support, No Support

--- a/docs/usage/float_support.csv
+++ b/docs/usage/float_support.csv
@@ -1,0 +1,20 @@
+,                           angr,       panda,      unicorn
+aarch64 scalar,             **Yes**,    No,         **Yes**
+aarch64 vector,             Untested,   No,         Untested
+amd64 x87,                  No,         No,         No
+amd64 mmx,                  No,         No,         No
+amd64 sse,                  **Yes**,    No,         **Yes**
+amd64 avx2,                 **Yes**,    No,         **Yes**
+amd64 avx512,               No Support, No,         Untested
+arm-v7 double scalar,       **Yes**,    No,         **Yes**
+arm-v7 quad scalar,         No Support, No,         Untested
+arm-v7 double vector,       Untested,   No,         Untested
+arm-v7 quad vector,         No Support, No,         Untested
+i386 x87,                   No,         No,         No
+i386 mmx,                   No,         No,         No
+i386 sse,                   **Yes**,    No,         **Yes**
+mips32,                     No,         No,         No Support
+mips64,                     No,         No,         No Support
+powerpc32,                  No,         No,         No Support
+powerpc64,                  No,         No Support, No Support
+xtensa,                     No,         No Support, No Support

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -7,3 +7,4 @@ Using SmallWorld
     emulators
     hinting
     analyses
+    platforms

--- a/docs/usage/platforms.rst
+++ b/docs/usage/platforms.rst
@@ -1,0 +1,80 @@
+.. _platforms:
+
+Supported Platforms
+===================
+
+SmallWorld provides a single interface for
+emulating or analyzing multiple ISAS and ABIs with multiple tools.
+Sadly, not every tool is compatible with every platform. 
+
+The following table gives a brief snapshot of our current emulation support.
+The entries mean the following:
+
+- **Yes**: The emulator supports at least the basic features of that ISA.
+- **No**: The emulator does not currently support that ISA, but it's not impossible.
+- **No Support**: The underlying tool does not support that ISA.
+
+.. csv-table:: Basic ISA Support
+    :file: basic_isa_support.csv
+    :header-rows: 1
+    :stub-columns: 1
+
+Specific Emulator Notes
+=======================
+
+- angr is strictly a user-space emulator.  It models very few, if any, privileged features of a processor.
+- Unicorn is a user-space emulator running on top of a full-system emulator (QEMU).  Privileged options may have unexpected effects or even crash the emulator.  Advanced users familiar with unicorn can unlock the full-system emulation features, but this is not supported directly by SmallWorld.
+
+Specific ISA Notes
+==================
+
+**arm32 Unicorn:** Unicorn only has one arm32 model.
+It appears to support up to arm-v7 application code, 
+but its privileged features are a mash-up of v6, v7, A-series, and M-series.  
+Support for privileged operations is unknown.
+
+**mips64 Panda:** The panda emulator currently runs code directly from physical memory.
+In mips64, the upper half of the address space is reserved for MMIO devices.
+Attempting to load state into this region will raise an exception.
+
+**xtensa:** The Xtensa ISA is made up of a core feature set, a number of open ISA options,
+and some proprietary extensions introduced by the manufacturer.
+Our emulation support depends on Ghidra's hardware model,
+which only handles part of the open ISA options.  
+In particular, it does _not_ handle all options and extensions used by the esp32 series of SoCs.
+You will run into untranslatable instruction errors.
+
+**Register Windows:** Some ISAs - SPARC64 and some Xtensa variants -
+save and restore call frames by changing how the general purpose registers alias the register file.  
+Compare this to how most other architectures push and pop registers from the stack.  
+Windowed architectures are impossible to emulate in a userspace-only emulator, 
+since they use interrupts to "spill" registers onto the stack if there are more call frames 
+than they have windows.  Currently, only angr supports the relevant ISAs;
+until that changes, SmallWorld cannot support windowed ISAs.
+
+Floating Point and Vector Support
+=================================
+
+Support for specific scalar and vector 
+floating point subsystems is much more variable, and largely untested.
+
+The following table lists our current support for known subsystems.
+"Support" means that a) the underlying emulator can emulate the instructions,
+and b) that we can interact with the relevant machine state through SmallWorld. 
+The entries mean the following:
+
+- **Yes:** The emulator has tested support for this subsystem.
+- **Untested:** The emulator exposes the right state, but the system is untested
+- **No**: The emulator does not currently support this subsystem.
+- **No Support:** The underlying tool doesn't support this subsytem
+
+.. csv-table:: Basic ISA Support
+    :file: float_support.csv
+    :header-rows: 1
+    :stub-columns: 1
+
+A few notes:
+
+- SmallWorld's State interface doesn't have special handling for floating-point registers.  Encoding and decoding the floating point format is currently up to the user. 
+- Panda can probably emulate many of these, but it needs to be modified to expose the FPU registers.
+- Unicorn looks like it supports the mips32 FPU.  It does not.

--- a/smallworld/analyses/unstable/angr/base.py
+++ b/smallworld/analyses/unstable/angr/base.py
@@ -1,7 +1,7 @@
-from angr.storage import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
-class BaseMemoryMixin(MemoryMixin):
+class BaseMemoryMixin(MemoryMixin):  # type: ignore[misc]
     """Base class for memory mixins.
 
     I wanted to add the _setup_tui() method,

--- a/smallworld/analyses/unstable/angr/divergence.py
+++ b/smallworld/analyses/unstable/angr/divergence.py
@@ -1,7 +1,7 @@
 import logging
 
 import angr
-from angr.storage import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 from .... import hinting
 from ....emulators.angr import PathTerminationSignal

--- a/smallworld/analyses/unstable/angr/model.py
+++ b/smallworld/analyses/unstable/angr/model.py
@@ -2,7 +2,7 @@ import ctypes
 import logging
 
 import claripy
-from angr.storage import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 from .... import hinting
 from ....emulators.angr import PathTerminationSignal

--- a/smallworld/analyses/unstable/angr/nwbt.py
+++ b/smallworld/analyses/unstable/angr/nwbt.py
@@ -10,7 +10,7 @@ from .model import ModelMemoryMixin
 from .typedefs import TypeDefPlugin
 
 
-class NWBTMemoryPlugin(  # typing: ignore[misc]
+class NWBTMemoryPlugin(  # type: ignore[misc]
     DivergenceMemoryMixin,
     TrackerMemoryMixin,
     ModelMemoryMixin,

--- a/smallworld/analyses/unstable/angr/nwbt.py
+++ b/smallworld/analyses/unstable/angr/nwbt.py
@@ -10,7 +10,7 @@ from .model import ModelMemoryMixin
 from .typedefs import TypeDefPlugin
 
 
-class NWBTMemoryPlugin(
+class NWBTMemoryPlugin(  # typing: ignore[misc]
     DivergenceMemoryMixin,
     TrackerMemoryMixin,
     ModelMemoryMixin,

--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -61,12 +61,17 @@ class AngrEmulator(
     description = "an emulator using angr as its backend"
     version = "0.0"
 
-    def __init__(self, platform: platforms.Platform, preinit=None, init=None):
+    def __init__(
+        self, platform: platforms.Platform, preinit=None, init=None, successors=None
+    ):
         # Dirty bit; tells us if we've started emulation
         self._dirty: bool = False
 
         # Linear mode bit; tells us if we're running in forced linear execution
         self._linear: bool = False
+
+        # Successors function; allows manual-override of successor computation
+        self._successors = successors
 
         # Plugin preset; tells us which plugin preset to use.
         self._plugin_preset = "default"
@@ -786,7 +791,11 @@ class AngrEmulator(
             num_inst = 1
         else:
             num_inst = None
-        self.mgr.step(num_inst=num_inst, thumb=self.machdef.is_thumb)
+        self.mgr.step(
+            num_inst=num_inst,
+            successor_func=self._successors,
+            thumb=self.machdef.is_thumb,
+        )
 
         # Test for exceptional states
         if len(self.mgr.errored) > 0:

--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -764,7 +764,7 @@ class AngrEmulator(
         self._dirty = True
         if self._linear:
             if self.state._ip.concrete_value not in self.state.scratch.func_bps:
-                disas = self.state.block().disassembly
+                disas = self.state.block(opt_level=0).disassembly
                 if disas is not None and len(disas.insns) > 0:
                     log.info(f"Stepping through {disas.insns[0]}")
                 else:

--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -61,17 +61,12 @@ class AngrEmulator(
     description = "an emulator using angr as its backend"
     version = "0.0"
 
-    def __init__(
-        self, platform: platforms.Platform, preinit=None, init=None, successors=None
-    ):
+    def __init__(self, platform: platforms.Platform, preinit=None, init=None):
         # Dirty bit; tells us if we've started emulation
         self._dirty: bool = False
 
         # Linear mode bit; tells us if we're running in forced linear execution
         self._linear: bool = False
-
-        # Successors function; allows manual-override of successor computation
-        self._successors = successors
 
         # Plugin preset; tells us which plugin preset to use.
         self._plugin_preset = "default"
@@ -793,7 +788,7 @@ class AngrEmulator(
             num_inst = None
         self.mgr.step(
             num_inst=num_inst,
-            successor_func=self._successors,
+            successor_func=self.machdef.successors,
             thumb=self.machdef.is_thumb,
         )
 

--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -354,6 +354,11 @@ class AngrEmulator(
             emu = ConcreteAngrEmulator(state, self)
             function(emu)
 
+            # An update to angr means some operations on `state`
+            # will clobber this variable, which causes bad problems.
+            # Unclobber it, just in case
+            state.inspect.action_attrs_set = True
+
         bp = self.state.inspect.b(
             "instruction", when=angr.BP_BEFORE, action=hook_handler, instruction=address
         )
@@ -389,6 +394,11 @@ class AngrEmulator(
         def hook_handler(state):
             emu = ConcreteAngrEmulator(state, self)
             function(emu)
+
+            # An update to angr means some operations on `state`
+            # will clobber this variable, which causes bad problems.
+            # Unclobber it, just in case
+            state.inspect.action_attrs_set = True
 
         self.state.scratch.global_insn_bp = self.state.inspect.b(
             "instruction", when=angr.BP_BEFORE, action=hook_handler
@@ -527,6 +537,11 @@ class AngrEmulator(
                 res = claripy.Reverse(res)
             state.inspect.mem_read_expr = res
 
+            # An update to angr means some operations on `state`
+            # will clobber this variable, which causes bad problems.
+            # Unclobber it, just in case
+            state.inspect.action_attrs_set = True
+
         bp = self.state.inspect.b(
             "mem_read",
             when=angr.BP_AFTER,
@@ -577,6 +592,11 @@ class AngrEmulator(
                 # system produces the incorrect value in the machine state.
                 res = claripy.Reverse(res)
             state.inspect.mem_read_expr = res
+
+            # An update to angr means some operations on `state`
+            # will clobber this variable, which causes bad problems.
+            # Unclobber it, just in case
+            state.inspect.action_attrs_set = True
 
         bp = self.state.inspect.b(
             "mem_read",
@@ -671,6 +691,11 @@ class AngrEmulator(
 
             function(ConcreteAngrEmulator(state, self), addr, size, value)
 
+            # An update to angr means some operations on `state`
+            # will clobber this variable, which causes bad problems.
+            # Unclobber it, just in case
+            state.inspect.action_attrs_set = True
+
         bp = self.state.inspect.b(
             "mem_write",
             when=angr.BP_BEFORE,
@@ -731,6 +756,11 @@ class AngrEmulator(
                 )
 
             function(ConcreteAngrEmulator(state, self), addr, size, value)
+
+            # An update to angr means some operations on `state`
+            # will clobber this variable, which causes bad problems.
+            # Unclobber it, just in case
+            state.inspect.action_attrs_set = True
 
         bp = self.state.inspect.b(
             "mem_write",

--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -757,9 +757,9 @@ class AngrEmulator(
         self._dirty = True
         if self._linear:
             if self.state._ip.concrete_value not in self.state.scratch.func_bps:
-                insns = self.state.block().disassembly.insns
-                if len(insns) > 0:
-                    log.info(f"Stepping through {insns[0]}")
+                disas = self.state.block().disassembly
+                if disas is not None and len(disas.insns) > 0:
+                    log.info(f"Stepping through {disas.insns[0]}")
                 else:
                     # Capstone only supports a subset of the instructions supported by LibVEX.
                     # I can only disassemble what I can disassemble.

--- a/smallworld/emulators/angr/machdefs/__init__.py
+++ b/smallworld/emulators/angr/machdefs/__init__.py
@@ -11,6 +11,7 @@ from .machdef import AngrMachineDef
 from .mips import MIPSBEMachineDef, MIPSELMachineDef
 from .mips64 import MIPS64BEMachineDef, MIPS64ELMachineDef
 from .ppc import PowerPC32MachineDef, PowerPC64MachineDef
+from .xtensa import XTensaBEMachineDef, XTensaELMachineDef
 
 __all__ = [
     "AArch64MachineDef",
@@ -27,4 +28,6 @@ __all__ = [
     "MIPS64ELMachineDef",
     "PowerPC32MachineDef",
     "PowerPC64MachineDef",
+    "XTensaBEMachineDef",
+    "XTensaELMachineDef",
 ]

--- a/smallworld/emulators/angr/machdefs/machdef.py
+++ b/smallworld/emulators/angr/machdefs/machdef.py
@@ -88,6 +88,8 @@ class AngrMachineDef:
         Returns:
             The successor states of `state`.
         """
+        if state.project is None:
+            raise exceptions.ConfigurationError("Angr state had no project.")
         return state.project.factory.successors(state, **kwargs)
 
     @classmethod

--- a/smallworld/emulators/angr/machdefs/machdef.py
+++ b/smallworld/emulators/angr/machdefs/machdef.py
@@ -66,6 +66,30 @@ class AngrMachineDef:
             )
         return self.angr_arch.registers[name]
 
+    def successors(self, state: angr.SimState, **kwargs) -> typing.Any:
+        """Compute successor states for this architecture
+
+        This allows a particular machine definition
+        to compensate for cases where the default
+        successor computation produces inaccurate results.
+
+        For the overwhelming majority of machine models,
+        the default should be sufficient.
+
+        The biggest case to date is to handle
+        user-defined operations in pcode.
+        These are treated as illegal ops by angr,
+        and there is currently no way to intercept their processing.
+
+        Arguments:
+            state: The angr state for which to compute successors
+            kwargs: See AngrObjectFactory.successors()
+
+        Returns:
+            The successor states of `state`.
+        """
+        return state.project.factory.successors(state, **kwargs)
+
     @classmethod
     def for_platform(cls, platform: platforms.Platform):
         """Find the appropriate MachineDef for your architecture

--- a/smallworld/emulators/angr/machdefs/xtensa.py
+++ b/smallworld/emulators/angr/machdefs/xtensa.py
@@ -195,6 +195,9 @@ class XTensaMachineDef(PcodeMachineDef):
             # Someone's already specified an IR block.
             irsb = kwargs["irsb"]
         else:
+            # Disable optimization; it doesn't work
+            kwargs["opt_level"] = 0
+
             # Compute the block from the state.
             # Pray to the Powers that kwargs are compatible.
             irsb = state.block(**kwargs).vex

--- a/smallworld/emulators/angr/machdefs/xtensa.py
+++ b/smallworld/emulators/angr/machdefs/xtensa.py
@@ -35,12 +35,6 @@ def handle_syscall(irsb, i):
     )
     irsb.jumpkind = "Ijk_Sys_syscall"
 
-    print(f"Syscall to {hex(next_addr)}")
-    for x in dir(irsb):
-        try:
-            print(f"{x}: {getattr(irsb, x)}")
-        except NotImplementedError:
-            print(f"{x}: N/A")
     return i
 
 

--- a/smallworld/emulators/angr/machdefs/xtensa.py
+++ b/smallworld/emulators/angr/machdefs/xtensa.py
@@ -1,0 +1,18 @@
+from ....platforms import Architecture, Byteorder
+from .machdef import PcodeMachineDef
+
+
+class XTensaMachineDef(PcodeMachineDef):
+    arch = Architecture.XTENSA
+    _registers = {f"a{i}": f"a{i}" for i in range(0, 16)} | {"pc": "pc", "sar": "sar"}
+    pc_reg = "pc"
+
+
+class XTensaELMachineDef(XTensaMachineDef):
+    byteorder = Byteorder.LITTLE
+    pcode_language = "Xtensa:LE:32:default"
+
+
+class XTensaBEMachineDef(XTensaMachineDef):
+    byteorder = Byteorder.BIG
+    pcode_language = "Xtensa:BE:32:default"

--- a/smallworld/emulators/angr/machdefs/xtensa.py
+++ b/smallworld/emulators/angr/machdefs/xtensa.py
@@ -1,11 +1,234 @@
+import enum
+import typing
+
+import angr
+import pypcode
+
+from ....exceptions import EmulationError
 from ....platforms import Architecture, Byteorder
 from .machdef import PcodeMachineDef
+
+
+def handle_nop(irsb, i):
+    # This op has no impact on user-facing machine state.
+    return i
+
+
+def handle_sigtrap(irsb, i):
+    # This op should terminate this block with SIGTRAP
+    return i
+
+
+def handle_sigill(irsb, i):
+    # This op should terminate this block with SIGILL
+    return i
+
+
+def handle_syscall(irsb, i):
+    # This op should terminate this block with a syscall
+    next_addr = irsb._ops[i + 1].inputs[0].offset
+    irsb._ops = irsb._ops[0:i]
+    irsb.next = next_addr
+    irsb._size = next_addr - irsb.addr
+    irsb._instruction_addresses = list(
+        filter(lambda x: x < next_addr, irsb._instruction_addresses)
+    )
+    irsb.jumpkind = "Ijk_Sys_syscall"
+
+    print(f"Syscall to {hex(next_addr)}")
+    for x in dir(irsb):
+        try:
+            print(f"{x}: {getattr(irsb, x)}")
+        except NotImplementedError:
+            print(f"{x}: N/A")
+    return i
+
+
+def handle_nope(irsb, i):
+    # This op cannot be handled by angr
+    userop = XtensaUserOp(irsb._ops[i].inputs[0].offset)
+    raise EmulationError(f"Unhandled user op {userop!r}")
+
+
+def handle_unimpl(irsb, i):
+    # I don't know what this op does yet
+    userop = XtensaUserOp(irsb._ops[i].inputs[0].offset)
+    raise EmulationError(f"Unimplemented user op {userop!r}")
+
+
+class UpdatedEnumMeta(enum.EnumMeta):
+    def __contains__(cls, obj):
+        if isinstance(obj, int):
+            return obj in cls._value2member_map_
+        return enum.EnumMeta.__contains__(enum.EnumMeta, obj)
+
+
+class XtensaUserOp(enum.IntEnum, metaclass=UpdatedEnumMeta):
+    def __new__(
+        cls, val: int, name: str = "", handler: typing.Any = None, desc: str = ""
+    ):
+        obj = int.__new__(cls, val)
+        obj._value_ = val
+        obj.short_name = name
+        obj.handler = handler
+        obj.description = desc
+        return obj
+
+    def __init__(
+        self, val: int, name: str = "", handler: typing.Any = None, desc: str = ""
+    ):
+        self._value_: int = val
+        self.short_name: str = name
+        self.handler: typing.Any = handler
+        self.description: str = desc
+
+    def __repr__(self):
+        return f"{hex(self.value)}: {self.short_name} - {self.description}"
+
+    BREAKPOINT = 0x00, "breakpoint", handle_sigtrap, "Breakpoint Instruction"
+    DHI = 0x01, "dhi", handle_nop, "Data Cache Hit Invalidate"
+    DHU = 0x02, "dhu", handle_nop, "Data Cache Hit Unlock"
+    DHWB = 0x03, "dhwb", handle_nop, "Data Cache Hit Writeback"
+    DHWBI = 0x04, "dhwbi", handle_nop, "Data Cache Hit Writeback Invalidate"
+    DII = 0x05, "dii", handle_nop, "Data Cache Index Invalidate"
+    DIU = 0x06, "diu", handle_nop, "Data Cache Index Unlock"
+    DIWB = 0x07, "diwb", handle_nop, "Data Cache Index Writeback"
+    DIWBI = 0x08, "diwbi", handle_nop, "Data Cache Index Writeback Invalidate"
+    DPFL = 0x09, "dpfl", handle_nop, "Data Cache Prefetch And Lock"
+    DPFR = 0x0A, "dpfr", handle_nop, "Data Cache Prefetch For Read"
+    DPFRO = 0x0B, "dpfro", handle_nop, "Data Cache Prefetch For Read Once"
+    DPFW = 0x0C, "dpfw", handle_nop, "Data Cache Prefetch For Write"
+    DPFWO = 0x0D, "dpfwo", handle_nop, "Data Cache Prefetch For Write Once"
+    DSYNC = 0x0E, "dsync", handle_nop, "Load/Store Synchronize"
+    ESYNC = 0x0F, "esync", handle_nop, "Execute Synchronize"
+    EXCW = 0x10, "excw", handle_sigtrap, "Exception Wait"
+    EXTW = 0x11, "extw", handle_sigtrap, "External Wait"
+    IDTLB = 0x12, "idtlb", handle_nop, "Invalidate Data TLB Entry"
+    IHI = 0x13, "ihi", handle_nop, "Instruction Cache Hit Invalidate"
+    IHU = 0x14, "ihu", handle_nop, "Instruction Cache Hit Unlock"
+    III = 0x15, "iii", handle_nop, "Instruction Cache Index Invalidate"
+    IITLB = 0x16, "iitlb", handle_nop, "Invalidate Instruction TLB Entry"
+    IIU = 0x17, "iiu", handle_nop, "Instruction Cache Index Unlock"
+    ILL = 0x18, "ill", handle_sigill, "Illegal Instruction"
+    IPF = 0x19, "ipf", handle_nop, "Instruction Cache Prefetch"
+    IPFL = 0x1A, "ipfl", handle_nop, "Instruction Cache Prefetch And Lock"
+    ISYNC = 0x1B, "isync", handle_nop, "Instruction Fetch Synchronize"
+    ACQUIRE = 0x1C, "acquire", handle_unimpl, "???"
+    LDCT = 0x1D, "ldct", handle_nope, "Load Data Cache Tag"
+    LICT = 0x1E, "lict", handle_nope, "Load Instruction Cache Tag"
+    LICW = 0x1F, "licw", handle_nope, "Load Instruction Cache Word"
+    MEMW = 0x20, "memw", handle_sigtrap, "Memory Wait"
+    NSA = 0x21, "nsa", handle_unimpl, "Normalization Shift Amount"
+    NSAU = 0x22, "nsau", handle_unimpl, "Normalization Shift Amount Unsigned"
+    PDTLB = 0x23, "pdtlb", handle_nope, "Probe Data TLB"
+    PITLB = 0x24, "pitlb", handle_nope, "Probe Instruction TLB"
+    RDTLB0 = 0x25, "rdtlb0", handle_nope, "Read Data TLB Entry Virtual"
+    RDTLB1 = 0x26, "rdtlb1", handle_nope, "Read Data TLB Entry Translation"
+    RER = 0x27, "rer", handle_nope, "Read External Register"
+    RESTORE4 = 0x28, "restore4", handle_unimpl, "???"
+    RESTORE8 = 0x29, "restore8", handle_unimpl, "???"
+    RESTORE12 = 0x2A, "restore12", handle_unimpl, "???"
+    RFDD = 0x2B, "rfdd", handle_nope, "Return from Debug and Dispatch"
+    RFDE = 0x2C, "rfde", handle_nope, "Return from Double Exception"
+    RFDO = 0x2D, "rfdo", handle_nope, "Return from Debug Operation"
+    RFE = 0x2E, "rfe", handle_nope, "Return from Exception"
+    RFI = 0x2F, "rfi", handle_nope, "Return from Interrupt"
+    RFME = 0x30, "rfme", handle_nope, "Return from Memory Error"
+    RFUE = 0x31, "rfue", handle_nope, "Return from User Exception"
+    RFWO = 0x32, "rfwo", handle_nope, "Return from Window Overflow"
+    RFWU = 0x33, "rfwu", handle_nope, "Return from Window Underflow"
+    RITLB0 = 0x34, "ritlb0", handle_nope, "Read Instruction TLB Entry Virtual"
+    RITLB1 = 0x35, "ritlb1", handle_nope, "Read Instruction TLB Entry Translation"
+    RSIL = 0x36, "rsil", handle_nope, "Read and Set Interrupt Level"
+    RSR = 0x37, "rsr", handle_unimpl, "Read Special Register"
+    RSYNC = 0x38, "rsync", handle_nop, "Register Read Synchronize"
+    RUR = 0x39, "rur", handle_unimpl, "Read User Register"
+    S32C1I = 0x3A, "s32c1i", handle_unimpl, "Store 32-bit compare conditional"
+    RELEASE = 0x3B, "release", handle_unimpl, "???"
+    RESTOREREGWINDOW = 0x3C, "restoreregwindow", handle_unimpl, "???"
+    ROTATEREGWINDOW = 0x3D, "rotateregwindow", handle_unimpl, "???"
+    SDCT = 0x3E, "sdct", handle_nope, "Store Data Cache Tag"
+    SICT = 0x3F, "sict", handle_nope, "Store Instruction Cache Tag"
+    SICW = 0x40, "sicw", handle_nope, "Store Instruction Cache Word"
+    SIMCALL = 0x41, "simcall", handle_nop, "Simulator Call"
+    SYSCALL = 0x42, "syscall", handle_syscall, "System Call"
+    SWAP4 = 0x43, "swap4", handle_unimpl, "???"
+    SWAP8 = 0x44, "swap8", handle_unimpl, "???"
+    SWAP12 = 0x45, "swap12", handle_unimpl, "???"
+    WAITI = 0x46, "waiti", handle_sigtrap, "Wait for Interrupt"
+    WDTLB = 0x47, "wdtlb", handle_nop, "Write Data TLB Entry"
+    WER = 0x48, "wer", handle_nop, "Write External Register"
+    WITLB = 0x49, "witlb", handle_nop, "Write Instruction TLB Entry"
+    WSR = 0x4A, "wsr", handle_unimpl, "Write Special Register"
+    WUR = 0x4B, "wur", handle_unimpl, "Write User Register"
+    XSR = 0x4C, "xsr", handle_unimpl, "Exchange Special Register"
+
+
+# Angr doesn't have a syscall calling convention for xtensa.
+# Remedy that situation.
+class SimCCXtensaLinuxSyscall(angr.calling_conventions.SimCCSyscall):
+    ARG_REGS = ["a6", "a3", "a4", "a5", "a8", "a9"]
+    FP_ARG_REGS: typing.List[str] = []
+    RETURN_VAL = angr.calling_conventions.SimRegArg("a2", 4)
+    RETURN_ADDR = angr.calling_conventions.SimRegArg("ip_at_syscall", 4)
+    ARCH = None
+
+    @classmethod
+    def _match(cls, arch, args, sp_data):
+        # Never match; only occurs durring syscalls
+        return False
+
+    @staticmethod
+    def syscall_num(state):
+        return state.regs.a2
+
+
+angr.calling_conventions.register_syscall_cc(
+    "Xtensa:LE:32:default", "default", SimCCXtensaLinuxSyscall
+)
 
 
 class XTensaMachineDef(PcodeMachineDef):
     arch = Architecture.XTENSA
     _registers = {f"a{i}": f"a{i}" for i in range(0, 16)} | {"pc": "pc", "sar": "sar"}
     pc_reg = "pc"
+
+    def successors(self, state: angr.SimState, **kwargs) -> typing.Any:
+        # xtensa includes a _LOT_ of custom pcode operations.
+
+        # Fetch or compute the IR block for our state
+        if "irsb" in kwargs and kwargs["irsb"] is not None:
+            # Someone's already specified an IR block.
+            irsb = kwargs["irsb"]
+        else:
+            # Compute the block from the state.
+            # Pray to the Powers that kwargs are compatible.
+            irsb = state.block(**kwargs).vex
+
+        i = 0
+        while i < len(irsb._ops):
+            op = irsb._ops[i]
+            if op.opcode == pypcode.OpCode.CALLOTHER:
+                # This is a user-defined Pcode op.
+                # Alter irsb to mimic its behavior, if we can.
+                opnum = op.inputs[0].offset
+
+                if opnum not in XtensaUserOp:
+                    # Not a userop.
+                    raise EmulationError(f"Undefined user op {hex(opnum)}")
+                # get the enum struct
+                userop = XtensaUserOp(opnum)
+
+                # Invoke the handler
+                i = userop.handler(irsb, i)
+
+            i += 1
+
+        # Force the engine to use our IR block
+        kwargs["irsb"] = irsb
+
+        # Turn the crank on the engine
+        return super().successors(state, **kwargs)
 
 
 class XTensaELMachineDef(XTensaMachineDef):

--- a/smallworld/emulators/angr/memory/default.py
+++ b/smallworld/emulators/angr/memory/default.py
@@ -3,7 +3,7 @@ import angr
 from .memtrack import TrackerMemoryMixin
 
 
-class DefaultMemoryPlugin(
+class DefaultMemoryPlugin(  # type: ignore[misc]
     TrackerMemoryMixin, angr.storage.DefaultMemory
-):  # type: ignore[misc]
+):
     pass

--- a/smallworld/emulators/angr/memory/default.py
+++ b/smallworld/emulators/angr/memory/default.py
@@ -3,5 +3,7 @@ import angr
 from .memtrack import TrackerMemoryMixin
 
 
-class DefaultMemoryPlugin(TrackerMemoryMixin, angr.storage.DefaultMemory):
+class DefaultMemoryPlugin(
+    TrackerMemoryMixin, angr.storage.DefaultMemory
+):  # typing: ignore[misc]
     pass

--- a/smallworld/emulators/angr/memory/default.py
+++ b/smallworld/emulators/angr/memory/default.py
@@ -5,5 +5,5 @@ from .memtrack import TrackerMemoryMixin
 
 class DefaultMemoryPlugin(
     TrackerMemoryMixin, angr.storage.DefaultMemory
-):  # typing: ignore[misc]
+):  # type: ignore[misc]
     pass

--- a/smallworld/emulators/angr/memory/memtrack.py
+++ b/smallworld/emulators/angr/memory/memtrack.py
@@ -1,6 +1,6 @@
 import logging
 
-from angr.storage import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 from ..utils import reg_name_from_offset
 

--- a/smallworld/platforms.py
+++ b/smallworld/platforms.py
@@ -36,6 +36,8 @@ class Architecture(enum.Enum):
     ARM_V7R = "arm-v7r"
     ARM_V7A = "arm-v7a"
 
+    XTENSA = "xtensa"
+
 
 class Byteorder(enum.Enum):
     """Endianness."""

--- a/smallworld/state/cpus/__init__.py
+++ b/smallworld/state/cpus/__init__.py
@@ -7,6 +7,7 @@ from .i386 import I386
 from .mips import MIPSBE, MIPSEL
 from .mips64 import MIPS64BE, MIPS64EL
 from .powerpc import PowerPC32, PowerPC64
+from .xtensa import XTensaBE, XTensaEL
 
 __all__ = __cpu__ + [
     "AArch64",
@@ -24,4 +25,6 @@ __all__ = __cpu__ + [
     "MIPSBE",
     "PowerPC32",
     "PowerPC64",
+    "XTensaBE",
+    "XTensaEL",
 ]

--- a/smallworld/state/cpus/xtensa.py
+++ b/smallworld/state/cpus/xtensa.py
@@ -1,0 +1,80 @@
+import typing
+
+from ... import platforms, state
+from . import cpu
+
+
+class XTensa(cpu.CPU):
+    """CPU for XTensa, little-endian
+
+    Like RISC-V, which shares its lineage,
+    xtensa has a very small core architecture
+    with a metric boatload of optional extensions.
+
+    One noteable option is that xtensa uses register windows.
+    I'm not putting up with that shit for now.
+    """
+
+    def get_general_purpose_registers(self) -> typing.List[str]:
+        return [f"a{i}" for i in range(0, 16)]
+
+    def __init__(self):
+        super().__init__()
+        # *** General Purpose Registers ***
+        # a0 is also the default link register, but it doesn't get an alias
+        self.a0 = state.Register("a0", 4)
+        self.add(self.a0)
+        # a1 is also the stack pointer
+        self.a1 = state.Register("a1", 4)
+        self.add(self.a1)
+        self.sp = state.RegisterAlias("sp", self.a1, 4, 0)
+        self.add(self.sp)
+        self.a2 = state.Register("a2", 4)
+        self.add(self.a2)
+        self.a3 = state.Register("a3", 4)
+        self.add(self.a3)
+        self.a4 = state.Register("a4", 4)
+        self.add(self.a4)
+        self.a5 = state.Register("a5", 4)
+        self.add(self.a5)
+        self.a6 = state.Register("a6", 4)
+        self.add(self.a6)
+        self.a7 = state.Register("a7", 4)
+        self.add(self.a7)
+        self.a8 = state.Register("a8", 4)
+        self.add(self.a8)
+        self.a9 = state.Register("a9", 4)
+        self.add(self.a9)
+        self.a10 = state.Register("a10", 4)
+        self.add(self.a10)
+        self.a11 = state.Register("a11", 4)
+        self.add(self.a11)
+        self.a12 = state.Register("a12", 4)
+        self.add(self.a12)
+        self.a13 = state.Register("a13", 4)
+        self.add(self.a13)
+        self.a14 = state.Register("a14", 4)
+        self.add(self.a14)
+        self.a15 = state.Register("a15", 4)
+        self.add(self.a15)
+
+        # *** Program Counter ***
+        self.pc = state.Register("pc", 4)
+        self.add(self.pc)
+
+        # *** Shift Amount Register ***
+        # This thing is actually 6 bits.
+        self.sar = state.Register("sar", 1)
+        self.add(self.sar)
+
+
+class XTensaEL(XTensa):
+    platform = platforms.Platform(
+        platforms.Architecture.XTENSA, platforms.Byteorder.LITTLE
+    )
+
+
+class XTensaBE(XTensa):
+    platform = platforms.Platform(
+        platforms.Architecture.XTENSA, platforms.Byteorder.BIG
+    )

--- a/smallworld/state/memory/stack/__init__.py
+++ b/smallworld/state/memory/stack/__init__.py
@@ -7,6 +7,7 @@ from .mips64 import MIPS64BEStack, MIPS64ELStack
 from .ppc import PowerPC32Stack, PowerPC64Stack
 from .stack import *  # noqa: F401, F403
 from .stack import __all__ as __stack__
+from .xtensa import XTensaBEStack, XTensaELStack
 
 __all__ = __stack__ + [
     "AArch64Stack",
@@ -23,4 +24,6 @@ __all__ = __stack__ + [
     "MIPS64ELStack",
     "PowerPC32Stack",
     "PowerPC64Stack",
+    "XTensaBEStack",
+    "XTensaELStack",
 ]

--- a/smallworld/state/memory/stack/xtensa.py
+++ b/smallworld/state/memory/stack/xtensa.py
@@ -1,0 +1,34 @@
+import typing
+
+from .... import platforms
+from . import stack
+
+
+class XTensaStack(stack.DescendingStack):
+    """A stack for an XTensa CPU"""
+
+    def get_pointer(self) -> int:
+        return (self.address + self.size) - self.get_used()
+
+    def get_alignment(self) -> int:
+        return 4
+
+    @classmethod
+    def initialize_stack(cls, argv: typing.List[bytes], *args, **kwargs):
+        raise NotImplementedError("Stack initialization not implemented for XTensa")
+
+
+class XTensaBEStack(XTensaStack):
+    """A stack for a big-endian XTensa CPU"""
+
+    platform = platforms.Platform(
+        platforms.Architecture.XTENSA, platforms.Byteorder.BIG
+    )
+
+
+class XTensaELStack(XTensaStack):
+    """A stack for a little-endian XTensa CPU"""
+
+    platform = platforms.Platform(
+        platforms.Architecture.XTENSA, platforms.Byteorder.LITTLE
+    )

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -138,6 +138,11 @@ PREREQS := $(patsubst %,%.prereq,aarch64-linux-gnu arm-linux-gnueabi arm-linux-g
 	xtensa-lx106-elf-objcopy -O binary -j .text $*.xtensa.o $*.xtensa.bin
 	rm $*.xtensa.o    
 
+%.xtensa.elf: %.xtensa.elf.s
+	xtensa-lx106-elf-as --no-transform --target-align --text-section-literals $*.xtensa.elf.s -o $*.xtensa.elf.o
+	xtensa-lx106-elf-ld $*.xtensa.elf.o -o $*.xtensa.elf
+	rm $*.xtensa.elf.o    
+
 all: prereqs build
 
 build: ${TARGETS}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@ TARGETS := $(BINS) $(MIPSEL_BINS) $(MIPS64EL_BINS) $(ELFS) $(MIPSEL_ELFS) $(MIPS
 NASM_SOURCES := $(wildcard *.amd64.s)
 NASM_TARGETS := $(NASM_SOURCES:.s=.bin)
 
-PREREQS := $(patsubst %,%.prereq,aarch64-linux-gnu arm-linux-gnueabi arm-linux-gnueabihf mips-linux-gnu mipsel-linux-gnu mips64-linux-gnuabi64 mips64el-linux-gnuabi64 powerpc-linux-gnu powerpc64-linux-gnu riscv64-linux-gnu sparc64-linux-gnu)
+PREREQS := $(patsubst %,%.prereq,aarch64-linux-gnu arm-linux-gnueabi arm-linux-gnueabihf mips-linux-gnu mipsel-linux-gnu mips64-linux-gnuabi64 mips64el-linux-gnuabi64 powerpc-linux-gnu powerpc64-linux-gnu riscv64-linux-gnu sparc64-linux-gnu xtensa-l106-elf)
 
 %.aarch64.elf: %.aarch64.elf.s
 	aarch64-linux-gnu-as $*.aarch64.elf.s -o $*.aarch64.elf.o
@@ -132,6 +132,11 @@ PREREQS := $(patsubst %,%.prereq,aarch64-linux-gnu arm-linux-gnueabi arm-linux-g
 	sparc64-linux-gnu-as $*.sparc64.s -o $*.sparc64.o
 	sparc64-linux-gnu-objcopy -O binary -j .text $*.sparc64.o $*.sparc64.bin
 	rm $*.sparc64.o
+
+%.xtensa.bin: %.xtensa.s
+	xtensa-lx106-elf-as $*.xtensa.s -o $*.xtensa.o
+	xtensa-lx106-elf-objcopy -O binary -j .text $*.xtensa.o $*.xtensa.bin
+	rm $*.xtensa.o    
 
 all: prereqs build
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -134,7 +134,7 @@ PREREQS := $(patsubst %,%.prereq,aarch64-linux-gnu arm-linux-gnueabi arm-linux-g
 	rm $*.sparc64.o
 
 %.xtensa.bin: %.xtensa.s
-	xtensa-lx106-elf-as --no-transform --target-align $*.xtensa.s -o $*.xtensa.o
+	xtensa-lx106-elf-as --no-transform --target-align --text-section-literals $*.xtensa.s -o $*.xtensa.o
 	xtensa-lx106-elf-objcopy -O binary -j .text $*.xtensa.o $*.xtensa.bin
 	rm $*.xtensa.o    
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@ TARGETS := $(BINS) $(MIPSEL_BINS) $(MIPS64EL_BINS) $(ELFS) $(MIPSEL_ELFS) $(MIPS
 NASM_SOURCES := $(wildcard *.amd64.s)
 NASM_TARGETS := $(NASM_SOURCES:.s=.bin)
 
-PREREQS := $(patsubst %,%.prereq,aarch64-linux-gnu arm-linux-gnueabi arm-linux-gnueabihf mips-linux-gnu mipsel-linux-gnu mips64-linux-gnuabi64 mips64el-linux-gnuabi64 powerpc-linux-gnu powerpc64-linux-gnu riscv64-linux-gnu sparc64-linux-gnu xtensa-l106-elf)
+PREREQS := $(patsubst %,%.prereq,aarch64-linux-gnu arm-linux-gnueabi arm-linux-gnueabihf mips-linux-gnu mipsel-linux-gnu mips64-linux-gnuabi64 mips64el-linux-gnuabi64 powerpc-linux-gnu powerpc64-linux-gnu riscv64-linux-gnu sparc64-linux-gnu xtensa-lx106-elf)
 
 %.aarch64.elf: %.aarch64.elf.s
 	aarch64-linux-gnu-as $*.aarch64.elf.s -o $*.aarch64.elf.o
@@ -134,7 +134,7 @@ PREREQS := $(patsubst %,%.prereq,aarch64-linux-gnu arm-linux-gnueabi arm-linux-g
 	rm $*.sparc64.o
 
 %.xtensa.bin: %.xtensa.s
-	xtensa-lx106-elf-as $*.xtensa.s -o $*.xtensa.o
+	xtensa-lx106-elf-as --no-transform --target-align $*.xtensa.s -o $*.xtensa.o
 	xtensa-lx106-elf-objcopy -O binary -j .text $*.xtensa.o $*.xtensa.bin
 	rm $*.xtensa.o    
 

--- a/tests/branch/branch.xtensa.angr.py
+++ b/tests/branch/branch.xtensa.angr.py
@@ -1,0 +1,42 @@
+import logging
+import sys
+
+import smallworld
+
+# Set up logging and hinting
+smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.hinting.setup_hinting(stream=True, verbose=True)
+
+# Define the platform
+platform = smallworld.platforms.Platform(
+    smallworld.platforms.Architecture.XTENSA, smallworld.platforms.Byteorder.LITTLE
+)
+
+# Create a machine
+machine = smallworld.state.Machine()
+
+# Create a CPU
+cpu = smallworld.state.cpus.CPU.for_platform(platform)
+machine.add(cpu)
+
+# Load and add code into the state
+code = smallworld.state.memory.code.Executable.from_filepath(
+    __file__.replace(".py", ".bin").replace(".angr", ""), address=0x1000
+)
+machine.add(code)
+
+# Set the instruction pointer to the code entrypoint
+cpu.pc.set(code.address)
+
+# Initialize argument registers
+cpu.a2.set(int(sys.argv[1]))
+
+# Emulate
+emulator = smallworld.emulators.AngrEmulator(platform)
+emulator.enable_linear()
+emulator.add_exit_point(cpu.pc.get() + code.get_capacity())
+final_machine = machine.emulate(emulator)
+
+# read out the final state
+cpu = final_machine.get_cpu()
+print(cpu.a2)

--- a/tests/branch/branch.xtensa.s
+++ b/tests/branch/branch.xtensa.s
@@ -1,0 +1,11 @@
+    .text
+test:
+    # This returns 1 if arg1 is 100, 0 otherwise
+    movi    $a3, 100
+    bne     $a2, $a3, .L2
+    movi    $a2, 0x1
+    j       .L3
+.L2:
+    movi    $a2, 0x0
+.L3:
+    nop

--- a/tests/call/call.xtensa.angr.py
+++ b/tests/call/call.xtensa.angr.py
@@ -1,0 +1,43 @@
+import logging
+import sys
+
+import smallworld
+
+# Set up logging and hinting
+smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.hinting.setup_hinting(stream=True, verbose=True)
+
+# Define the platform
+platform = smallworld.platforms.Platform(
+    smallworld.platforms.Architecture.XTENSA, smallworld.platforms.Byteorder.LITTLE
+)
+
+# Create a machine
+machine = smallworld.state.Machine()
+
+# Create a CPU
+cpu = smallworld.state.cpus.CPU.for_platform(platform)
+machine.add(cpu)
+
+# Load and add code into the state
+code = smallworld.state.memory.code.Executable.from_filepath(
+    __file__.replace(".py", ".bin").replace(".angr", ""), address=0x1000
+)
+machine.add(code)
+
+# Set the instruction pointer to the code entrypoint
+cpu.pc.set(code.address)
+
+# Initialize argument registers
+cpu.a2.set(int(sys.argv[1]))
+
+# Emulate
+emulator = smallworld.emulators.AngrEmulator(platform)
+emulator.enable_linear()
+emulator.add_exit_point(cpu.pc.get() + code.get_capacity())
+
+final_machine = machine.emulate(emulator)
+
+# read out the final state
+cpu = final_machine.get_cpu()
+print(hex(cpu.a2.get()))

--- a/tests/call/call.xtensa.s
+++ b/tests/call/call.xtensa.s
@@ -1,0 +1,33 @@
+    .text
+# NOTE: This uses what's known as the "call0" ABI.
+#
+# This acts a lot like ARM and others,
+# where you need to save and restore your own
+# link register and frame pointer (a0 and a15),
+# probably using the stack
+#
+# XTensa also has a "windowed" ABI,
+# which uses optional instructions
+# to use register aliasing to preserve
+# caller state.
+# The open source assembler doesn't support
+# the windowed register option.
+
+_start:
+    call0   foo
+    .byte   0x00
+bar:
+    movi    $a3, 8
+    mull    $a3, $a2, $a3
+    movi    $a4, 101
+    bge     $a2, $a4, .L2
+    mov     $a2, $a3
+    j       .L3
+.L2:
+    movi    $a2, 32
+.L3:
+    ret
+foo:
+    addi    $a2, $a2, -1
+    call0   bar
+    addi    $a2, $a2, 1

--- a/tests/dependencies/apt.txt
+++ b/tests/dependencies/apt.txt
@@ -11,4 +11,4 @@ binutils-powerpc-linux-gnu
 binutils-powerpc64-linux-gnu
 binutils-riscv64-linux-gnu
 binutils-sparc64-linux-gnu
-binutils-xtensa-lx106-elf
+binutils-xtensa-lx106

--- a/tests/dependencies/apt.txt
+++ b/tests/dependencies/apt.txt
@@ -11,3 +11,4 @@ binutils-powerpc-linux-gnu
 binutils-powerpc64-linux-gnu
 binutils-riscv64-linux-gnu
 binutils-sparc64-linux-gnu
+binutils-xtensa-lx106-elf

--- a/tests/dma/dma.xtensa.angr.py
+++ b/tests/dma/dma.xtensa.angr.py
@@ -1,0 +1,110 @@
+import logging
+import sys
+
+import smallworld
+
+# Set up logging and hinting
+smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.hinting.setup_hinting(stream=True, verbose=True)
+
+# Define the platform
+platform = smallworld.platforms.Platform(
+    smallworld.platforms.Architecture.XTENSA, smallworld.platforms.Byteorder.LITTLE
+)
+
+# Create a machine
+machine = smallworld.state.Machine()
+
+# Create a CPU
+cpu = smallworld.state.cpus.CPU.for_platform(platform)
+machine.add(cpu)
+
+# Load and add code into the state
+code = smallworld.state.memory.code.Executable.from_filepath(
+    __file__.replace(".py", ".bin").replace(".angr", ""), address=0x1000
+)
+machine.add(code)
+
+# Set the instruction pointer to the code entrypoint
+cpu.pc.set(code.address + 4)
+
+# Initialize argument registers
+cpu.a2.set(int(sys.argv[1]))
+cpu.a3.set(int(sys.argv[2]))
+
+
+class HDivModel(smallworld.state.models.mmio.MemoryMappedModel):
+    def __init__(self, address: int, nbytes: int):
+        super().__init__(address, nbytes * 4)
+        self.reg_size = nbytes
+        self.num_addr = address
+        self.den_addr = address + nbytes
+        self.quo_addr = address + nbytes * 2
+        self.rem_addr = address + nbytes * 3
+        self.end_addr = address + nbytes * 4
+
+        self.numerator = 0
+        self.denominator = 0
+        self.quotient = 0
+        self.remainder = 0
+
+    def on_read(
+        self, emu: smallworld.emulators.Emulator, addr: int, size: int
+    ) -> bytes:
+        print(f"Reading from {hex(addr)}")
+        if addr >= self.quo_addr and addr < self.rem_addr:
+            self.numerator = 0
+            self.denominator = 0
+            start = addr - self.quo_addr
+            end = start + size
+            return self.quotient.to_bytes(self.reg_size, "little")[start:end]
+        elif addr >= self.rem_addr and addr < self.end_addr:
+            self.numerator = 0
+            self.denominator = 0
+            start = addr - self.rem_addr
+            end = start + size
+            return self.remainder.to_bytes(self.reg_size, "little")[start:end]
+        else:
+            raise smallworld.exceptions.AnalysisError(
+                "Unexpected read from MMIO register {hex(addr)}"
+            )
+
+    def on_write(
+        self, emu: smallworld.emulators.Emulator, addr: int, size: int, value: bytes
+    ) -> None:
+        print(f"Writing to {hex(addr)}")
+        if addr >= self.num_addr and addr < self.den_addr:
+            start = addr - self.num_addr
+            end = start + size
+            num_bytes = bytearray(self.numerator.to_bytes(self.reg_size, "little"))
+            num_bytes[start:end] = value
+            self.numerator = int.from_bytes(num_bytes, "little")
+        elif addr >= self.den_addr and addr < self.quo_addr:
+            start = addr - self.den_addr
+            end = start + size
+            den_bytes = bytearray(self.denominator.to_bytes(self.reg_size, "little"))
+            den_bytes[start:end] = value
+            self.denominator = int.from_bytes(den_bytes, "little")
+
+            if self.denominator != 0:
+                # TODO: I have no idea how the real thing handles DIV0
+                self.quotient = self.numerator // self.denominator
+                self.remainder = self.numerator % self.denominator
+        else:
+            raise smallworld.exceptions.AnalysisError(
+                "Unexpected write to MMIO register {hex(addr)}"
+            )
+
+
+hdiv = HDivModel(0x50014000, 4)
+machine.add(hdiv)
+
+# Emulate
+emulator = smallworld.emulators.AngrEmulator(platform)
+emulator.enable_linear()
+emulator.add_exit_point(cpu.pc.get() + code.get_capacity())
+final_machine = machine.emulate(emulator)
+
+# read out the final state
+cpu = final_machine.get_cpu()
+print(hex(cpu.a2.get_content()))

--- a/tests/dma/dma.xtensa.s
+++ b/tests/dma/dma.xtensa.s
@@ -1,0 +1,17 @@
+    .text
+    .literal_position
+    .literal .LC0, 0x50014000
+    .align 4
+    .global divide
+divide:
+    # DMA example modelling a hardware divisor unit
+    # - Write 32-bit numerator to 0x50014000
+    # - Write 32-bit denominator to 0x50014004
+    # - Read 32-bit quotient from 0x50014008
+    #
+    # XTensa's immediates are pitifully small,
+    # so it loads long literals from memory
+    l32r    $a4, .LC0
+    s32i    $a4, $a2, 0
+    s32i    $a4, $a3, 4
+    l32i    $a4, $a2, 8

--- a/tests/dma/dma.xtensa.s
+++ b/tests/dma/dma.xtensa.s
@@ -12,6 +12,6 @@ divide:
     # XTensa's immediates are pitifully small,
     # so it loads long literals from memory
     l32r    $a4, .LC0
-    s32i    $a4, $a2, 0
-    s32i    $a4, $a3, 4
-    l32i    $a4, $a2, 8
+    s32i    $a2, $a4, 0
+    s32i    $a3, $a4, 4
+    l32i    $a2, $a4, 8

--- a/tests/elf/elf.xtensa.angr.py
+++ b/tests/elf/elf.xtensa.angr.py
@@ -1,0 +1,70 @@
+import logging
+import sys
+
+import smallworld
+
+# Set up logging and hinting
+smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.hinting.setup_hinting(stream=True, verbose=True)
+
+# Define the platform
+platform = smallworld.platforms.Platform(
+    smallworld.platforms.Architecture.XTENSA, smallworld.platforms.Byteorder.LITTLE
+)
+
+# Create a machine
+machine = smallworld.state.Machine()
+
+# Create a CPU
+cpu = smallworld.state.cpus.CPU.for_platform(platform)
+machine.add(cpu)
+
+# Load and add code into the state
+filename = __file__.replace(".py", ".elf").replace(".angr", "")
+with open(filename, "rb") as f:
+    code = smallworld.state.memory.code.Executable.from_elf(f)
+    machine.add(code)
+
+# Set entrypoint from the ELF
+if code.entrypoint is None:
+    raise ValueError("ELF has no entrypoint")
+cpu.pc.set(code.entrypoint)
+
+# Create a stack and add it to the state
+stack = smallworld.state.memory.stack.Stack.for_platform(platform, 0x2000, 0x4000)
+machine.add(stack)
+
+# Push a string onto the stack
+string = sys.argv[1].encode("utf-8")
+string += b"\0"
+string += b"\0" * (16 - (len(string) % 16))
+
+stack.push_bytes(string, None)
+str_addr = stack.get_pointer()
+
+# Push argv
+stack.push_integer(0, 4, None)  # NULL terminator
+stack.push_integer(str_addr, 4, None)  # pointer to string
+stack.push_integer(0x10101010, 4, None)  # Bogus pointer to argv[0]
+
+# Push address of argv
+argv = stack.get_pointer()
+stack.push_integer(argv, 4, None)
+
+# Push argc
+stack.push_integer(2, 4, None)
+
+# Configure the stack pointer
+sp = stack.get_pointer()
+cpu.sp.set(sp)
+
+# Emulate
+emulator = smallworld.emulators.AngrEmulator(platform)
+emulator.enable_linear()
+
+# Use code bounds from the ELF
+for bound in code.bounds:
+    machine.add_bound(bound.start, bound.stop)
+
+final_machine = machine.emulate(emulator)
+print(final_machine.get_cpu().a2)

--- a/tests/elf/elf.xtensa.elf.s
+++ b/tests/elf/elf.xtensa.elf.s
@@ -1,0 +1,35 @@
+    .text
+    .literal_position
+    .align  4
+    .globl  _start
+    .type   _start, @function
+_start:
+    # Load argc
+    l32i    a2, sp, 0
+    
+    # If argc != 2, exit
+    bnei    a2, 2, .L2
+
+    # Load argv
+    l32i    a3, sp, 4
+    # Load argv[1]
+    l32i    a3, a3, 4
+
+    movi    a2, 0
+
+.L3:
+    # for(i = 0; argv[1][i] != '\0'; i++);
+    add     a4, a2, a3
+    l8ui    a4, a4, 0
+    beqz    a4, .L1
+    addi    a2, a2, 1
+    j       .L3 
+    
+.L2: 
+    # Failed; return 1
+    movi    a2, 1
+
+.L1:
+    # Leave, by any means necessary
+    ret
+

--- a/tests/hooking/hooking.xtensa.angr.py
+++ b/tests/hooking/hooking.xtensa.angr.py
@@ -1,0 +1,100 @@
+import logging
+
+import smallworld
+
+# Set up logging and hinting
+smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.hinting.setup_hinting(stream=True, verbose=True)
+
+# Define the platform
+platform = smallworld.platforms.Platform(
+    smallworld.platforms.Architecture.XTENSA, smallworld.platforms.Byteorder.LITTLE
+)
+
+# Create a machine
+machine = smallworld.state.Machine()
+
+# Create a CPU
+cpu = smallworld.state.cpus.CPU.for_platform(platform)
+machine.add(cpu)
+
+# Load and add code into the state
+code = smallworld.state.memory.code.Executable.from_filepath(
+    __file__.replace(".py", ".bin").replace(".angr", ""), address=0x1000
+)
+machine.add(code)
+
+# Create a stack and add it to the state
+stack = smallworld.state.memory.stack.Stack.for_platform(platform, 0x2000, 0x4000)
+machine.add(stack)
+
+# Set the instruction pointer to the code entrypoint
+cpu.pc.set(code.address + 8)
+
+# Push a return address onto the stack
+stack.push_integer(0xFFFFFFFF, 4, "fake return address")
+
+# Configure the stack pointer
+sp = stack.get_pointer()
+cpu.sp.set(sp)
+
+
+# Configure gets model
+class GetsModel(smallworld.state.models.Model):
+    name = "gets"
+    platform = platform
+    abi = smallworld.platforms.ABI.NONE
+
+    def model(self, emulator: smallworld.emulators.Emulator) -> None:
+        s = emulator.read_register("a2")
+        v = input().encode("utf-8") + b"\0"
+        try:
+            emulator.write_memory_content(s, v)
+        except:
+            raise smallworld.exceptions.AnalysisError(
+                f"Failed writing {len(v)} bytes to {hex(s)} "
+            )
+
+
+gets = GetsModel(0x1000)
+machine.add(gets)
+
+
+# Configure puts model
+class PutsModel(smallworld.state.models.Model):
+    name = "puts"
+    platform = platform
+    abi = smallworld.platforms.ABI.NONE
+
+    def model(self, emulator: smallworld.emulators.Emulator) -> None:
+        # Reading a block of memory from angr will fail,
+        # since values beyond the string buffer's bounds
+        # are guaranteed to be symbolic.
+        #
+        # Thus, we must step one byte at a time.
+        s = emulator.read_register("a2")
+        v = b""
+        try:
+            b = emulator.read_memory_content(s, 1)
+        except smallworld.exceptions.SymbolicValueError:
+            b = None
+        while b is not None and b != b"\x00":
+            v = v + b
+            s = s + 1
+            try:
+                b = emulator.read_memory_content(s, 1)
+            except smallworld.exceptions.SymbolicValueError:
+                b = None
+        if b is None:
+            raise smallworld.exceptions.SymbolicValueError(f"Symbolic byte at {hex(s)}")
+        print(v)
+
+
+puts = PutsModel(0x1004)
+machine.add(puts)
+
+# Emulate
+emulator = smallworld.emulators.AngrEmulator(platform)
+emulator.enable_linear()
+emulator.add_exit_point(code.address + code.get_capacity())
+final_machine = machine.emulate(emulator)

--- a/tests/hooking/hooking.xtensa.s
+++ b/tests/hooking/hooking.xtensa.s
@@ -1,0 +1,25 @@
+    .text
+# Fake the PLT.
+# gas doesn't have the nice pseudo-ops to assign symbols like nasm has,
+# but this will work similarly.
+#
+# gets is at offset 0x4
+# puts is at offset 0x8
+gets:
+    ill.n
+    ill.n
+puts:
+    ill.n
+    ill.n
+test:
+    # Read an input string into a stack buffer, and write it back out.
+    # This requires a stack, and libc models for gets and puts
+
+    # alloca a 64-byte stack buffer
+    addi    $sp, $sp, -64 
+    # Put a pointer to the stack buffer in arg1
+    mov     $a2, $sp
+    # Read a string from stdin
+    call0   gets
+    # Write the string back to stdout
+    call0   puts 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -353,6 +353,9 @@ class DMATests(ScriptIntegrationTest):
     def test_dma_ppc64_angr(self):
         self.run_test("ppc64.angr")
 
+    def test_dma_xtensa_angr(self):
+        self.run_test("xtensa.angr")
+
 
 class SquareTests(ScriptIntegrationTest):
     def test_basic(self):
@@ -509,6 +512,9 @@ class SquareTests(ScriptIntegrationTest):
     def test_square_ppc64_angr(self):
         self.run_test("ppc64.angr", signext=True)
 
+    def test_square_xtensa_angr(self):
+        self.run_test("xtensa.angr")
+
 
 class RecursionTests(ScriptIntegrationTest):
     def run_test(self, arch):
@@ -602,15 +608,18 @@ class RecursionTests(ScriptIntegrationTest):
     def test_recursion_mips64el_angr(self):
         self.run_test("mips64el.angr")
 
-    def test_call_ppc_angr(self):
+    def test_recursion_ppc_angr(self):
         self.run_test("ppc.angr")
 
     @unittest.skipUnless(pandare, "Panda support is optional")
-    def test_call_ppc_panda(self):
+    def test_recursion_ppc_panda(self):
         self.run_test("ppc.panda")
 
-    def test_call_ppc64_angr(self):
+    def test_recursion_ppc64_angr(self):
         self.run_test("ppc64.angr")
+
+    def test_xtensa_angr(self):
+        self.run_test("xtensa.angr")
 
 
 class BlockTests(ScriptIntegrationTest):
@@ -829,6 +838,9 @@ class StackTests(ScriptIntegrationTest):
     def test_stack_ppc64_angr(self):
         self.run_test("ppc64.angr", reg="r3", res="0xffff")
 
+    def test_stack_xtensa(self):
+        self.run_test("xtensa.angr", reg="a2", res="0xaaaaaaaa")
+
 
 class StructureTests(ScriptIntegrationTest):
     def test_basic(self):
@@ -1001,6 +1013,9 @@ class BranchTests(ScriptIntegrationTest):
     def test_branch_ppc64_angr(self):
         self.run_branch("ppc64.angr", reg="r3")
 
+    def test_branch_xtensa_angr(self):
+        self.run_branch("xtensa.angr", reg="a2")
+
 
 class StrlenTests(ScriptIntegrationTest):
     def run_test(self, arch):
@@ -1099,6 +1114,9 @@ class StrlenTests(ScriptIntegrationTest):
 
     def test_strlen_ppc64_angr(self):
         self.run_test("ppc64.angr")
+
+    def test_strlen_xtensa_angr(self):
+        self.run_test("xtensa.angr")
 
 
 class HookingTests(ScriptIntegrationTest):
@@ -1204,6 +1222,9 @@ class HookingTests(ScriptIntegrationTest):
     def test_hooking_ppc64_angr(self):
         self.run_test("ppc64.angr")
 
+    def test_hooking_xtensa_angr(self):
+        self.run_test("xtensa.angr")
+
 
 class ElfTests(ScriptIntegrationTest):
     def run_test(self, arch):
@@ -1262,6 +1283,9 @@ class ElfTests(ScriptIntegrationTest):
 
     def test_elf_ppc64_angr(self):
         self.run_test("ppc64.angr")
+
+    def test_elf_xtensa_angr(self):
+        self.run_test("xtensa.angr")
 
 
 class FloatsTests(ScriptIntegrationTest):
@@ -1335,6 +1359,9 @@ class SyscallTests(ScriptIntegrationTest):
 
     def test_syscall_ppc64_angr(self):
         self.run_test("ppc64.angr")
+
+    def test_syscall_xtensa_angr(self):
+        self.run_test("xtensa.angr")
 
 
 class FuzzTests(ScriptIntegrationTest):

--- a/tests/recursion/recursion.xtensa.angr.py
+++ b/tests/recursion/recursion.xtensa.angr.py
@@ -1,0 +1,53 @@
+import logging
+import sys
+
+import smallworld
+
+# Set up logging and hinting
+smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.hinting.setup_hinting(stream=True, verbose=True)
+
+# Define the platform
+platform = smallworld.platforms.Platform(
+    smallworld.platforms.Architecture.XTENSA, smallworld.platforms.Byteorder.LITTLE
+)
+
+# Create a machine
+machine = smallworld.state.Machine()
+
+# Create a CPU
+cpu = smallworld.state.cpus.CPU.for_platform(platform)
+machine.add(cpu)
+
+# Load and add code into the state
+code = smallworld.state.memory.code.Executable.from_filepath(
+    __file__.replace(".py", ".bin").replace(".angr", ""), address=0x1000
+)
+machine.add(code)
+
+# Create a stack and add it to the state
+stack = smallworld.state.memory.stack.Stack.for_platform(platform, 0x2000, 0x4000)
+machine.add(stack)
+
+# Set the instruction pointer to the code entrypoint
+cpu.pc.set(code.address)
+
+# Initialize argument registers
+cpu.a2.set(int(sys.argv[1]))
+
+# Push a return address onto the stack
+stack.push_integer(0xFFFFFFFF, 4, "fake return address")
+
+# Configure the stack pointer
+sp = stack.get_pointer()
+cpu.sp.set(sp)
+
+# Emulate
+emulator = smallworld.emulators.AngrEmulator(platform)
+emulator.enable_linear()
+emulator.add_exit_point(cpu.pc.get() + code.get_capacity())
+final_machine = machine.emulate(emulator)
+
+# read out the final state
+cpu = final_machine.get_cpu()
+print(hex(cpu.a2.get()))

--- a/tests/recursion/recursion.xtensa.s
+++ b/tests/recursion/recursion.xtensa.s
@@ -1,0 +1,37 @@
+    .text
+_start:
+    call0   main
+
+# Whoever made an ISA with 24-bit instructions
+# require 32-bit call target alignment is not my friend...
+.byte 0x00
+
+mc91:
+    # Set up the stack frame
+    addi    $sp, $sp, -4
+    s32i    $a0, $sp, 0
+
+    # Check if we want case 1 or case 2
+    movi    $a3, 101
+    blt     $a2, $a3, .L2
+
+    # Case 1: n > 100 -> M(n) := n - 10
+    movi    $a3, -10
+    add     $a2, $a2, $a3
+    j       .L3
+    .byte 0x00
+
+.L2:
+    # Case 2: n <= 100 -> M(n) := M(M(n + 11))
+    addi    $a2, $a2, 11
+    call0   mc91
+    call0   mc91
+
+.L3:
+    # Clean up the stack and return    
+    l32i    $a0, $sp, 0
+    addi    $sp, $sp, 4
+    ret
+
+main:
+    call0   mc91

--- a/tests/square/square.xtensa.angr.py
+++ b/tests/square/square.xtensa.angr.py
@@ -1,0 +1,42 @@
+import logging
+import sys
+
+import smallworld
+
+# Set up logging and hinting
+smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.hinting.setup_hinting(stream=True, verbose=True)
+
+# Define the platform
+platform = smallworld.platforms.Platform(
+    smallworld.platforms.Architecture.XTENSA, smallworld.platforms.Byteorder.LITTLE
+)
+
+# Create a machine
+machine = smallworld.state.Machine()
+
+# Create a CPU
+cpu = smallworld.state.cpus.CPU.for_platform(platform)
+machine.add(cpu)
+
+# Load and add code into the state
+code = smallworld.state.memory.code.Executable.from_filepath(
+    __file__.replace(".py", ".bin").replace(".angr", ""), address=0x1000
+)
+machine.add(code)
+
+# Set the instruction pointer to the code entrypoint
+cpu.pc.set(code.address)
+
+# Initialize argument registers
+cpu.a2.set(int(sys.argv[1]))
+
+# Emulate
+emulator = smallworld.emulators.AngrEmulator(platform)
+emulator.enable_linear()
+emulator.add_exit_point(cpu.pc.get() + code.get_capacity())
+final_machine = machine.emulate(emulator)
+
+# read out the final state
+cpu = final_machine.get_cpu()
+print(hex(cpu.a2.get()))

--- a/tests/square/square.xtensa.s
+++ b/tests/square/square.xtensa.s
@@ -1,0 +1,6 @@
+    .text
+test:
+    # Square the first argument (??)
+    # and save it to the return (??)
+    mull    a2, a2, a2
+    ret

--- a/tests/square/square.xtensa.s
+++ b/tests/square/square.xtensa.s
@@ -3,4 +3,3 @@ test:
     # Square the first argument (??)
     # and save it to the return (??)
     mull    a2, a2, a2
-    ret

--- a/tests/stack/stack.xtensa.angr.py
+++ b/tests/stack/stack.xtensa.angr.py
@@ -1,0 +1,56 @@
+import logging
+
+import smallworld
+
+# Set up logging and hinting
+smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.hinting.setup_hinting(stream=True, verbose=True)
+
+# Define the platform
+platform = smallworld.platforms.Platform(
+    smallworld.platforms.Architecture.XTENSA, smallworld.platforms.Byteorder.LITTLE
+)
+
+# Create a machine
+machine = smallworld.state.Machine()
+
+# create a CPU
+cpu = smallworld.state.cpus.CPU.for_platform(platform)
+machine.add(cpu)
+
+# load and add code into the state
+code = smallworld.state.memory.code.Executable.from_filepath(
+    __file__.replace(".py", ".bin").replace(".angr", ""), address=0x1000
+)
+machine.add(code)
+
+# Create and register a stack
+stack = smallworld.state.memory.stack.Stack.for_platform(platform, 0x2000, 0x4000)
+machine.add(stack)
+
+# Set the instruction pointer to the machine entrypoint
+cpu.pc.set(code.address)
+
+# Initialize argument registers
+cpu.a2.set(0x11111111)
+cpu.a3.set(0x01010101)
+cpu.a4.set(0x22222222)
+cpu.a5.set(0x01010101)
+cpu.a6.set(0x33333333)
+cpu.a7.set(0x01010101)
+
+# Push additional arguments onto the stack, and configure the stack pointer
+stack.push_integer(0x44444444, 4, None)
+
+sp = stack.get_pointer()
+cpu.sp.set(sp)
+
+# emulate
+emulator = smallworld.emulators.AngrEmulator(platform)
+emulator.enable_linear()
+emulator.add_exit_point(cpu.pc.get() + code.get_capacity())
+final_machine = machine.emulate(emulator)
+
+# read out the final state
+final_cpu = final_machine.get_cpu()
+print(final_cpu.a2)

--- a/tests/stack/stack.xtensa.s
+++ b/tests/stack/stack.xtensa.s
@@ -1,0 +1,10 @@
+    .text
+manyargs:
+    # Take seven args
+    # add 1, 3, 5, 7
+    # return the sum
+    l32i    $a3, $sp, 0
+    add     $a2, $a2, $a4
+    add     $a2, $a2, $a6
+    add     $a2, $a2, $a3
+    

--- a/tests/strlen/strlen.xtensa.angr.py
+++ b/tests/strlen/strlen.xtensa.angr.py
@@ -1,0 +1,60 @@
+import logging
+import sys
+
+import smallworld
+
+# Set up logging and hinting
+smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.hinting.setup_hinting(stream=True, verbose=True)
+
+# Define the platform
+platform = smallworld.platforms.Platform(
+    smallworld.platforms.Architecture.XTENSA, smallworld.platforms.Byteorder.LITTLE
+)
+
+# Create a machine
+machine = smallworld.state.Machine()
+
+# Create a CPU
+cpu = smallworld.state.cpus.CPU.for_platform(platform)
+machine.add(cpu)
+
+# Load and add code into the state
+code = smallworld.state.memory.code.Executable.from_filepath(
+    __file__.replace(".py", ".bin").replace(".angr", ""), address=0x1000
+)
+machine.add(code)
+
+# Create a stack and add it to the state
+stack = smallworld.state.memory.stack.Stack.for_platform(platform, 0x2000, 0x4000)
+machine.add(stack)
+
+# Set the instruction pointer to the code entrypoint
+cpu.pc.set(code.address)
+
+# Push a string onto the stack, padded to 16 bytes to make life easier.
+# Remember the starting address
+string = sys.argv[1].encode("utf-8") + b"\0"
+padding = b"\0" * (16 - (len(string) % 16))
+stack.push_bytes(string + padding, None)
+
+saddr = stack.get_pointer()
+
+# Push a return address
+stack.push_integer(0x00000000, 4, None)
+
+# Configure the stack
+cpu.sp.set(stack.get_pointer())
+
+# Set the first argument to the stack address
+cpu.a2.set(saddr)
+
+# Emulate
+emulator = smallworld.emulators.AngrEmulator(platform)
+emulator.enable_linear()
+emulator.add_exit_point(cpu.pc.get() + code.get_capacity())
+final_machine = machine.emulate(emulator)
+
+# read out the final state
+cpu = final_machine.get_cpu()
+print(hex(cpu.a2.get()))

--- a/tests/strlen/strlen.xtensa.s
+++ b/tests/strlen/strlen.xtensa.s
@@ -1,0 +1,20 @@
+    .text
+_start:
+    call0   main
+.byte 0x00
+
+strlen:
+    movi    $a3, 0x0
+.L0:
+    l8ui    $a4, $a2, 0
+    beqz    $a4, .L1
+    addi    $a2, $a2, 1
+    addi    $a3, $a3, 1
+    j       .L0
+.L1:
+    mov     $a2, $a3
+    ret
+    
+main:
+    call0   strlen
+

--- a/tests/syscall/syscall.xtensa.angr.py
+++ b/tests/syscall/syscall.xtensa.angr.py
@@ -66,17 +66,4 @@ emulator.hook_syscall(4, write_hook)
 # Emulate
 emulator.enable_linear()
 emulator.add_exit_point(cpu.pc.get() + code.get_capacity())
-machine.apply(emulator)
-while True:
-    history = emulator.state.history
-    print(history)
-    if history is not None:
-        print(history.addr)
-        print(history.jumpkind)
-        print(history.recent_ins_addrs)
-        for action in history.actions:
-            try:
-                print(action.type)
-            except:
-                print("derp")
-    emulator.step_block()
+machine.emulate(emulator)

--- a/tests/syscall/syscall.xtensa.angr.py
+++ b/tests/syscall/syscall.xtensa.angr.py
@@ -59,24 +59,24 @@ def write_hook(emu: smallworld.emulators.Emulator) -> None:
     print("Executing a write syscall")
 
 
-def successor_func(state, **kwargs):
-    if "irsb" in kwargs and kwargs["irsb"] is not None:
-        irsb = kwargs["irsb"]
-    else:
-        irsb = state.block().vex
-
-    for op in irsb._ops:
-        print(op.opcode)
-
-    kwargs["irsb"] = irsb
-    return state.project.factory.successors(state, **kwargs)
-
-
-emulator = smallworld.emulators.AngrEmulator(platform, successors=successor_func)
+emulator = smallworld.emulators.AngrEmulator(platform)
 emulator.hook_syscalls(syscall_hook)
 emulator.hook_syscall(4, write_hook)
 
 # Emulate
 emulator.enable_linear()
 emulator.add_exit_point(cpu.pc.get() + code.get_capacity())
-final_machine = machine.emulate(emulator)
+machine.apply(emulator)
+while True:
+    history = emulator.state.history
+    print(history)
+    if history is not None:
+        print(history.addr)
+        print(history.jumpkind)
+        print(history.recent_ins_addrs)
+        for action in history.actions:
+            try:
+                print(action.type)
+            except:
+                print("derp")
+    emulator.step_block()

--- a/tests/syscall/syscall.xtensa.angr.py
+++ b/tests/syscall/syscall.xtensa.angr.py
@@ -1,0 +1,82 @@
+import logging
+
+import smallworld
+
+# import angr
+# import pypcode
+
+
+smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.hinting.setup_hinting(verbose=True, stream=True, file=None)
+
+# Define the platform
+platform = smallworld.platforms.Platform(
+    smallworld.platforms.Architecture.XTENSA, smallworld.platforms.Byteorder.LITTLE
+)
+
+# create a state object
+machine = smallworld.state.Machine()
+
+# Create a CPU
+cpu = smallworld.state.cpus.CPU.for_platform(platform)
+machine.add(cpu)
+
+# load and map code into the state and set ip
+code = smallworld.state.memory.code.Executable.from_filepath(
+    __file__.replace(".py", ".bin").replace(".angr", ""), address=0x1000
+)
+machine.add(code)
+cpu.pc.set(code.address)
+
+# create a stack and push a value
+stack = smallworld.state.memory.stack.Stack.for_platform(platform, 0x2000, 0x1000)
+machine.add(stack)
+
+data = b"Hello, world!\n\0"
+stack.push_bytes(data, None)
+arg1 = stack.get_pointer()
+
+# Push a fake return address
+stack.push_integer(0xFFFFFFFF, 8, None)
+
+# set the stack pointer
+cpu.sp.set(stack.get_pointer())
+
+# Initialize call to write():
+# - edi: File descriptor 1 (stdout)
+# - rsi: Buffer containing output
+# - rdx: Size of output buffer
+cpu.a2.set(0x1)
+cpu.a3.set(arg1)
+cpu.a4.set(len(data) - 1)
+
+
+def syscall_hook(emu: smallworld.emulators.Emulator, number: int) -> None:
+    print(f"Executing syscall {number}")
+
+
+def write_hook(emu: smallworld.emulators.Emulator) -> None:
+    print("Executing a write syscall")
+
+
+def successor_func(state, **kwargs):
+    if "irsb" in kwargs and kwargs["irsb"] is not None:
+        irsb = kwargs["irsb"]
+    else:
+        irsb = state.block().vex
+
+    for op in irsb._ops:
+        print(op.opcode)
+
+    kwargs["irsb"] = irsb
+    return state.project.factory.successors(state, **kwargs)
+
+
+emulator = smallworld.emulators.AngrEmulator(platform, successors=successor_func)
+emulator.hook_syscalls(syscall_hook)
+emulator.hook_syscall(4, write_hook)
+
+# Emulate
+emulator.enable_linear()
+emulator.add_exit_point(cpu.pc.get() + code.get_capacity())
+final_machine = machine.emulate(emulator)

--- a/tests/syscall/syscall.xtensa.s
+++ b/tests/syscall/syscall.xtensa.s
@@ -1,0 +1,11 @@
+    .text
+test:
+    # xtensa's syscall ABI is a) different from its function call ABI,
+    # and b) weird.
+    # The syscall number goes into a2,
+    # then the arg registers are, in order, a6, a3, a4, a5, a8, a9.
+    # Don't look at me; I just work here :p
+    mov     $a6, $a2 
+    movi    $a2, 0x4
+    syscall
+    nop


### PR DESCRIPTION
Adds xtensa support.

This is our first pcode architecture.  It required some updates to angr in order to work.

xtensa itself is an extensible ISA.  angr doesn't handle all possible exceptions,
especially the proprietary ones.  May need more work if someone actually wants to use this.