### PR TITLE
refactor: Make helpers.analyze() run on specific analyses

### DIFF
--- a/examples/basic_harness.py
+++ b/examples/basic_harness.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import typing
 
 import smallworld
 
@@ -29,8 +30,11 @@ machine.add_exit_point(code.address + code.get_capacity())
 # set the instruction pointer to the entrypoint of our executable
 cpu.rip.set(code.address)
 
+analyses: typing.List[
+    typing.Union[smallworld.analyses.Analysis, smallworld.analyses.Filter]
+] = [smallworld.analyses.Colorizer(), smallworld.analyses.ColorizerSummary()]
 
 machine.add(cpu)
 
 # analyze
-smallworld.analyze(machine)
+smallworld.analyze(machine, analyses)

--- a/smallworld/analyses/__init__.py
+++ b/smallworld/analyses/__init__.py
@@ -2,10 +2,13 @@ from .analysis import *  # noqa: F401, F403
 from .analysis import __all__ as __analysis__
 from .colorizer import Colorizer
 from .colorizer_summary import ColorizerSummary
+from .field_detection import FieldDetectionAnalysis, ForcedFieldDetectionAnalysis
+from .forced_exec import ForcedExecution
 
-# from .code_coverage import CodeCoverage
-# from .unstable import *  # noqa: F401, F403
-# from .unstable import __all__ as __unstable__
-
-# __all__ = __analysis__ + __unstable__ + ["CodeCoverage"]
-__all__ = __analysis__ + ["Colorizer", "ColorizerSummary"]
+__all__ = __analysis__ + [
+    "Colorizer",
+    "ColorizerSummary",
+    "FieldDetectionAnalysis",
+    "ForcedFieldDetectionAnalysis",
+    "ForcedExecution",
+]

--- a/tests/struct/structure.py
+++ b/tests/struct/structure.py
@@ -1,6 +1,7 @@
 # let's get all of it
 import ctypes
 import logging
+import typing
 
 import smallworld
 
@@ -90,7 +91,11 @@ cpu.rdi.set_label("arg1")
 print(f"RDI: {hex(cpu.rdi.get())}")
 # all the allocated things get put in memory as concrete bytes
 
-smallworld.helpers.analyze(machine)
+analyses: typing.List[
+    typing.Union[smallworld.analyses.Analysis, smallworld.analyses.Filter]
+] = [smallworld.analyses.Colorizer(), smallworld.analyses.ColorizerSummary()]
+
+smallworld.helpers.analyze(machine, analyses)
 
 # now we can do a single micro-execution without error
 # final_state = smallworld.emulate(code, cpu)


### PR DESCRIPTION
Previously, we had helpers.analyze() run on all exported analysis modules.
This wasn't really useful, since you usually wanted to run a specific module or set of modules.
It also forced us to hide analyses that couldn't be run without specific configuration.

The new version takes a specific list of Analysis and Filter classes.