### PR TITLE
fix: Fixed bug with platform def on concrete angr emulator

### DIFF
--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -1631,6 +1631,7 @@ class ConcreteAngrEmulator(AngrEmulator):
         self.platform: platforms.Platform = parent.platform
         self.proj: angr.Project = parent.proj
         self.state: angr.SimState = state
+        self.platdef: platforms.PlatformDef = parent.platdef
         self.machdef: AngrMachineDef = parent.machdef
         self.pagesize: int = parent.PAGE_SIZE
 


### PR DESCRIPTION
Forgot to copy the platdef field from the parent to the hook-specific emulators.  Behavior isn't tested in integration.