### PR TITLE
fix: Fix memory map bug in unicorn hooks

### DIFF
--- a/smallworld/emulators/unicorn/unicorn.py
+++ b/smallworld/emulators/unicorn/unicorn.py
@@ -407,13 +407,13 @@ class UnicornEmulator(
         self, address: int, function: typing.Callable[[emulator.Emulator], None]
     ) -> None:
         super(UnicornEmulator, self).hook_instruction(address, function)
-        self.map_memory(self.PAGE_SIZE, address)
+        self.map_memory(address, self.PAGE_SIZE)
 
     def hook_function(
         self, address: int, function: typing.Callable[[emulator.Emulator], None]
     ) -> None:
         super(UnicornEmulator, self).hook_function(address, function)
-        self.map_memory(self.PAGE_SIZE, address)
+        self.map_memory(address, self.PAGE_SIZE)
 
     def _disassemble(
         self, code: bytes, base: int, count: typing.Optional[int] = None


### PR DESCRIPTION
Unicorn still used old `map_memory` signatures; our tests map low, so they didn't catch the error.