### PR TITLE
fix: mixed arm/thumb for step instruction

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -245,6 +245,7 @@ jobs:
           - testsuite: SyscallTests
           - testsuite: SysVModelTests
           - testsuite: TraceExecutionTests
+          - testsuite: ThumbTests
           - testsuite: CheckedDoubleFreeTests
           - testsuite: CheckedReadTests
           - testsuite: CheckedUAFTests

--- a/smallworld/emulators/emulator.py
+++ b/smallworld/emulators/emulator.py
@@ -453,6 +453,30 @@ class Emulator(utils.MetadataMixin, metaclass=abc.ABCMeta):
 
         pass
 
+    def get_thumb(self) -> bool:
+        """For applicable platforms, checks if the CPU is in ARM or Thumb mode.
+
+        Returns:
+            True if in Thumb mode, otherwise False.
+
+        Raises:
+            ConfigurationError: if not using an ARM32 platform.
+            NotImplementedError: if not using a supported emulator.
+        """
+        raise NotImplementedError("get_thumb() is not supported for this emulator")
+
+    def set_thumb(self, enabled=True) -> None:
+        """For applicable platforms, set the CPU to Thumb or ARM mode.
+
+        Arguments:
+            enabled: True for Thumb mode, False for ARM mode.
+
+        Raises:
+            ConfigurationError: if not using an ARM32 platform.
+            NotImplementedError: if not using a supported emulator.
+        """
+        raise NotImplementedError("set_thumb() is not supported for this emulator")
+
     @abc.abstractmethod
     def __repr__(self) -> str:
         return ""

--- a/smallworld/emulators/unicorn/unicorn.py
+++ b/smallworld/emulators/unicorn/unicorn.py
@@ -563,7 +563,7 @@ class UnicornEmulator(
         # We use CPSR to determine if unicorn was previously in thumb
         # mode and set the low bit to 1 to maintain it. We also set
         # the mode of the disassembler.
-        if self._arm32_thumb_override or self.get_thumb():
+        if self.get_thumb():
             pc |= 1
             self.disassembler.mode = capstone.CS_MODE_THUMB
         else:

--- a/smallworld/emulators/unicorn/unicorn.py
+++ b/smallworld/emulators/unicorn/unicorn.py
@@ -527,6 +527,21 @@ class UnicornEmulator(
         if pc == exit_point:
             raise exceptions.EmulationBounds
 
+        # handle Thumb ISA exchange for ARM32
+        if self.platform.architecture in [
+            platforms.Architecture.ARM_V5T,
+            platforms.Architecture.ARM_V6M,
+            platforms.Architecture.ARM_V7A,
+            platforms.Architecture.ARM_V7M,
+            platforms.Architecture.ARM_V7R,
+        ]:
+            cpsr = self.engine.reg_read(unicorn.arm_const.UC_ARM_REG_CPSR)
+            if cpsr & 0x20:
+                pc |= 1
+                self.disassembler.mode = capstone.CS_MODE_THUMB
+            else:
+                self.disassembler.mode = capstone.CS_MODE_ARM
+
         if pc not in self.function_hooks:
             disas = self.current_instruction()
             logger.debug(f"single step at 0x{pc:x}: {disas}")

--- a/smallworld/emulators/unicorn/unicorn.py
+++ b/smallworld/emulators/unicorn/unicorn.py
@@ -518,6 +518,33 @@ class UnicornEmulator(
                 "at least one exit point must be set, emulation cannot start"
             )
 
+    # handle Thumb ISA exchange for ARM32
+    def _handle_thumb_interwork(self, pc) -> int:
+        if self.platform.architecture not in [
+            platforms.Architecture.ARM_V5T,
+            platforms.Architecture.ARM_V6M,
+            platforms.Architecture.ARM_V7A,
+            platforms.Architecture.ARM_V7M,
+            platforms.Architecture.ARM_V7R,
+        ]:
+            return pc
+
+        CPSR_THUMB_MODE_MASK = 0x20
+
+        # reg_read(pc) does not set the low bit for thumb mode, and
+        # reg_write(pc) (which is implicitly called by emu_start) clears
+        # thumb mode if the low bit is not set, so we have to set the
+        # low bit to stay in thumb mode if we were previously in thumb
+        # mode.
+        cpsr = self.engine.reg_read(unicorn.arm_const.UC_ARM_REG_CPSR)
+        if cpsr & CPSR_THUMB_MODE_MASK:
+            pc |= 1
+            self.disassembler.mode = capstone.CS_MODE_THUMB
+        else:
+            self.disassembler.mode = capstone.CS_MODE_ARM
+
+        return pc
+
     def step_instruction(self) -> None:
         self._check()
         self.state = EmulatorState.START_STEP
@@ -527,20 +554,7 @@ class UnicornEmulator(
         if pc == exit_point:
             raise exceptions.EmulationBounds
 
-        # handle Thumb ISA exchange for ARM32
-        if self.platform.architecture in [
-            platforms.Architecture.ARM_V5T,
-            platforms.Architecture.ARM_V6M,
-            platforms.Architecture.ARM_V7A,
-            platforms.Architecture.ARM_V7M,
-            platforms.Architecture.ARM_V7R,
-        ]:
-            cpsr = self.engine.reg_read(unicorn.arm_const.UC_ARM_REG_CPSR)
-            if cpsr & 0x20:
-                pc |= 1
-                self.disassembler.mode = capstone.CS_MODE_THUMB
-            else:
-                self.disassembler.mode = capstone.CS_MODE_ARM
+        pc = self._handle_thumb_interwork(pc)
 
         if pc not in self.function_hooks:
             disas = self.current_instruction()
@@ -570,8 +584,10 @@ class UnicornEmulator(
         logger.info(f"step block at 0x{pc:x}: {disas}")
         try:
             self.state = EmulatorState.START_BLOCK
+            pc = self._handle_thumb_interwork(pc)
             self.engine.emu_start(pc, exit_point)
             pc = self.read_register("pc")
+            pc = self._handle_thumb_interwork(pc)
 
             self.state = EmulatorState.BLOCK
             self.engine.emu_start(pc, exit_point)
@@ -590,7 +606,9 @@ class UnicornEmulator(
         try:
             # unicorn requires one exit point so just use first
             exit_point = list(self._exit_points)[0]
-            self.engine.emu_start(self.read_register("pc"), exit_point)
+            pc = self.read_register("pc")
+            pc = self._handle_thumb_interwork(pc)
+            self.engine.emu_start(pc, exit_point)
         except exceptions.EmulationStop:
             pass
         except unicorn.UcError as e:
@@ -619,6 +637,8 @@ class UnicornEmulator(
         try:
             # NB: can't use self.read_memory here since if it has an exception it will call _error, itself.
             code = bytes(self.engine.mem_read(pc, 16))
+            # on arm32, update disassembler for ARM vs Thumb
+            _ = self._handle_thumb_interwork(pc)
             insns, _ = self._disassemble(code, pc, 1)
             i = instructions.Instruction.from_capstone(insns[0])
         except:

--- a/smallworld/state/state.py
+++ b/smallworld/state/state.py
@@ -769,22 +769,6 @@ class Machine(StatefulSet):
             for expr in self._constraints:
                 emulator.add_constraint(expr)
 
-        # set thumb mode flag
-        if isinstance(emulator, emulators.UnicornEmulator):
-            for cpu in self.get_cpus():
-                if (
-                    hasattr(cpu, "cpsr")
-                    and cpu.cpsr.get() is not None
-                    and cpu.cpsr.get() & 0x20
-                ):
-                    emulator.set_thumb()
-                if (
-                    hasattr(cpu, "psr")
-                    and cpu.psr.get() is not None
-                    and cpu.psr.get() & 0x20
-                ):
-                    emulator.set_thumb()
-
         return super().apply(emulator)
 
     def extract(self, emulator: emulators.Emulator) -> None:

--- a/smallworld/state/state.py
+++ b/smallworld/state/state.py
@@ -769,6 +769,22 @@ class Machine(StatefulSet):
             for expr in self._constraints:
                 emulator.add_constraint(expr)
 
+        # set thumb mode flag
+        if isinstance(emulator, emulators.UnicornEmulator):
+            for cpu in self.get_cpus():
+                if (
+                    hasattr(cpu, "cpsr")
+                    and cpu.cpsr.get() is not None
+                    and cpu.cpsr.get() & 0x20
+                ):
+                    emulator.set_thumb()
+                if (
+                    hasattr(cpu, "psr")
+                    and cpu.psr.get() is not None
+                    and cpu.psr.get() & 0x20
+                ):
+                    emulator.set_thumb()
+
         return super().apply(emulator)
 
     def extract(self, emulator: emulators.Emulator) -> None:

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -3161,6 +3161,8 @@ class ThumbTests(ScriptIntegrationTest):
             self.assertLineContainsStrings(stdout, f"RUN_{arch.name}=0x6")
             # check program result for run starting in Thumb mode
             self.assertLineContainsStrings(stdout, f"RUN_{arch.name}=0x4")
+            # check ISA persistance between emulators
+            self.assertLineContainsStrings(stdout, f"PERSIST_THUMB_{arch.name}=0x4")
             # check program mode pre-execution, starting in Thumb
             self.assertLineContainsStrings(stdout, f"GET_THUMB_PRE1_{arch.name}=True")
             # check program mode post-execution, ending in ARM

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -3161,6 +3161,14 @@ class ThumbTests(ScriptIntegrationTest):
             self.assertLineContainsStrings(stdout, f"RUN_{arch.name}=0x6")
             # check program result for run starting in Thumb mode
             self.assertLineContainsStrings(stdout, f"RUN_{arch.name}=0x4")
+            # check program mode pre-execution, starting in Thumb
+            self.assertLineContainsStrings(stdout, f"GET_THUMB_PRE1_{arch.name}=True")
+            # check program mode post-execution, ending in ARM
+            self.assertLineContainsStrings(stdout, f"GET_THUMB_POST1_{arch.name}=False")
+            # check program mode pre-execution, starting in ARM
+            self.assertLineContainsStrings(stdout, f"GET_THUMB_PRE2_{arch.name}=False")
+            # check program mode post-execution, ending in Thumb
+            self.assertLineContainsStrings(stdout, f"GET_THUMB_POST2_{arch.name}=True")
 
     def test_thumb_armhf(self):
         archs = [

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -3114,6 +3114,19 @@ class RTOSDemoTests(ScriptIntegrationTest):
         self.assertLineContainsStrings(stdout, "Reached stop_udp: True")
 
 
+class ThumbTests(ScriptIntegrationTest):
+    def test_thumb_armhf(self):
+        stdout, _ = self.command("python3 thumb/thumb.armhf.py")
+        self.assertLineContainsStrings(stdout, "ARM_V7A=0x6")
+        self.assertLineContainsStrings(stdout, "ARM_V7M=0x6")
+        self.assertLineContainsStrings(stdout, "ARM_V7R=0x6")
+
+    def test_thumb_armel(self):
+        stdout, _ = self.command("python3 thumb/thumb.armel.py")
+        self.assertLineContainsStrings(stdout, "ARM_V5T=0x6")
+        self.assertLineContainsStrings(stdout, "ARM_V6M=0x6")
+
+
 class CheckedDoubleFreeTests(ScriptIntegrationTest):
     def run_test(self, kind):
         self.command(f"python3 checked_heap/double_free/double_free.{kind}.py")

--- a/tests/thumb/thumb.armel.py
+++ b/tests/thumb/thumb.armel.py
@@ -39,12 +39,12 @@ for arch in [
 
     cpu.r0.extract(emulator)
     print(f"{arch.name}={hex(cpu.r0.get())}")
-    assert(cpu.r0.get() == 6)
+    assert cpu.r0.get() == 6
 
     # test beginning execution in thumb code
-    cpu.pc.set(code.address + 0x11) # beginning of thumb code
+    cpu.pc.set(code.address + 0x11)  # beginning of thumb code
     cpu.r0.set(0)
     machine = machine.emulate(emulator)
     cpu.r0.extract(emulator)
     print(f"{arch.name}={hex(cpu.r0.get())}")
-    assert(cpu.r0.get() == 4)
+    assert cpu.r0.get() == 4

--- a/tests/thumb/thumb.armel.py
+++ b/tests/thumb/thumb.armel.py
@@ -1,0 +1,41 @@
+import logging
+
+import smallworld
+from smallworld.state.cpus.arm import ARM
+
+# setup logging and hinting
+smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.hinting.setup_hinting(level=logging.DEBUG)
+
+for arch in [
+    smallworld.platforms.Architecture.ARM_V5T,
+    smallworld.platforms.Architecture.ARM_V6M,
+]:
+    platform = smallworld.platforms.Platform(
+        arch, smallworld.platforms.Byteorder.LITTLE
+    )
+
+    machine = smallworld.state.Machine()
+
+    # create a CPU and add it to the machine
+    cpu: ARM = smallworld.state.cpus.CPU.for_platform(platform)
+
+    # create an executable and add it to the machine
+    code = smallworld.state.memory.code.Executable.from_filepath(
+        "thumb/thumb.armel.bin", address=0x1000
+    )
+    machine.add(code)
+
+    machine.add_exit_point(code.address + code.get_capacity())
+    # set the instruction pointer to the entrypoint of our executable
+    cpu.pc.set(code.address)
+
+    machine.add(cpu)
+
+    emulator = smallworld.emulators.UnicornEmulator(platform)
+
+    for step in machine.step(emulator):
+        pass
+
+    cpu.r0.extract(emulator)
+    print(f"{arch.name}={hex(cpu.r0.get())}")

--- a/tests/thumb/thumb.armel.py
+++ b/tests/thumb/thumb.armel.py
@@ -39,3 +39,12 @@ for arch in [
 
     cpu.r0.extract(emulator)
     print(f"{arch.name}={hex(cpu.r0.get())}")
+    assert(cpu.r0.get() == 6)
+
+    # test beginning execution in thumb code
+    cpu.pc.set(code.address + 0x11) # beginning of thumb code
+    cpu.r0.set(0)
+    machine = machine.emulate(emulator)
+    cpu.r0.extract(emulator)
+    print(f"{arch.name}={hex(cpu.r0.get())}")
+    assert(cpu.r0.get() == 4)

--- a/tests/thumb/thumb.armel.py
+++ b/tests/thumb/thumb.armel.py
@@ -5,7 +5,7 @@ from smallworld.state.cpus.arm import ARM
 from smallworld.state.state import Register
 
 # setup logging and hinting
-smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.logging.setup_logging(level=logging.DEBUG)
 
 THUMB_BLOCK_OFFSET = 0x10
 

--- a/tests/thumb/thumb.armel.py
+++ b/tests/thumb/thumb.armel.py
@@ -5,7 +5,6 @@ from smallworld.state.cpus.arm import ARM
 
 # setup logging and hinting
 smallworld.logging.setup_logging(level=logging.INFO)
-smallworld.hinting.setup_hinting(level=logging.DEBUG)
 
 THUMB_BLOCK_OFFSET = 0x10
 
@@ -77,6 +76,18 @@ for arch in [
     machine.emulate(emulator)
     cpu.r0.extract(emulator)
     print(f"RUN_{arch.name}={hex(cpu.r0.get())}")
+
+    # test ISA persistance across emulator instances
+    emulator2 = smallworld.emulators.UnicornEmulator(platform)
+    cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
+    emulator.set_thumb()
+    cpu.r0.set(0)
+    machine.step(emulator)
+    machine.extract(emulator)
+    for step in machine.step(emulator2):
+        pass
+    cpu.r0.extract(emulator2)
+    print(f"PERSIST_THUMB_{arch.name}={hex(cpu.r0.get())}")
 
     # test mode change Thumb->ARM
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)

--- a/tests/thumb/thumb.armel.py
+++ b/tests/thumb/thumb.armel.py
@@ -7,7 +7,7 @@ from smallworld.state.cpus.arm import ARM
 smallworld.logging.setup_logging(level=logging.INFO)
 smallworld.hinting.setup_hinting(level=logging.DEBUG)
 
-THUMB_BLOCK_OFFSET = 0x11
+THUMB_BLOCK_OFFSET = 0x10
 
 for arch in [
     smallworld.platforms.Architecture.ARM_V5T,
@@ -36,6 +36,7 @@ for arch in [
 
     # test step_instruction starting with Thumb
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
+    emulator.set_thumb()
     cpu.r0.set(0)
     for step in machine.step(emulator):
         pass
@@ -54,6 +55,7 @@ for arch in [
 
     # test step_block starting with Thumb
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
+    emulator.set_thumb()
     cpu.r0.set(0)
     machine.apply(emulator)
     emulator.step_block()
@@ -70,7 +72,26 @@ for arch in [
 
     # test run starting with Thumb
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
+    emulator.set_thumb()
     cpu.r0.set(0)
     machine.emulate(emulator)
     cpu.r0.extract(emulator)
     print(f"RUN_{arch.name}={hex(cpu.r0.get())}")
+
+    # test mode change Thumb->ARM
+    cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
+    emulator.set_thumb()
+    print(f"GET_THUMB_PRE1_{arch.name}={emulator.get_thumb()}")
+    cpu.r0.set(0)
+    machine.emulate(emulator)
+    cpu.r0.extract(emulator)
+    print(f"GET_THUMB_POST1_{arch.name}={emulator.get_thumb()}")
+
+    # test mode change ARM->Thumb
+    cpu.pc.set(code.address)
+    print(f"GET_THUMB_PRE2_{arch.name}={emulator.get_thumb()}")
+    machine.add_exit_point(code.address + 0x14)
+    cpu.r0.set(0)
+    machine.emulate(emulator)
+    cpu.r0.extract(emulator)
+    print(f"GET_THUMB_POST2_{arch.name}={emulator.get_thumb()}")

--- a/tests/thumb/thumb.armel.py
+++ b/tests/thumb/thumb.armel.py
@@ -2,11 +2,30 @@ import logging
 
 import smallworld
 from smallworld.state.cpus.arm import ARM
+from smallworld.state.state import Register
 
 # setup logging and hinting
 smallworld.logging.setup_logging(level=logging.INFO)
 
 THUMB_BLOCK_OFFSET = 0x10
+
+
+# write to cpsr before pc to ensure writing pc doesn't clear thumb bit
+def is_cpu_register_order_bad(cpu):
+    index = 0
+    pc_index = None
+    cpsr_index = None
+
+    for r in cpu:
+        index += 1
+        if isinstance(r, Register):
+            if r.name == "pc":
+                pc_index = index
+            if r.name in ["cpsr", "psr"]:
+                cpsr_index = index
+
+    return pc_index > cpsr_index
+
 
 for arch in [
     smallworld.platforms.Architecture.ARM_V5T,
@@ -19,6 +38,9 @@ for arch in [
     emulator = smallworld.emulators.UnicornEmulator(platform)
     machine = smallworld.state.Machine()
     cpu: ARM = smallworld.state.cpus.CPU.for_platform(platform)
+    while not is_cpu_register_order_bad(cpu):
+        # reroll until we get a CPU instance where when we iterate over registers, we get CPSR before PC
+        cpu = smallworld.state.cpus.CPU.for_platform(platform)
     code = smallworld.state.memory.code.Executable.from_filepath(
         "thumb/thumb.armel.bin", address=0x1000
     )
@@ -82,7 +104,7 @@ for arch in [
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
     emulator.set_thumb()
     cpu.r0.set(0)
-    machine.step(emulator)
+    next(machine.step(emulator))
     machine.extract(emulator)
     for step in machine.step(emulator2):
         pass
@@ -95,7 +117,7 @@ for arch in [
     print(f"GET_THUMB_PRE1_{arch.name}={emulator.get_thumb()}")
     cpu.r0.set(0)
     machine.emulate(emulator)
-    cpu.r0.extract(emulator)
+    cpu.extract(emulator)
     print(f"GET_THUMB_POST1_{arch.name}={emulator.get_thumb()}")
 
     # test mode change ARM->Thumb
@@ -104,5 +126,4 @@ for arch in [
     machine.add_exit_point(code.address + 0x14)
     cpu.r0.set(0)
     machine.emulate(emulator)
-    cpu.r0.extract(emulator)
     print(f"GET_THUMB_POST2_{arch.name}={emulator.get_thumb()}")

--- a/tests/thumb/thumb.armel.py
+++ b/tests/thumb/thumb.armel.py
@@ -57,7 +57,7 @@ for arch in [
 
     # test step_instruction starting with Thumb
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
-    emulator.set_thumb()
+    emulator.set_thumb(True)
     cpu.r0.set(0)
     for step in machine.step(emulator):
         pass
@@ -76,7 +76,7 @@ for arch in [
 
     # test step_block starting with Thumb
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
-    emulator.set_thumb()
+    emulator.set_thumb(True)
     cpu.r0.set(0)
     machine.apply(emulator)
     emulator.step_block()
@@ -93,7 +93,7 @@ for arch in [
 
     # test run starting with Thumb
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
-    emulator.set_thumb()
+    emulator.set_thumb(True)
     cpu.r0.set(0)
     machine.emulate(emulator)
     cpu.r0.extract(emulator)
@@ -102,7 +102,7 @@ for arch in [
     # test ISA persistance across emulator instances
     emulator2 = smallworld.emulators.UnicornEmulator(platform)
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
-    emulator.set_thumb()
+    emulator.set_thumb(True)
     cpu.r0.set(0)
     next(machine.step(emulator))
     machine.extract(emulator)
@@ -113,7 +113,7 @@ for arch in [
 
     # test mode change Thumb->ARM
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
-    emulator.set_thumb()
+    emulator.set_thumb(True)
     print(f"GET_THUMB_PRE1_{arch.name}={emulator.get_thumb()}")
     cpu.r0.set(0)
     machine.emulate(emulator)

--- a/tests/thumb/thumb.armel.s
+++ b/tests/thumb/thumb.armel.s
@@ -1,0 +1,20 @@
+    .text
+test:
+    mov r1, #1
+    add r0, r1
+    add r0, #1
+    blx thumb
+
+    .thumb
+thumb:
+    mov r1, #1
+    add r0, r1
+    add r0, #1
+    blx arm
+
+    .arm
+arm:
+    mov r1, #1
+    add r0, r1
+    add r0, #1
+    nop

--- a/tests/thumb/thumb.armhf.py
+++ b/tests/thumb/thumb.armhf.py
@@ -1,0 +1,42 @@
+import logging
+
+import smallworld
+from smallworld.state.cpus.arm import ARM
+
+# setup logging and hinting
+smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.hinting.setup_hinting(level=logging.DEBUG)
+
+for arch in [
+    smallworld.platforms.Architecture.ARM_V7A,
+    smallworld.platforms.Architecture.ARM_V7M,
+    smallworld.platforms.Architecture.ARM_V7R,
+]:
+    platform = smallworld.platforms.Platform(
+        arch, smallworld.platforms.Byteorder.LITTLE
+    )
+
+    machine = smallworld.state.Machine()
+
+    # create a CPU and add it to the machine
+    cpu: ARM = smallworld.state.cpus.CPU.for_platform(platform)
+
+    # create an executable and add it to the machine
+    code = smallworld.state.memory.code.Executable.from_filepath(
+        "thumb/thumb.armhf.bin", address=0x1000
+    )
+    machine.add(code)
+
+    machine.add_exit_point(code.address + code.get_capacity())
+    # set the instruction pointer to the entrypoint of our executable
+    cpu.pc.set(code.address)
+
+    machine.add(cpu)
+
+    emulator = smallworld.emulators.UnicornEmulator(platform)
+
+    for step in machine.step(emulator):
+        pass
+
+    cpu.r0.extract(emulator)
+    print(f"{arch.name}={hex(cpu.r0.get())}")

--- a/tests/thumb/thumb.armhf.py
+++ b/tests/thumb/thumb.armhf.py
@@ -58,7 +58,7 @@ for arch in [
 
     # test step_instruction starting with Thumb
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
-    emulator.set_thumb()
+    emulator.set_thumb(True)
     cpu.r0.set(0)
     for step in machine.step(emulator):
         pass
@@ -77,7 +77,7 @@ for arch in [
 
     # test step_block starting with Thumb
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
-    emulator.set_thumb()
+    emulator.set_thumb(True)
     cpu.r0.set(0)
     machine.apply(emulator)
     emulator.step_block()
@@ -94,7 +94,7 @@ for arch in [
 
     # test run starting with Thumb
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
-    emulator.set_thumb()
+    emulator.set_thumb(True)
     cpu.r0.set(0)
     machine.emulate(emulator)
     cpu.r0.extract(emulator)
@@ -103,7 +103,7 @@ for arch in [
     # test ISA persistance across emulator instances
     emulator2 = smallworld.emulators.UnicornEmulator(platform)
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
-    emulator.set_thumb()
+    emulator.set_thumb(True)
     cpu.r0.set(0)
     next(machine.step(emulator))
     machine.extract(emulator)
@@ -114,7 +114,7 @@ for arch in [
 
     # test mode change Thumb->ARM
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
-    emulator.set_thumb()
+    emulator.set_thumb(True)
     print(f"GET_THUMB_PRE1_{arch.name}={emulator.get_thumb()}")
     cpu.r0.set(0)
     machine.emulate(emulator)

--- a/tests/thumb/thumb.armhf.py
+++ b/tests/thumb/thumb.armhf.py
@@ -40,12 +40,12 @@ for arch in [
 
     cpu.r0.extract(emulator)
     print(f"{arch.name}={hex(cpu.r0.get())}")
-    assert(cpu.r0.get() == 6)
+    assert cpu.r0.get() == 6
 
     # test beginning execution in thumb code
-    cpu.pc.set(code.address + 0x11) # beginning of thumb code
+    cpu.pc.set(code.address + 0x11)  # beginning of thumb code
     cpu.r0.set(0)
     machine = machine.emulate(emulator)
     cpu.r0.extract(emulator)
     print(f"{arch.name}={hex(cpu.r0.get())}")
-    assert(cpu.r0.get() == 4)
+    assert cpu.r0.get() == 4

--- a/tests/thumb/thumb.armhf.py
+++ b/tests/thumb/thumb.armhf.py
@@ -40,3 +40,12 @@ for arch in [
 
     cpu.r0.extract(emulator)
     print(f"{arch.name}={hex(cpu.r0.get())}")
+    assert(cpu.r0.get() == 6)
+
+    # test beginning execution in thumb code
+    cpu.pc.set(code.address + 0x11) # beginning of thumb code
+    cpu.r0.set(0)
+    machine = machine.emulate(emulator)
+    cpu.r0.extract(emulator)
+    print(f"{arch.name}={hex(cpu.r0.get())}")
+    assert(cpu.r0.get() == 4)

--- a/tests/thumb/thumb.armhf.py
+++ b/tests/thumb/thumb.armhf.py
@@ -7,7 +7,7 @@ from smallworld.state.cpus.arm import ARM
 smallworld.logging.setup_logging(level=logging.INFO)
 smallworld.hinting.setup_hinting(level=logging.DEBUG)
 
-THUMB_BLOCK_OFFSET = 0x11
+THUMB_BLOCK_OFFSET = 0x10
 
 for arch in [
     smallworld.platforms.Architecture.ARM_V7A,
@@ -37,6 +37,7 @@ for arch in [
 
     # test step_instruction starting with Thumb
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
+    emulator.set_thumb()
     cpu.r0.set(0)
     for step in machine.step(emulator):
         pass
@@ -55,6 +56,7 @@ for arch in [
 
     # test step_block starting with Thumb
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
+    emulator.set_thumb()
     cpu.r0.set(0)
     machine.apply(emulator)
     emulator.step_block()
@@ -71,7 +73,26 @@ for arch in [
 
     # test run starting with Thumb
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
+    emulator.set_thumb()
     cpu.r0.set(0)
     machine.emulate(emulator)
     cpu.r0.extract(emulator)
     print(f"RUN_{arch.name}={hex(cpu.r0.get())}")
+
+    # test mode change Thumb->ARM
+    cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
+    emulator.set_thumb()
+    print(f"GET_THUMB_PRE1_{arch.name}={emulator.get_thumb()}")
+    cpu.r0.set(0)
+    machine.emulate(emulator)
+    cpu.r0.extract(emulator)
+    print(f"GET_THUMB_POST1_{arch.name}={emulator.get_thumb()}")
+
+    # test mode change ARM->Thumb
+    cpu.pc.set(code.address)
+    print(f"GET_THUMB_PRE2_{arch.name}={emulator.get_thumb()}")
+    machine.add_exit_point(code.address + 0x14)
+    cpu.r0.set(0)
+    machine.emulate(emulator)
+    cpu.r0.extract(emulator)
+    print(f"GET_THUMB_POST2_{arch.name}={emulator.get_thumb()}")

--- a/tests/thumb/thumb.armhf.py
+++ b/tests/thumb/thumb.armhf.py
@@ -5,7 +5,7 @@ from smallworld.state.cpus.arm import ARM
 from smallworld.state.state import Register
 
 # setup logging and hinting
-smallworld.logging.setup_logging(level=logging.INFO)
+smallworld.logging.setup_logging(level=logging.DEBUG)
 
 THUMB_BLOCK_OFFSET = 0x10
 

--- a/tests/thumb/thumb.armhf.py
+++ b/tests/thumb/thumb.armhf.py
@@ -5,7 +5,6 @@ from smallworld.state.cpus.arm import ARM
 
 # setup logging and hinting
 smallworld.logging.setup_logging(level=logging.INFO)
-smallworld.hinting.setup_hinting(level=logging.DEBUG)
 
 THUMB_BLOCK_OFFSET = 0x10
 
@@ -78,6 +77,18 @@ for arch in [
     machine.emulate(emulator)
     cpu.r0.extract(emulator)
     print(f"RUN_{arch.name}={hex(cpu.r0.get())}")
+
+    # test ISA persistance across emulator instances
+    emulator2 = smallworld.emulators.UnicornEmulator(platform)
+    cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
+    emulator.set_thumb()
+    cpu.r0.set(0)
+    machine.step(emulator)
+    machine.extract(emulator)
+    for step in machine.step(emulator2):
+        pass
+    cpu.r0.extract(emulator2)
+    print(f"PERSIST_THUMB_{arch.name}={hex(cpu.r0.get())}")
 
     # test mode change Thumb->ARM
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)

--- a/tests/thumb/thumb.armhf.py
+++ b/tests/thumb/thumb.armhf.py
@@ -2,11 +2,30 @@ import logging
 
 import smallworld
 from smallworld.state.cpus.arm import ARM
+from smallworld.state.state import Register
 
 # setup logging and hinting
 smallworld.logging.setup_logging(level=logging.INFO)
 
 THUMB_BLOCK_OFFSET = 0x10
+
+
+# write to cpsr before pc to ensure writing pc doesn't clear thumb bit
+def is_cpu_register_order_bad(cpu):
+    index = 0
+    pc_index = None
+    cpsr_index = None
+
+    for r in cpu:
+        index += 1
+        if isinstance(r, Register):
+            if r.name == "pc":
+                pc_index = index
+            if r.name in ["cpsr", "psr"]:
+                cpsr_index = index
+
+    return pc_index > cpsr_index
+
 
 for arch in [
     smallworld.platforms.Architecture.ARM_V7A,
@@ -20,8 +39,11 @@ for arch in [
     emulator = smallworld.emulators.UnicornEmulator(platform)
     machine = smallworld.state.Machine()
     cpu: ARM = smallworld.state.cpus.CPU.for_platform(platform)
+    while not is_cpu_register_order_bad(cpu):
+        # reroll until we get a CPU instance where when we iterate over registers, we get CPSR before PC
+        cpu = smallworld.state.cpus.CPU.for_platform(platform)
     code = smallworld.state.memory.code.Executable.from_filepath(
-        "thumb/thumb.armel.bin", address=0x1000
+        "thumb/thumb.armhf.bin", address=0x1000
     )
     machine.add(cpu)
     machine.add(code)
@@ -83,7 +105,7 @@ for arch in [
     cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
     emulator.set_thumb()
     cpu.r0.set(0)
-    machine.step(emulator)
+    next(machine.step(emulator))
     machine.extract(emulator)
     for step in machine.step(emulator2):
         pass
@@ -96,7 +118,7 @@ for arch in [
     print(f"GET_THUMB_PRE1_{arch.name}={emulator.get_thumb()}")
     cpu.r0.set(0)
     machine.emulate(emulator)
-    cpu.r0.extract(emulator)
+    cpu.extract(emulator)
     print(f"GET_THUMB_POST1_{arch.name}={emulator.get_thumb()}")
 
     # test mode change ARM->Thumb
@@ -105,5 +127,4 @@ for arch in [
     machine.add_exit_point(code.address + 0x14)
     cpu.r0.set(0)
     machine.emulate(emulator)
-    cpu.r0.extract(emulator)
     print(f"GET_THUMB_POST2_{arch.name}={emulator.get_thumb()}")

--- a/tests/thumb/thumb.armhf.py
+++ b/tests/thumb/thumb.armhf.py
@@ -7,45 +7,71 @@ from smallworld.state.cpus.arm import ARM
 smallworld.logging.setup_logging(level=logging.INFO)
 smallworld.hinting.setup_hinting(level=logging.DEBUG)
 
+THUMB_BLOCK_OFFSET = 0x11
+
 for arch in [
     smallworld.platforms.Architecture.ARM_V7A,
     smallworld.platforms.Architecture.ARM_V7M,
     smallworld.platforms.Architecture.ARM_V7R,
 ]:
+    # harness definition
     platform = smallworld.platforms.Platform(
         arch, smallworld.platforms.Byteorder.LITTLE
     )
-
-    machine = smallworld.state.Machine()
-
-    # create a CPU and add it to the machine
-    cpu: ARM = smallworld.state.cpus.CPU.for_platform(platform)
-
-    # create an executable and add it to the machine
-    code = smallworld.state.memory.code.Executable.from_filepath(
-        "thumb/thumb.armhf.bin", address=0x1000
-    )
-    machine.add(code)
-
-    machine.add_exit_point(code.address + code.get_capacity())
-    # set the instruction pointer to the entrypoint of our executable
-    cpu.pc.set(code.address)
-
-    machine.add(cpu)
-
     emulator = smallworld.emulators.UnicornEmulator(platform)
+    machine = smallworld.state.Machine()
+    cpu: ARM = smallworld.state.cpus.CPU.for_platform(platform)
+    code = smallworld.state.memory.code.Executable.from_filepath(
+        "thumb/thumb.armel.bin", address=0x1000
+    )
+    machine.add(cpu)
+    machine.add(code)
+    machine.add_exit_point(code.address + code.get_capacity())
 
+    # test step_instruction starting with ARM
+    cpu.pc.set(code.address)
     for step in machine.step(emulator):
         pass
-
     cpu.r0.extract(emulator)
-    print(f"{arch.name}={hex(cpu.r0.get())}")
-    assert cpu.r0.get() == 6
+    print(f"STEP_{arch.name}={hex(cpu.r0.get())}")
 
-    # test beginning execution in thumb code
-    cpu.pc.set(code.address + 0x11)  # beginning of thumb code
+    # test step_instruction starting with Thumb
+    cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
     cpu.r0.set(0)
-    machine = machine.emulate(emulator)
+    for step in machine.step(emulator):
+        pass
     cpu.r0.extract(emulator)
-    print(f"{arch.name}={hex(cpu.r0.get())}")
-    assert cpu.r0.get() == 4
+    print(f"STEP_{arch.name}={hex(cpu.r0.get())}")
+
+    # test step_block starting with ARM
+    cpu.pc.set(code.address)
+    cpu.r0.set(0)
+    machine.apply(emulator)
+    emulator.step_block()
+    emulator.step_block()
+    emulator.step_block()
+    cpu.r0.extract(emulator)
+    print(f"BLOCK_{arch.name}={hex(cpu.r0.get())}")
+
+    # test step_block starting with Thumb
+    cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
+    cpu.r0.set(0)
+    machine.apply(emulator)
+    emulator.step_block()
+    emulator.step_block()
+    cpu.r0.extract(emulator)
+    print(f"BLOCK_{arch.name}={hex(cpu.r0.get())}")
+
+    # test run starting with ARM
+    cpu.pc.set(code.address)
+    cpu.r0.set(0)
+    machine.emulate(emulator)
+    cpu.r0.extract(emulator)
+    print(f"RUN_{arch.name}={hex(cpu.r0.get())}")
+
+    # test run starting with Thumb
+    cpu.pc.set(code.address + THUMB_BLOCK_OFFSET)
+    cpu.r0.set(0)
+    machine.emulate(emulator)
+    cpu.r0.extract(emulator)
+    print(f"RUN_{arch.name}={hex(cpu.r0.get())}")

--- a/tests/thumb/thumb.armhf.s
+++ b/tests/thumb/thumb.armhf.s
@@ -1,0 +1,20 @@
+    .text
+test:
+    mov r1, #1
+    add r0, r1
+    add r0, #1
+    blx thumb
+
+    .thumb
+thumb:
+    mov r1, #1
+    add r0, r1
+    add r0, #1
+    blx arm
+
+    .arm
+arm:
+    mov r1, #1
+    add r0, r1
+    add r0, #1
+    nop


### PR DESCRIPTION
Currently, when stepping through an ARM32 binary instruction-by-instruction, Unicorn will misinterpret Thumb code as ARM. This is because the emulator always starts in ARM mode and does not check CPSR. This PR accounts for this by setting the LSB of PC to 1 for Thumb instructions. It also corrects the mode of the disassembler.