### PR TITLE
fix: Fixed a few un-pickleable types

### DIFF
--- a/smallworld/state/state.py
+++ b/smallworld/state/state.py
@@ -197,6 +197,14 @@ class Value(metaclass=abc.ABCMeta):
         else:
             return None
 
+    def __getstate__(self):
+        # Override default pickling operation
+        # The '_type' field is a ctypes class which won't be pickleable.
+        # TODO: figure out how to pickle ctypes classes
+        state = self.__dict__.copy()
+        state["_type"] = None
+        return state
+
     @abc.abstractmethod
     def to_bytes(self, byteorder: platforms.Byteorder) -> bytes:
         """Convert this value into a byte string.
@@ -230,6 +238,7 @@ class Value(metaclass=abc.ABCMeta):
             def __getstate__(self):
                 state = self.__dict__.copy()
                 del state["_content"]
+                del state["_type"]
                 return state
 
             # def __setstate__(self, state):

--- a/smallworld/utils.py
+++ b/smallworld/utils.py
@@ -541,12 +541,17 @@ class RBTree(Iterable):
         return iter(self.values())
 
 
+def _range_collection_key(x):
+    # Used to be a lambda, but can't pickle lambdas
+    return x[0]
+
+
 class RangeCollection(Iterable):
     """A collection of non-overlapping ranges"""
 
     def __init__(self):
         # Back with an RBTree keyed off the start of the range
-        self._ranges = RBTree(key=lambda x: x[0])
+        self._ranges = RBTree(key=_range_collection_key)
 
     def is_empty(self) -> bool:
         """Check if this collection is empty


### PR DESCRIPTION
For some reason, copy.deepcopy() worked, but pickle.dump() didn't.

Values with datatypes were not pickleable,
since ctypes classes are not pickleable.

Local lambdas aren't pickleable.  RangeCollection contained a lambda,
which is now broken out into a real function.