### PR TITLE
fix: added version numbers to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smallworld-re"
-version = "2.0.0"
+version = "2.0.1"
 description = "An emulation stack tracking library"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,13 @@ authors = [
 ]
 
 dependencies = [
-  "angr",
-  "capstone",
-  "jsons",
-  "lief",
+  "angr==9.2.137",
+  "capstone==5.0.3",
+  "jsons==1.6.3",
+  "lief==0.14.1",
   "pyhidra==1.3.0", # pip-compile does not pin pyhidra in constraints.txt for some reason
-  "pypcode",
-  "unicorn",
+  "pypcode==3.0",
+  "unicorn==2.0.1.post1",
 ]
 
 [project.urls]


### PR DESCRIPTION
We were getting a weird version of lief from `pip install smallworld-re`. Hoping this will correct.