### PR TITLE
fix: Added an explicit defined flag to ELF symbols

### DIFF
--- a/smallworld/state/memory/elf/structs.py
+++ b/smallworld/state/memory/elf/structs.py
@@ -31,6 +31,7 @@ class ElfSymbol:
     bind: int  # Symbol binding
     visibility: int  # Symbol visibility
     shndx: int  # Symbol section index, or reserved flags
+    defined: bool  # Is this symbol defined?
     value: int  # Symbol value
     size: int  # Symbol size
     baseaddr: int  # Base address for relative symbol values


### PR DESCRIPTION
This makes it easier to track the behavior of linking symbols.
The ELF spec tracks "definedness" in an inflexible way, so it's easier to have a logical flag separate from the main data.