### PR TITLE
chore: ignore venv directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@
 *.egg-info/
 dist/
 build/
-
+venv/
 core.*


### PR DESCRIPTION
ignoring venv directory to allow folks to create and use a python virtual environment without git complaining