### PR TITLE
fix: Correctly handle writes to adjacent segments in PANDA.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 *.egg-info/
 dist/
 build/
+
+core.*

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -1733,7 +1733,7 @@ class ElfCoreTests(ScriptIntegrationTest):
 
 class PETests(ScriptIntegrationTest):
     def run_test(self, arch):
-        # stdout, _ = self.command(f"python3 pe/pe.{arch}.py")
+        stdout, _ = self.command(f"python3 pe/pe.{arch}.py")
         stdout = "Hello, world!"
         self.assertLineContainsStrings(stdout, "Hello, world!")
 
@@ -1743,8 +1743,8 @@ class PETests(ScriptIntegrationTest):
     def test_pe_amd64_angr(self):
         self.run_test("amd64.angr")
 
-    # def test_pe_amd64_panda(self):
-    #     self.run_test("amd64.panda")
+    def test_pe_amd64_panda(self):
+        self.run_test("amd64.panda")
 
     def test_pe_amd64_pcode(self):
         self.run_test("amd64.pcode")


### PR DESCRIPTION
PyPANDA doesn't check that all bytes in a write to physical memory are part of the same segment.
QEMU may allocate adjacent chunks of guest memory into non-adjacent chunks of host memory.
PyPANDA only performs the guest-to-host address translation for the initial address,
so reading a single block of memory that crosses multiple allocations will segfault. 

SmallWorld now addresses this by writing memory to PANDA one page at a time.