### PR TITLE
feat: Use CLE to load code for AngrEmulator

### DIFF
--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -336,6 +336,10 @@ class AngrEmulator(
 
     def write_register_content(self, name: str, content: typing.Optional[int]) -> None:
         if not self._initialized and content is not None:
+            if name == "pc":
+                name = self.machdef.pc_reg
+            # Test that the angr register exists
+            _, _ = self.machdef.angr_reg(name)
             self._register_contents[name] = content
         elif self._dirty and not self._linear:
             raise NotImplementedError(
@@ -365,6 +369,10 @@ class AngrEmulator(
         if label is None:
             return
         elif not self._initialized:
+            if name == "pc":
+                name = self.machdef.pc_reg
+            # Test that the angr register exists
+            _, _ = self.machdef.angr_reg(name)
             self._register_labels[name] = label
         elif self._dirty and not self._linear:
             raise NotImplementedError(
@@ -704,7 +712,7 @@ class AngrEmulator(
             def syscall_handler(state, number: int):
                 function(ConcreteAngrEmulator(state, self), number)
 
-        self.state.scratch.global_syscall_func = syscall_handler
+            self.state.scratch.global_syscall_func = syscall_handler
 
     def unhook_syscalls(self) -> None:
         if self._dirty and not self._linear:

--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -1197,7 +1197,7 @@ class AngrEmulator(
         self._linear = True
         log.warn("Linear execution mode enabled")
 
-    def get_code_bounds(self) -> typing.List[typing.Tuple[int, int]]:
+    def get_bounds(self) -> typing.List[typing.Tuple[int, int]]:
         if not self._initialized:
             return list(self._code_bounds)
 
@@ -1266,7 +1266,10 @@ class AngrEmulator(
             self.state.scratch.exit_points.remove(address)
 
     def __repr__(self):
-        return f"Angr ({self.mgr})"
+        if self._initialized:
+            return f"Angr ({self.mgr})"
+        else:
+            return "Angr (Uninitialized)"
 
 
 class ConcreteAngrEmulator(AngrEmulator):

--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -62,7 +62,10 @@ class AngrEmulator(
     version = "0.0"
 
     def __init__(self, platform: platforms.Platform, preinit=None, init=None):
-        # Dirty bit; tells us if we've started emulation
+        # Initializaed bit; tells us if angr state is initialized
+        self._initialized: bool = False
+
+        # Dirty bit; tells us if we can modify self.state
         self._dirty: bool = False
 
         # Linear mode bit; tells us if we're running in forced linear execution
@@ -71,15 +74,100 @@ class AngrEmulator(
         # Plugin preset; tells us which plugin preset to use.
         self._plugin_preset = "default"
 
-        self.platform: platforms.Platform = platform
-
-        # Locate the angr machine definition
+        # The machine definition;
+        # helps translate between angr and smallworld
         self.machdef: AngrMachineDef = AngrMachineDef.for_platform(platform)
+
+        self.platform = platform
+        self.preinit = preinit
+        self.init = init
+
+        # Cached state modifications,
+        # to be applied during initialization
+        self._code: typing.List[typing.Tuple[int, bytes]] = list()
+        self._register_contents: typing.Dict[str, int] = dict()
+        self._register_labels: typing.Dict[str, str] = dict()
+        self._memory_maps: typing.List[typing.Tuple[int, int]] = list()
+        self._memory_contents: typing.List[typing.Tuple[int, bytes]] = list()
+        self._memory_labels: typing.List[typing.Tuple[int, int, str]] = list()
+        self._instr_hooks: typing.List[
+            typing.Tuple[int, typing.Callable[[emulator.Emulator], None]]
+        ] = list()
+        self._gb_instr_hook: typing.Optional[
+            typing.Callable[[emulator.Emulator], None]
+        ] = None
+        self._func_hooks: typing.List[
+            typing.Tuple[int, typing.Callable[[emulator.Emulator], None]]
+        ] = list()
+        self._syscall_hooks: typing.Dict[
+            int, typing.Callable[[emulator.Emulator], None]
+        ] = dict()
+        self._gb_syscall_hook: typing.Optional[
+            typing.Callable[[emulator.Emulator, int], None]
+        ] = None
+        self._read_hooks: typing.List[
+            typing.Tuple[
+                int, int, typing.Callable[[emulator.Emulator, int, int], bytes]
+            ]
+        ] = list()
+        self._gb_read_hook: typing.Optional[
+            typing.Callable[[emulator.Emulator, int, int], bytes]
+        ] = None
+        self._write_hooks: typing.List[
+            typing.Tuple[
+                int, int, typing.Callable[[emulator.Emulator, int, int, bytes], None]
+            ]
+        ] = list()
+        self._gb_write_hook: typing.Optional[
+            typing.Callable[[emulator.Emulator, int, int, bytes], None]
+        ] = None
+        self._code_bounds: typing.List[typing.Tuple[int, int]] = list()
+        self._exit_points: typing.Set[int] = set()
+
+    def initialize(self):
+        """Initialize the emulator
+
+        To take advantage of CLE, we need to know about all code
+        before we initialize the angr state objects.
+        However, applying register and memory changes requires access
+        to the angr state object.
+
+        SmallWorld doesn't support ordering how state is applied,
+        so I need to collect it, then apply it once emulation starts.
+
+        This function is invoked automatically when you cycle the emulator,
+        but you're free to invoke it early if you want.
+        """
+
+        if self._initialized:
+            raise exceptions.ConfigurationError("Cannot reinitialize running emulator")
+
+        # Build a single, coherent byte stream out of our code
+        self._code.sort(key=lambda x: x[0])
+
+        code = b""
+        segments = list()
+
+        if len(self._code) > 0:
+            base_address = self._code[0][0]
+            last_address = base_address
+            for addr, data in self._code:
+                log.info("Code at {hex(addr)}")
+                if addr > last_address:
+                    code += b"\x00" * (addr - last_address)
+                size = len(data)
+                segments.append((addr - base_address, addr, size))
+                code += data
+                last_address = addr + size
 
         # Create an angr project using a blank byte stream,
         # and registered as self-modifying so we can load more code later.
-        options = {"arch": self.machdef.angr_arch, "backend": "blob"}
-        stream = io.BytesIO(b"")
+        options = {
+            "arch": self.machdef.angr_arch,
+            "backend": "blob",
+            "segments": segments,
+        }
+        stream = io.BytesIO(code)
         loader = cle.Loader(stream, main_opts=options)
         self.proj: angr.Project = angr.Project(
             loader,
@@ -98,8 +186,8 @@ class AngrEmulator(
         configure_default_plugins(self)
 
         # If preinit is specified, run it.
-        if preinit is not None:
-            preinit(self)
+        if self.preinit is not None:
+            self.preinit(self)
 
         # Create a completely blank entry state
         self.state = self.proj.factory.blank_state(
@@ -129,18 +217,78 @@ class AngrEmulator(
         configure_default_strategy(self)
 
         # If we have an init runner, run it.
-        if init:
-            init(self)
+        if self.init:
+            self.init(self)
+
+        # Mark this emulator as initialized
+        self._initialized = True
+
+        # Read back any changes that happened before initialization.
+        for name, content in self._register_contents.items():
+            self.write_register_content(name, content)
+
+        for name, label in self._register_labels.items():
+            self.write_register_label(name, label)
+
+        for addr, size in self._memory_maps:
+            self.map_memory(addr, size)
+
+        for addr, content in self._memory_contents:
+            self.write_memory_content(addr, content)
+
+        for addr, size, label in self._memory_labels:
+            self.write_memory_label(addr, size, label)
+
+        for addr, func in self._instr_hooks:
+            self.hook_instruction(addr, func)
+
+        if self._gb_instr_hook is not None:
+            self.hook_instructions(self._gb_instr_hook)
+
+        for addr, func in self._func_hooks:
+            self.hook_function(addr, func)
+
+        for num, func in self._syscall_hooks.items():
+            self.hook_syscall(num, func)
+
+        if self._gb_syscall_hook is not None:
+            self.hook_syscalls(self._gb_syscall_hook)
+
+        for start, end, func in self._read_hooks:
+            self.hook_memory_read(start, end, func)
+
+        if self._gb_read_hook is not None:
+            self.hook_memory_reads(self._gb_read_hook)
+
+        for start, end, func in self._write_hooks:
+            self.hook_memory_write(start, end, func)
+
+        if self._gb_write_hook is not None:
+            self.hook_memory_writes(self._gb_write_hook)
+
+        for start, end in self._code_bounds:
+            self.add_bound(start, end)
+
+        for addr in self._exit_points:
+            self.add_exit_point(addr)
 
     def read_register_content(self, name: str) -> int:
+        if not self._initialized:
+            raise exceptions.ConfigurationError(
+                "Cannot read registers before initialization"
+            )
+
         if self._dirty and not self._linear:
             raise NotImplementedError(
                 "Reading registers not supported once execution begins."
             )
+
         if name == "pc":
             name = self.machdef.pc_reg
+
         (off, size) = self.machdef.angr_reg(name)
         out = self.state.registers.load(off, size)
+
         if out.symbolic:
             log.warn(f"Register {name} is symbolic: {out}")
             raise exceptions.SymbolicValueError(f"Register {name} is symbolic")
@@ -151,15 +299,22 @@ class AngrEmulator(
         return None
 
     def read_register_label(self, name: str) -> typing.Optional[str]:
-        # This considers all BVSs to be labeled values;
-        # if it has a name, we're giving it to you.
+        if not self._initialized:
+            raise exceptions.ConfigurationError(
+                "Cannot read registers before initialization"
+            )
+
         if self._dirty and not self._linear:
             raise NotImplementedError(
                 "Reading register not supported once execution begins."
             )
+
         if name == "pc":
             name = self.machdef.pc_reg
+
         try:
+            # This considers all BVSs to be labeled values;
+            # if it has a name, we're giving it to you.
             (off, size) = self.machdef.angr_reg(name)
             out = self.state.registers.load(off, size)
             if out.symbolic:
@@ -180,22 +335,24 @@ class AngrEmulator(
             return None
 
     def write_register_content(self, name: str, content: typing.Optional[int]) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized and content is not None:
+            self._register_contents[name] = content
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Writing registers not supported once execution begins."
             )
-
-        # This will replace any value - symbolic or otherwise - currently in the emulator.
-        # Since labels are treated as symbolic values, it must be called before
-        # write_register_label().
-        if name == "pc":
-            name = self.machdef.pc_reg
-        (off, size) = self.machdef.angr_reg(name)
-        if content is None:
-            v = claripy.BVS("UNINITIALIZED", size * 8)
         else:
-            v = claripy.BVV(content, size * 8)
-        self.state.registers.store(off, v)
+            # This will replace any value - symbolic or otherwise - currently in the emulator.
+            # Since labels are treated as symbolic values, it must be called before
+            # write_register_label().
+            if name == "pc":
+                name = self.machdef.pc_reg
+            (off, size) = self.machdef.angr_reg(name)
+            if content is None:
+                v = claripy.BVS("UNINITIALIZED", size * 8)
+            else:
+                v = claripy.BVV(content, size * 8)
+            self.state.registers.store(off, v)
 
     def write_register_type(
         self, name: str, type: typing.Optional[typing.Any] = None
@@ -205,37 +362,45 @@ class AngrEmulator(
     def write_register_label(
         self, name: str, label: typing.Optional[str] = None
     ) -> None:
-        if self._dirty and not self._linear:
+        if label is None:
+            return
+        elif not self._initialized:
+            self._register_labels[name] = label
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Writing registers not supported once execution begins."
             )
-        if label is None:
-            return
-        if name == "pc":
-            name = self.machdef.pc_reg
-        (off, size) = self.machdef.angr_reg(name)
+        else:
+            if name == "pc":
+                name = self.machdef.pc_reg
+            (off, size) = self.machdef.angr_reg(name)
 
-        # This will bind whatever value is currently in the register
-        # to a symbol named after the label
-        # The same label will ALWAYS map to the same symbol!
-        # This can introduce unintended restrictions on exploration,
-        # or even a contradictory state.
-        s = claripy.BVS(label, size * 8, explicit_name=True)
-        v = self.state.registers.load(off, size)
+            # This will bind whatever value is currently in the register
+            # to a symbol named after the label
+            # The same label will ALWAYS map to the same symbol!
+            # This can introduce unintended restrictions on exploration,
+            # or even a contradictory state.
+            s = claripy.BVS(label, size * 8, explicit_name=True)
+            v = self.state.registers.load(off, size)
 
-        if not self.state.solver.satisfiable(extra_constraints=[v == s]):
-            # Creating this binding will definitely cause a contradiction.
-            # Have you already used this label somewhere else?
-            raise exceptions.ConfigurationError(
-                f"Contradiction binding register {name} to label {label}"
-            )
+            if not self.state.solver.satisfiable(extra_constraints=[v == s]):
+                # Creating this binding will definitely cause a contradiction.
+                # Have you already used this label somewhere else?
+                raise exceptions.ConfigurationError(
+                    f"Contradiction binding register {name} to label {label}"
+                )
 
-        # Passing the last check doesn't guarantee you're safe.
-        # There may be over-constraints.  Please be careful.
-        self.state.registers.store(off, s)
-        self.state.solver.add(v == s)
+            # Passing the last check doesn't guarantee you're safe.
+            # There may be over-constraints.  Please be careful.
+            self.state.registers.store(off, s)
+            self.state.solver.add(v == s)
 
     def read_memory_content(self, address: int, size: int) -> bytes:
+        if not self._initialized:
+            raise exceptions.ConfigurationError(
+                "Cannot read memory before initialization"
+            )
+
         if self._dirty and not self._linear:
             raise NotImplementedError(
                 "Reading memory not supported once execution begins."
@@ -252,6 +417,11 @@ class AngrEmulator(
         return None
 
     def read_memory_label(self, address: int, size: int) -> typing.Optional[str]:
+        if not self._initialized:
+            raise exceptions.ConfigurationError(
+                "Cannot read memory before initialization"
+            )
+
         if self._dirty and not self._linear:
             raise NotImplementedError(
                 "Writing memory not supported once execution begins."
@@ -277,15 +447,20 @@ class AngrEmulator(
             return None
 
     def map_memory(self, address: int, size: int) -> None:
-        if self._dirty and not self._linear:
-            raise NotImplementedError(
-                "Mapping memory not supported once execution begins."
-            )
-        # Unlike Unicorn, angr doesn't care about pages.
-        region = (address, address + size)
-        self.state.scratch.memory_map.add_range(region)
+        if not self._initialized:
+            self._memory_maps.append((address, size))
+        else:
+            if self._dirty and not self._linear:
+                raise NotImplementedError(
+                    "Mapping memory not supported once execution begins."
+                )
+            # Unlike Unicorn, angr doesn't care about pages.
+            region = (address, address + size)
+            self.state.scratch.memory_map.add_range(region)
 
     def get_memory_map(self) -> typing.List[typing.Tuple[int, int]]:
+        if not self._initialized:
+            return list(map(lambda x: (x[0], x[0] + x[1]), self._memory_maps))
         if self._dirty and not self._linear:
             raise NotImplementedError(
                 "Mapping memory not supported once execution begins."
@@ -293,13 +468,16 @@ class AngrEmulator(
         return list(self.state.scratch.memory_map.ranges)
 
     def write_memory_content(self, address: int, content: bytes) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._memory_contents.append((address, content))
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Writing memory not supported once execution begins."
             )
-        log.info(f"Storing {len(content)} bytes at {hex(address)}")
-        v = claripy.BVV(content)
-        self.state.memory.store(address, v)
+        else:
+            log.info(f"Storing {len(content)} bytes at {hex(address)}")
+            v = claripy.BVV(content)
+            self.state.memory.store(address, v)
 
     def write_memory_type(
         self, address: int, size: int, type: typing.Optional[typing.Any] = None
@@ -309,163 +487,222 @@ class AngrEmulator(
     def write_memory_label(
         self, address: int, size: int, label: typing.Optional[str] = None
     ) -> None:
-        if self._dirty and not self._linear:
+        if label is None:
+            return
+        elif not self._initialized:
+            self._memory_labels.append((address, size, label))
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Writing memory not supported once execution begins."
             )
-        if label is None:
-            return
-        # This will bind whatever value is currently at this address
-        # to a symbol named after the label
-        #
-        # The same label will ALWAYS map to the same symbol!
-        # This can introduce unintended restrictions on exploration,
-        # or even a contradictory state.
-        #
-        # This will trigger angr's default value computation,
-        # which may cause spurious results in some analyses.
-        s = claripy.BVS(label, size * 8, explicit_name=True)
-        v = self.state.memory.load(address, size)
-        if not self.state.solver.satisfiable(extra_constraints=[v == s]):
-            # Creating this binding will definitely cause a contradiction.
-            # Have you already used this label somewhere else?
-            raise exceptions.ConfigurationError(
-                f"Contradiction binding memory at {hex(address)} to label {label}"
-            )
+        else:
+            # This will bind whatever value is currently at this address
+            # to a symbol named after the label
+            #
+            # The same label will ALWAYS map to the same symbol!
+            # This can introduce unintended restrictions on exploration,
+            # or even a contradictory state.
+            #
+            # This will trigger angr's default value computation,
+            # which may cause spurious results in some analyses.
+            s = claripy.BVS(label, size * 8, explicit_name=True)
+            v = self.state.memory.load(address, size)
+            if not self.state.solver.satisfiable(extra_constraints=[v == s]):
+                # Creating this binding will definitely cause a contradiction.
+                # Have you already used this label somewhere else?
+                raise exceptions.ConfigurationError(
+                    f"Contradiction binding memory at {hex(address)} to label {label}"
+                )
 
-        # Passing the last check doesn't mean you're safe.
-        # There may be over-constraints.  Please be careful.
-        self.state.memory.store(address, s)
-        self.state.solver.add(v == s)
+            # Passing the last check doesn't mean you're safe.
+            # There may be over-constraints.  Please be careful.
+            self.state.memory.store(address, s)
+            self.state.solver.add(v == s)
+
+    def write_code(self, address: int, content: bytes):
+        if self._initialized:
+            self.write_memory_content(address, content)
+        else:
+            self._code.append((address, content))
 
     def hook_instruction(
         self, address: int, function: typing.Callable[[emulator.Emulator], None]
     ) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._instr_hooks.append((address, function))
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Instruction hooking not supported once execution begins"
             )
-        if address in self.state.scratch.insn_bps:
+
+        elif address in self.state.scratch.insn_bps:
             raise exceptions.ConfigurationError(
                 "Instruction at address {hex(address)} is already hooked"
             )
 
-        def hook_handler(state):
-            emu = ConcreteAngrEmulator(state, self)
-            function(emu)
+        else:
 
-            # An update to angr means some operations on `state`
-            # will clobber this variable, which causes bad problems.
-            # Unclobber it, just in case
-            state.inspect.action_attrs_set = True
+            def hook_handler(state):
+                emu = ConcreteAngrEmulator(state, self)
+                function(emu)
 
-        bp = self.state.inspect.b(
-            "instruction", when=angr.BP_BEFORE, action=hook_handler, instruction=address
-        )
-        self.state.scratch.insn_bps[address] = bp
+                # An update to angr means some operations on `state`
+                # will clobber this variable, which causes bad problems.
+                # Unclobber it, just in case
+                state.inspect.action_attrs_set = True
+
+            bp = self.state.inspect.b(
+                "instruction",
+                when=angr.BP_BEFORE,
+                action=hook_handler,
+                instruction=address,
+            )
+            self.state.scratch.insn_bps[address] = bp
 
     def unhook_instruction(self, address: int) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._instr_hooks = list(
+                filter(lambda x: x[0] != address, self._instr_hooks)
+            )
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Instruction hooking not supported once execution begins"
             )
-        if address not in self.state.scratch.insn_bps:
+
+        elif address not in self.state.scratch.insn_bps:
             raise exceptions.ConfigurationError(
                 "Instruction at address {hex(address)} is not hooked"
             )
-        bp = self.state.scratch.insn_bps[address]
-        del self.state.scratch.insn_bps[address]
 
-        self.state.inspect.remove_breakpoint("instruction", bp)
+        else:
+            bp = self.state.scratch.insn_bps[address]
+            del self.state.scratch.insn_bps[address]
+
+            self.state.inspect.remove_breakpoint("instruction", bp)
 
     def hook_instructions(
         self, function: typing.Callable[[emulator.Emulator], None]
     ) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._gb_instr_hook = function
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Global instruction hooking not supported once execution begins"
             )
 
-        if self.state.scratch.global_insn_bp is not None:
+        elif self.state.scratch.global_insn_bp is not None:
             raise exceptions.ConfigurationError(
                 "Global instruction hook already registered"
             )
 
-        def hook_handler(state):
-            emu = ConcreteAngrEmulator(state, self)
-            function(emu)
+        else:
 
-            # An update to angr means some operations on `state`
-            # will clobber this variable, which causes bad problems.
-            # Unclobber it, just in case
-            state.inspect.action_attrs_set = True
+            def hook_handler(state):
+                emu = ConcreteAngrEmulator(state, self)
+                function(emu)
 
-        self.state.scratch.global_insn_bp = self.state.inspect.b(
-            "instruction", when=angr.BP_BEFORE, action=hook_handler
-        )
+                # An update to angr means some operations on `state`
+                # will clobber this variable, which causes bad problems.
+                # Unclobber it, just in case
+                state.inspect.action_attrs_set = True
+
+            self.state.scratch.global_insn_bp = self.state.inspect.b(
+                "instruction", when=angr.BP_BEFORE, action=hook_handler
+            )
 
     def unhook_instructions(self) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._gb_instruction_hook = None
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Global instruction unhooking not supported once execution begins"
             )
 
-        if self.state.scratch.global_insn_bp is None:
+        elif self.state.scratch.global_insn_bp is None:
             raise exceptions.ConfigurationError("No global instruction hook present")
 
-        bp = self.state.scratch.global_insn_bp
-        self.state.scratch.global_insn_bp = None
-        self.state.inspect.remove_breakpoint("instruction", bp)
+        else:
+            bp = self.state.scratch.global_insn_bp
+            self.state.scratch.global_insn_bp = None
+            self.state.inspect.remove_breakpoint("instruction", bp)
 
     def hook_function(
         self, address: int, function: typing.Callable[[emulator.Emulator], None]
     ) -> None:
-        if self._dirty and not self._linear:
-            raise NotImplementedError("Cannot hook functions once emulation starts")
-        hook = HookHandler(callback=function, parent=self)
-        self.proj.hook(address, hook, 0)
+        if not self._initialized:
+            self._func_hooks.append((address, function))
 
-        self.map_memory(address, 1)
-        self.state.scratch.func_bps[address] = None
+        elif self._dirty and not self._linear:
+            raise NotImplementedError("Cannot hook functions once emulation starts")
+
+        else:
+            hook = HookHandler(callback=function, parent=self)
+            self.proj.hook(address, hook, 0)
+
+            self.map_memory(address, 1)
+            self.state.scratch.func_bps[address] = None
 
     def unhook_function(self, address: int) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._func_hooks = list(filter(lambda x: x[0] != address, self._func_hooks))
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError("Cannot unhook functions once emulation starts")
-        self.proj.unhook(address)
+
+        else:
+            self.proj.unhook(address)
 
     def hook_syscall(
         self, number: int, function: typing.Callable[[emulator.Emulator], None]
     ) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._syscall_hooks[number] = function
+        elif self._dirty and not self._linear:
             raise NotImplementedError("Cannot hook syscalls once emulation starts")
-        if number in self.state.scratch.syscall_funcs:
+        elif number in self.state.scratch.syscall_funcs:
             raise exceptions.ConfigurationError(
                 f"Already have a syscall hook for {number}"
             )
+        else:
 
-        def syscall_handler(state):
-            function(ConcreteAngrEmulator(state, self))
+            def syscall_handler(state):
+                function(ConcreteAngrEmulator(state, self))
 
-        self.state.scratch.syscall_funcs[number] = syscall_handler
+            self.state.scratch.syscall_funcs[number] = syscall_handler
 
     def unhook_syscall(self, number: int) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            del self._syscall_hooks[number]
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError("Cannot unhook syscalls once emulation starts")
-        if number not in self.state.scratch.syscall_funcs:
+
+        elif number not in self.state.scratch.syscall_funcs:
             raise exceptions.ConfigurationError(f"No syscall hook for {number}")
-        del self.state.scratch.syscall_funcs[number]
+
+        else:
+            del self.state.scratch.syscall_funcs[number]
 
     def hook_syscalls(
         self, function: typing.Callable[[emulator.Emulator, int], None]
     ) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._gb_syscall_hook = function
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError("Cannot hook syscalls once emulation starts")
 
-        if self.state.scratch.global_syscall_func is not None:
+        elif self.state.scratch.global_syscall_func is not None:
             raise exceptions.ConfigurationError("Already have a global syscall hook")
 
-        def syscall_handler(state, number: int):
-            function(ConcreteAngrEmulator(state, self), number)
+        else:
+
+            def syscall_handler(state, number: int):
+                function(ConcreteAngrEmulator(state, self), number)
 
         self.state.scratch.global_syscall_func = syscall_handler
 
@@ -483,139 +720,165 @@ class AngrEmulator(
         end: int,
         function: typing.Callable[[emulator.Emulator, int, int], bytes],
     ) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._read_hooks.append((start, end, function))
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Memory hooking not supported once execution begins"
             )
-        if (start, end) in self.state.scratch.mem_read_bps:
+
+        elif (start, end) in self.state.scratch.mem_read_bps:
             raise exceptions.ConfigurationError(
                 f"{hex(start)}-{hex(end)} already hooked for reads"
             )
 
-        # This uses angr's conditional breakpoint facility
-        def read_condition(state):
-            # The breakpoint condition.
-            # This needs to be a bit clever to detect reads at bound symbolic addresses.
-            # The actual address won't get concretized until later
-            read_start = state.inspect.mem_read_address
-            if not isinstance(read_start, int):
-                if read_start.symbolic:
-                    try:
-                        values = state.solver.eval_atmost(read_start, 1)
-                        # Truly unbound address.
-                        # Assume it won't collapse to our hook address
-                        if len(values) < 1:
+        else:
+            # This uses angr's conditional breakpoint facility
+            def read_condition(state):
+                # The breakpoint condition.
+                # This needs to be a bit clever to detect reads at bound symbolic addresses.
+                # The actual address won't get concretized until later
+                read_start = state.inspect.mem_read_address
+                if not isinstance(read_start, int):
+                    if read_start.symbolic:
+                        try:
+                            values = state.solver.eval_atmost(read_start, 1)
+                            # Truly unbound address.
+                            # Assume it won't collapse to our hook address
+                            if len(values) < 1:
+                                return False
+                            read_start = values[0]
+                        except angr.errors.SimUnsatError:
                             return False
-                        read_start = values[0]
-                    except angr.errors.SimUnsatError:
-                        return False
-                    except angr.errors.SimValueError:
-                        return False
-                else:
-                    read_start = read_start.concrete_value
-                state.inspect.mem_read_address = read_start
-            read_size = state.inspect.mem_read_length
+                        except angr.errors.SimValueError:
+                            return False
+                    else:
+                        read_start = read_start.concrete_value
+                    state.inspect.mem_read_address = read_start
+                read_size = state.inspect.mem_read_length
 
-            if read_size is None:
-                return False
-            read_end = read_start + read_size
+                if read_size is None:
+                    return False
+                read_end = read_start + read_size
 
-            return start <= read_start and end >= read_end
+                return start <= read_start and end >= read_end
 
-        def read_callback(state):
-            # The breakpoint action.
-            addr = state.inspect.mem_read_address
-            size = state.inspect.mem_read_length
+            def read_callback(state):
+                # The breakpoint action.
+                addr = state.inspect.mem_read_address
+                size = state.inspect.mem_read_length
 
-            res = claripy.BVV(function(ConcreteAngrEmulator(state, self), addr, size))
+                res = claripy.BVV(
+                    function(ConcreteAngrEmulator(state, self), addr, size)
+                )
 
-            if self.platform.byteorder == platforms.Byteorder.LITTLE:
-                # Fix byte order if needed.
-                # I don't know _why_ this is needed,
-                # but encoding the result as little-endian on a little-endian
-                # system produces the incorrect value in the machine state.
-                res = claripy.Reverse(res)
-            state.inspect.mem_read_expr = res
+                if self.platform.byteorder == platforms.Byteorder.LITTLE:
+                    # Fix byte order if needed.
+                    # I don't know _why_ this is needed,
+                    # but encoding the result as little-endian on a little-endian
+                    # system produces the incorrect value in the machine state.
+                    res = claripy.Reverse(res)
+                state.inspect.mem_read_expr = res
 
-            # An update to angr means some operations on `state`
-            # will clobber this variable, which causes bad problems.
-            # Unclobber it, just in case
-            state.inspect.action_attrs_set = True
+                # An update to angr means some operations on `state`
+                # will clobber this variable, which causes bad problems.
+                # Unclobber it, just in case
+                state.inspect.action_attrs_set = True
 
-        bp = self.state.inspect.b(
-            "mem_read",
-            when=angr.BP_AFTER,
-            condition=read_condition,
-            action=read_callback,
-        )
-        self.state.scratch.mem_read_bps[(start, end)] = bp
+            bp = self.state.inspect.b(
+                "mem_read",
+                when=angr.BP_AFTER,
+                condition=read_condition,
+                action=read_callback,
+            )
+            self.state.scratch.mem_read_bps[(start, end)] = bp
 
     def unhook_memory_read(self, start: int, end: int):
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._read_hooks = list(
+                filter(lambda x: x[0] != start and x[1] != end, self._read_hooks)
+            )
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Memory hooking not supported once execution begins"
             )
-        if (start, end) not in self.state.scratch.mem_read_bps:
+
+        elif (start, end) not in self.state.scratch.mem_read_bps:
             raise exceptions.ConfigurationError(
                 f"{hex(start)} - {hex(end)} is not hooked for reads"
             )
-
-        bp = self.state.scratch.mem_read_bps[(start, end)]
-        del self.state.scratch.mem_read_bps[(start, end)]
-        self.state.inspect.remove_breakpoint("mem_read", bp=bp)
+        else:
+            bp = self.state.scratch.mem_read_bps[(start, end)]
+            del self.state.scratch.mem_read_bps[(start, end)]
+            self.state.inspect.remove_breakpoint("mem_read", bp=bp)
 
     def hook_memory_reads(
         self, function: typing.Callable[[emulator.Emulator, int, int], bytes]
     ) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._gb_read_hook = function
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Memory hooking not supported once execution begins"
             )
-        if self.state.scratch.global_read_bp is not None:
+
+        elif self.state.scratch.global_read_bp is not None:
             raise exceptions.ConfigurationError(
                 "Global memory read hook already present"
             )
 
-        def read_callback(state):
-            # the breakpoint action.
-            addr = state.inspect.mem_read_address
-            if not isinstance(addr, int):
-                addr = addr.concrete_value
-            size = state.inspect.mem_read_length
+        else:
 
-            res = claripy.BVV(function(ConcreteAngrEmulator(state, self), addr, size))
+            def read_callback(state):
+                # the breakpoint action.
+                addr = state.inspect.mem_read_address
+                if not isinstance(addr, int):
+                    addr = addr.concrete_value
+                size = state.inspect.mem_read_length
 
-            if self.platform.byteorder == platforms.byteorder.LITTLE:
-                # fix byte order if needed.
-                # i don't know _why_ this is needed,
-                # but encoding the result as little-endian on a little-endian
-                # system produces the incorrect value in the machine state.
-                res = claripy.Reverse(res)
-            state.inspect.mem_read_expr = res
+                res = claripy.BVV(
+                    function(ConcreteAngrEmulator(state, self), addr, size)
+                )
 
-            # An update to angr means some operations on `state`
-            # will clobber this variable, which causes bad problems.
-            # Unclobber it, just in case
-            state.inspect.action_attrs_set = True
+                if self.platform.byteorder == platforms.byteorder.LITTLE:
+                    # fix byte order if needed.
+                    # i don't know _why_ this is needed,
+                    # but encoding the result as little-endian on a little-endian
+                    # system produces the incorrect value in the machine state.
+                    res = claripy.Reverse(res)
+                state.inspect.mem_read_expr = res
 
-        bp = self.state.inspect.b(
-            "mem_read",
-            when=angr.BP_AFTER,
-            action=read_callback,
-        )
-        self.state.scratch.global_read_bp = bp
+                # An update to angr means some operations on `state`
+                # will clobber this variable, which causes bad problems.
+                # Unclobber it, just in case
+                state.inspect.action_attrs_set = True
+
+            bp = self.state.inspect.b(
+                "mem_read",
+                when=angr.BP_AFTER,
+                action=read_callback,
+            )
+            self.state.scratch.global_read_bp = bp
 
     def unhook_memory_reads(self) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._gb_read_hook = None
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Memory unhooking not supported once execution begins"
             )
-        if self.state.scratch.global_read_bp is not None:
+
+        elif self.state.scratch.global_read_bp is not None:
             raise exceptions.ConfigurationError("Global memory read hook not present")
 
-        bp = self.state.scratch.global_read_bp
-        self.state.scratch.global_read_bp = None
-        self.state.inspect.remove_breakpoint("mem_read", bp)
+        else:
+            bp = self.state.scratch.global_read_bp
+            self.state.scratch.global_read_bp = None
+            self.state.inspect.remove_breakpoint("mem_read", bp)
 
     def hook_memory_write(
         self,
@@ -623,152 +886,179 @@ class AngrEmulator(
         end: int,
         function: typing.Callable[[emulator.Emulator, int, int, bytes], None],
     ) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._write_hooks.append((start, end, function))
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Memory hooking not supported once execution begins"
             )
-        if (start, end) in self.state.scratch.mem_write_bps:
+
+        elif (start, end) in self.state.scratch.mem_write_bps:
             raise exceptions.ConfigurationError(
                 f"{hex(start)} - {hex(end)} already hooked for writes"
             )
 
-        def write_condition(state):
-            write_start = state.inspect.mem_write_address
-            if not isinstance(write_start, int):
-                if write_start.symbolic:
-                    # Need to use the solver to resolve this.
-                    try:
-                        values = state.solver.eval_atmost(write_start, 1)
-                        if len(values) < 1:
+        else:
+
+            def write_condition(state):
+                write_start = state.inspect.mem_write_address
+                if not isinstance(write_start, int):
+                    if write_start.symbolic:
+                        # Need to use the solver to resolve this.
+                        try:
+                            values = state.solver.eval_atmost(write_start, 1)
+                            if len(values) < 1:
+                                return False
+                            write_start = values[0]
+                        except angr.errors.SimUnsatError:
                             return False
-                        write_start = values[0]
+                        except angr.errors.SimValueError:
+                            return False
+                    else:
+                        write_start = write_start.concrete_value
+                    # Populate concrete value back to the inspect struct
+                    state.inspect.mem_write_address = write_start
+                log.info(f"Writing to {hex(write_start)}")
+                write_size = state.inspect.mem_write_length
+
+                if write_size is None:
+                    # Some ISAs don't populate mem_write_length.
+                    # Infer length from value
+                    write_size = len(state.inspect.mem_write_expr) // 8
+                    # Populate concrete value back to the inspect struct
+                    state.inspect.mem_write_length = write_size
+                write_end = write_start + write_size
+
+                return start <= write_start and end >= write_end
+
+            def write_callback(state):
+                addr = state.inspect.mem_write_address
+                size = state.inspect.mem_write_length
+                expr = state.inspect.mem_write_expr
+                if expr.symbolic:
+                    # Have the solver handle binding resolution for us.
+                    try:
+                        values = state.solver.eval_atmost(expr, 1)
+                        if len(values) < 1:
+                            raise exceptions.AnalysisError(
+                                f"No possible values fpr {expr}"
+                            )
+                        value = values[0].to_bytes(
+                            size, byteorder=self.machdef.byteorder
+                        )
+                        log.info("Collapsed symbolic {expr} to {values[0]:x} for MMIO")
                     except angr.errors.SimUnsatError:
-                        return False
+                        raise exceptions.AnalysisError(f"No possible values for {expr}")
                     except angr.errors.SimValueError:
-                        return False
+                        raise exceptions.AnalysisError(
+                            f"Unbound value for MMIO write to {hex(addr)}: {expr}"
+                        )
                 else:
-                    write_start = write_start.concrete_value
-                # Populate concrete value back to the inspect struct
-                state.inspect.mem_write_address = write_start
-            log.info(f"Writing to {hex(write_start)}")
-            write_size = state.inspect.mem_write_length
-
-            if write_size is None:
-                # Some ISAs don't populate mem_write_length.
-                # Infer length from value
-                write_size = len(state.inspect.mem_write_expr) // 8
-                # Populate concrete value back to the inspect struct
-                state.inspect.mem_write_length = write_size
-            write_end = write_start + write_size
-
-            return start <= write_start and end >= write_end
-
-        def write_callback(state):
-            addr = state.inspect.mem_write_address
-            size = state.inspect.mem_write_length
-            expr = state.inspect.mem_write_expr
-            if expr.symbolic:
-                # Have the solver handle binding resolution for us.
-                try:
-                    values = state.solver.eval_atmost(expr, 1)
-                    if len(values) < 1:
-                        raise exceptions.AnalysisError(f"No possible values fpr {expr}")
-                    value = values[0].to_bytes(size, byteorder=self.machdef.byteorder)
-                    log.info("Collapsed symbolic {expr} to {values[0]:x} for MMIO")
-                except angr.errors.SimUnsatError:
-                    raise exceptions.AnalysisError(f"No possible values for {expr}")
-                except angr.errors.SimValueError:
-                    raise exceptions.AnalysisError(
-                        f"Unbound value for MMIO write to {hex(addr)}: {expr}"
+                    value = expr.concrete_value.to_bytes(
+                        size, byteorder=self.platform.byteorder.value
                     )
-            else:
-                value = expr.concrete_value.to_bytes(
-                    size, byteorder=self.platform.byteorder.value
-                )
 
-            if size is None:
-                size = len(expr)
+                if size is None:
+                    size = len(expr)
 
-            function(ConcreteAngrEmulator(state, self), addr, size, value)
+                function(ConcreteAngrEmulator(state, self), addr, size, value)
 
-            # An update to angr means some operations on `state`
-            # will clobber this variable, which causes bad problems.
-            # Unclobber it, just in case
-            state.inspect.action_attrs_set = True
+                # An update to angr means some operations on `state`
+                # will clobber this variable, which causes bad problems.
+                # Unclobber it, just in case
+                state.inspect.action_attrs_set = True
 
-        bp = self.state.inspect.b(
-            "mem_write",
-            when=angr.BP_BEFORE,
-            condition=write_condition,
-            action=write_callback,
-        )
-        self.state.scratch.mem_write_bps[(start, end)] = bp
+            bp = self.state.inspect.b(
+                "mem_write",
+                when=angr.BP_BEFORE,
+                condition=write_condition,
+                action=write_callback,
+            )
+            self.state.scratch.mem_write_bps[(start, end)] = bp
 
     def unhook_memory_write(self, start: int, end: int) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._write_hooks = list(
+                filter(lambda x: x[0] != start or x[1] != end, self._write_hooks)
+            )
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Memory hooking not supported once execution begins"
             )
-        if (start, end) not in self.state.scratch.mem_write_bps:
+
+        elif (start, end) not in self.state.scratch.mem_write_bps:
             raise exceptions.ConfigurationError(
                 f"{hex(start)} - {hex(end)} is not hooked for writes"
             )
 
-        bp = self.state.scratch.mem_write_bps[(start, end)]
-        del self.state.scratch.mem_write_bps[(start, end)]
-        self.state.inspect.remove_breakpoint("mem_write", bp=bp)
+        else:
+            bp = self.state.scratch.mem_write_bps[(start, end)]
+            del self.state.scratch.mem_write_bps[(start, end)]
+            self.state.inspect.remove_breakpoint("mem_write", bp=bp)
 
     def hook_memory_writes(
         self, function: typing.Callable[[emulator.Emulator, int, int, bytes], None]
     ) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._gb_write_hook = function
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Memory hooking not supported once execution begins"
             )
-        if self.state.scratch.global_write_bp is not None:
+
+        elif self.state.scratch.global_write_bp is not None:
             raise exceptions.ConfigurationError(
                 "Global memory write hook already present"
             )
 
-        def write_callback(state):
-            addr = state.inspect.mem_write_address
-            if not isinstance(addr, int):
-                addr = addr.concrete_value
-            size = state.inspect.mem_write_length
-            expr = state.inspect.mem_write_expr
-            if expr.symbolic:
-                # Have the solver handle binding resolution for us.
-                try:
-                    values = state.solver.eval_atmost(expr, 1)
-                    if len(values) < 1:
-                        raise exceptions.AnalysisError(f"No possible values fpr {expr}")
-                    value = values[0].to_bytes(size, byteorder=self.machdef.byteorder)
-                    log.info("Collapsed symbolic {expr} to {values[0]:x} for MMIO")
-                except angr.errors.SimUnsatError:
-                    raise exceptions.AnalysisError(f"No possible values for {expr}")
-                except angr.errors.SimValueError:
-                    raise exceptions.AnalysisError(
-                        f"Unbound value for MMIO write to {hex(addr)}: {expr}"
+        else:
+
+            def write_callback(state):
+                addr = state.inspect.mem_write_address
+                if not isinstance(addr, int):
+                    addr = addr.concrete_value
+                size = state.inspect.mem_write_length
+                expr = state.inspect.mem_write_expr
+                if expr.symbolic:
+                    # Have the solver handle binding resolution for us.
+                    try:
+                        values = state.solver.eval_atmost(expr, 1)
+                        if len(values) < 1:
+                            raise exceptions.AnalysisError(
+                                f"No possible values fpr {expr}"
+                            )
+                        value = values[0].to_bytes(
+                            size, byteorder=self.machdef.byteorder
+                        )
+                        log.info("Collapsed symbolic {expr} to {values[0]:x} for MMIO")
+                    except angr.errors.SimUnsatError:
+                        raise exceptions.AnalysisError(f"No possible values for {expr}")
+                    except angr.errors.SimValueError:
+                        raise exceptions.AnalysisError(
+                            f"Unbound value for MMIO write to {hex(addr)}: {expr}"
+                        )
+                else:
+                    value = expr.concrete_value.to_bytes(
+                        size, byteorder=self.platform.byteorder.value
                     )
-            else:
-                value = expr.concrete_value.to_bytes(
-                    size, byteorder=self.platform.byteorder.value
-                )
 
-            function(ConcreteAngrEmulator(state, self), addr, size, value)
+                function(ConcreteAngrEmulator(state, self), addr, size, value)
 
-            # An update to angr means some operations on `state`
-            # will clobber this variable, which causes bad problems.
-            # Unclobber it, just in case
-            state.inspect.action_attrs_set = True
+                # An update to angr means some operations on `state`
+                # will clobber this variable, which causes bad problems.
+                # Unclobber it, just in case
+                state.inspect.action_attrs_set = True
 
-        bp = self.state.inspect.b(
-            "mem_write",
-            when=angr.BP_BEFORE,
-            action=write_callback,
-        )
+            bp = self.state.inspect.b(
+                "mem_write",
+                when=angr.BP_BEFORE,
+                action=write_callback,
+            )
 
-        self.state.scratch.global_write_bp = bp
+            self.state.scratch.global_write_bp = bp
 
     def unhook_memory_writes(self) -> None:
         if self._dirty and not self._linear:
@@ -790,6 +1080,10 @@ class AngrEmulator(
         Arguments:
             single_insn: True to step one instruction.  False to step to the end of the block
         """
+        # If we have not been initialized, initialize ourself
+        if not self._initialized:
+            self.initialize()
+
         # As soon as we start executing, disable value access
         self._dirty = True
         if self._linear:
@@ -903,7 +1197,10 @@ class AngrEmulator(
         self._linear = True
         log.warn("Linear execution mode enabled")
 
-    def get_bounds(self) -> typing.List[typing.Tuple[int, int]]:
+    def get_code_bounds(self) -> typing.List[typing.Tuple[int, int]]:
+        if not self._initialized:
+            return list(self._code_bounds)
+
         if self._dirty and not self._linear:
             raise NotImplementedError(
                 "Accessing bounds not supported once execution begins"
@@ -911,21 +1208,35 @@ class AngrEmulator(
         return list(self.state.scratch.bounds.ranges)
 
     def add_bound(self, start: int, end: int) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._code_bounds.append((start, end))
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Accessing bounds not supported once execution begins"
             )
-        self.state.scratch.bounds.add_range((start, end))
+
+        else:
+            self.state.scratch.bounds.add_range((start, end))
 
     def remove_bound(self, start: int, end: int) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._code_bounds = list(
+                filter(lambda x: x[0] != start or x[1] != end, self._code_bounds)
+            )
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Accessing bounds not supported once execution begins"
             )
 
-        self.state.scratch.bounds.remove_range((start, end))
+        else:
+            self.state.scratch.bounds.remove_range((start, end))
 
     def get_exit_points(self) -> typing.Set[int]:
+        if not self._initialized:
+            return set(self._exit_points)
+
         if self._dirty and not self._linear:
             raise NotImplementedError(
                 "Accessing exit points not supported once execution begins"
@@ -933,18 +1244,26 @@ class AngrEmulator(
         return set(self.state.scratch.exit_points)
 
     def add_exit_point(self, address: int) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._exit_points.add(address)
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Accessing exit points not supported once execution begins"
             )
-        self.state.scratch.exit_points.add(address)
+        else:
+            self.state.scratch.exit_points.add(address)
 
     def remove_exit_point(self, address: int) -> None:
-        if self._dirty and not self._linear:
+        if not self._initialized:
+            self._exit_points.remove(address)
+
+        elif self._dirty and not self._linear:
             raise NotImplementedError(
                 "Accessing exit points not supported once execution begins"
             )
-        self.state.scratch.exit_points.remove(address)
+
+        else:
+            self.state.scratch.exit_points.remove(address)
 
     def __repr__(self):
         return f"Angr ({self.mgr})"
@@ -975,6 +1294,7 @@ class ConcreteAngrEmulator(AngrEmulator):
     def __init__(self, state: angr.SimState, parent: AngrEmulator):
         # Do NOT call the superclass constructor.
         # It initializes the angr project, and we've already done that.
+        self._initialized: bool = True
         self._dirty: bool = False
         self._linear: bool = False
 

--- a/smallworld/emulators/emulator.py
+++ b/smallworld/emulators/emulator.py
@@ -282,6 +282,25 @@ class Emulator(utils.MetadataMixin, metaclass=abc.ABCMeta):
 
         self.write_memory_content(address, content)
 
+    def write_code(self, address: int, content: bytes) -> None:
+        """Write executable memory at a specific address.
+
+        Implementations can take advantage of this
+        if they store code and memory differently.
+
+        Otherwise, it should be identical to `write_memory()`.
+
+        Note:
+            Written memory should already be mapped by some call to
+            `map_memory()`.
+
+        Arguments:
+            address: The address of the memory region.
+            content: The content to write.
+
+        """
+        self.write_memory_content(address, content)
+
     def get_bounds(self) -> typing.List[typing.Tuple[int, int]]:
         """Get a list of all registered execution bounds.
 

--- a/smallworld/state/memory/code.py
+++ b/smallworld/state/memory/code.py
@@ -1,5 +1,6 @@
 import typing
 
+from ... import emulators
 from . import memory
 
 
@@ -13,6 +14,11 @@ class Executable(memory.RawMemory):
         This is not used by Emulators - but is available for reference from
         file parsing, if supported.
     """
+
+    def _write_content(
+        self, emulator: emulators.Emulator, address: int, content: bytes
+    ):
+        emulator.write_code(address, content)
 
     @classmethod
     def from_elf(cls, file: typing.BinaryIO, address: typing.Optional[int] = None):

--- a/smallworld/state/state.py
+++ b/smallworld/state/state.py
@@ -500,7 +500,6 @@ class StatefulSet(Stateful, collections.abc.MutableSet):
 
     def extract(self, emulator: emulators.Emulator) -> None:
         for stateful in self:
-            # logger.debug(f"extracting state {stateful} of type {type(stateful)} from {emulator}")
             stateful.extract(emulator)
 
     def apply(self, emulator: emulators.Emulator) -> None:


### PR DESCRIPTION
Loading code directly into symbolic memory makes the emulator inoperable for larger (at least 80 MB) images.
Code loaded through CLE gets a shortcut in angr's memory handling, making the emulator work.

This required a bunch of changes to AngrEmulator, but should not impact its API behavior.
If it does, let me know.