### PR TITLE
Added test dependencies for core file loading tests

### DIFF
--- a/tests/dependencies/apt.txt
+++ b/tests/dependencies/apt.txt
@@ -24,3 +24,5 @@ gcc-powerpc-linux-gnu
 gcc-powerpc64-linux-gnu
 gcc-riscv64-linux-gnu
 gcc-sparc64-linux-gnu
+qemu-user
+gdb-multiarch


### PR DESCRIPTION
Need gdb-multiarch and qemu-user in the testdeps container