### PR TITLE
feat: Added mips64el bios file to dependencies

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -35,3 +35,5 @@ RUN python3 -c "import pandare"
 
 # Fix bug in Panda; it needs this file for mips64 to work
 RUN touch /usr/local/share/panda/mips_bios.bin
+# ...and it needs this file for mips64el to work
+RUN touch /usr/local/share/panda/mipsel_bios.bin


### PR DESCRIPTION
Panda does support mips64el, but it needs a separate little-endian BIOS file.
Like mips64, this file is not present in the standard Panda distribution;
our dockerfile now adds it.