### PR TITLE
fix: Fixed many small bugs

### DIFF
--- a/smallworld/emulators/angr/memory/default.py
+++ b/smallworld/emulators/angr/memory/default.py
@@ -1,9 +1,10 @@
 import angr
 
+from .fixups import FixupMemoryMixin
 from .memtrack import TrackerMemoryMixin
 
 
 class DefaultMemoryPlugin(  # type: ignore[misc]
-    TrackerMemoryMixin, angr.storage.DefaultMemory
+    TrackerMemoryMixin, FixupMemoryMixin, angr.storage.DefaultMemory
 ):
     pass

--- a/smallworld/emulators/angr/memory/fixups.py
+++ b/smallworld/emulators/angr/memory/fixups.py
@@ -1,0 +1,43 @@
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
+
+
+class FixupMemoryMixin(MemoryMixin):
+    """Mixin providing some basic bug-fixed/feature improvements
+
+    angr doesn't always behave as I'd expect.
+    This mixin helps things a little.
+    """
+
+    def _concretize_addr(self, supercall, addr, strategies=None, condition=None):
+        # Handle potential errors durring concretization
+        # This works the same for reads and writes, so why duplicate code?
+
+        if not self.state.solver.satisfiable():
+            # This state isn't satisfiable; concretization is impossible, but irrelevant.
+            #
+            # Under some conditions of which I'm uncertain,
+            # the concretizer will try to run even if the state is already unsat.
+            # Since the concretizer relies on the solver,
+            # it fails with a big ole' fatal exception.
+            #
+            # The successor computation will eventually kill these states anyway,
+            # so just return a dummy value to keep things running.
+            return [0xDEAD0000]
+
+        return supercall(addr, strategies=strategies, condition=condition)
+
+    def concretize_read_addr(self, addr, strategies=None, condition=None):
+        return self._concretize_addr(
+            super().concretize_read_addr,
+            addr,
+            strategies=strategies,
+            condition=condition,
+        )
+
+    def concretize_write_addr(self, addr, strategies=None, condition=None):
+        return self._concretize_addr(
+            super().concretize_write_addr,
+            addr,
+            strategies=strategies,
+            condition=condition,
+        )

--- a/smallworld/hinting/hints.py
+++ b/smallworld/hinting/hints.py
@@ -422,5 +422,6 @@ __all__ = [
     "MemoryUnavailableProbHint",
     "EmulationException",
     "CoverageHint",
+    "ControlFlowHint",
     "ReachableCodeHint",
 ]

--- a/smallworld/state/state.py
+++ b/smallworld/state/state.py
@@ -382,7 +382,7 @@ class Register(Value, Stateful):
         elif isinstance(x, int):
             s = s + f"0x{x:x}"
         else:
-            s = s + str(x)
+            s = s + str(type(x))
         return s
 
     def set_content(self, content: typing.Union[None, int, bytes, claripy.ast.bv.BV]):

--- a/smallworld/utils.py
+++ b/smallworld/utils.py
@@ -387,7 +387,7 @@ class RBTree(Iterable):
                 S.is_black = False
                 N = P
                 P = N.parent
-                branch = 0 if P.child[0] is N else 1
+                branch = 0 if P is None or P.child[0] is N else 1
 
             # Case 5.1: N is the new root; we're done.
         # self._verify_rb(self._root, 0)


### PR DESCRIPTION
- Claripy expressions can get big; printing them may never terminate, so don't print them.
- angr tries to concretize addresses when the solver is already unsat, leading to a fatal error.  Block this.
- Fixed a missing export in hinting