### PR TITLE
fix: Updated protobuf version

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -131,7 +131,7 @@ ply==3.11
     # via cppheaderparser
 pre-commit==3.5.0
     # via smallworld (setup.py)
-protobuf==5.28.2
+protobuf==6.30.2
     # via angr
 psutil==5.9.6
     # via angr


### PR DESCRIPTION
Not sure why we're locked to the minimum version supported by angr. Fixed by manually editing constraints.txt;
may have to test again if you regenerate it.