### PR TITLE
build: migrate deprecated setup.py install to pip install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[development] -c constraints.txt
       - name: Build
-        run: python setup.py sdist bdist_wheel
+        env:
+          PIP_CONSTRAINT: constraints.txt
+        run: |
+          python -m pip install --upgrade build
+          python -m build
       - name: Deploy
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,7 +20,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[development] -c constraints.txt
       - name: Build
-        run: python setup.py sdist bdist_wheel
+        env:
+          PIP_CONSTRAINT: constraints.txt
+        run: |
+          python -m pip install --upgrade build
+          python -m build
       - name: Notes
         run: |
           VERSION=${GITHUB_REF/refs\/tags\/v/}

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -53,7 +53,7 @@ RUN make install
 
 # We need to reinstall in our venv
 WORKDIR /opt/afl/AFLplusplus/unicorn_mode/unicornafl/bindings/python
-RUN python3 setup.py install
+RUN python3 -m pip install .
 RUN python3 -c "import unicornafl"
 
 WORKDIR /opt

--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,7 @@ else
   make -j"$(nproc)" binary-only
   sudo make install
   cd unicorn_mode/unicornafl/bindings/python
-  python3 setup.py install
+  python3 -m pip install .
   python3 -c "import unicornafl"
   cd "$CODE_ROOT" && rm -rf afl
 fi


### PR DESCRIPTION
#224 

Replace deprecated `python setup.py install` with guidelines: https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#modernize-setup-py-project

Enforcement begins with PEP 25.3, allegedly in October 2025.