### PR TITLE
feat: Can visit symbolic states with Machine

### DIFF
--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -37,6 +37,7 @@ class AngrEmulator(
     emulator.MemoryReadHookable,
     emulator.MemoryWriteHookable,
     emulator.ConstrainedEmulator,
+    emulator.SymbolicEmulator,
 ):
     """
     Angr symbolic execution emulator
@@ -1496,12 +1497,13 @@ class AngrEmulator(
         for s in self.mgr.stashes[stash]:
             function(ConcreteAngrEmulator(s, self))
 
-    def enable_linear(self):
-        """Enable linear execution
+    def get_active_states(self) -> typing.Generator[emulator.Emulator, None, None]:
+        if not self._initialized:
+            raise NotImplementedError("Cannot visit states before initialization")
+        for s in self.mgr.stashes["active"]:
+            yield ConcreteAngrEmulator(s, self)
 
-        This doesn't actually concretize anything;
-        it just kills execution when it hits an unconstrained branch.
-        """
+    def enable_linear(self):
         if self._dirty:
             raise NotImplementedError(
                 "Enabling linear mode not supported once execution begins"

--- a/smallworld/emulators/emulator.py
+++ b/smallworld/emulators/emulator.py
@@ -1048,6 +1048,59 @@ class ConstrainedEmulator:
         raise NotImplementedError("Abstract method")
 
 
+class SymbolicEmulator(metaclass=abc.ABCMeta):
+    """Emulator that supports symbolic path exploration
+
+    By default, symbolic emulators will explore the entire state space
+    by forking separate machine states for every possible branch
+    the program could take.
+    Once execution starts in this default mode,
+    it is no longer possible to access machine state
+    such as registers, memory, hooks, or constraints.
+    Which machine state are you trying to access?
+
+    Programs can use get_active_states()
+    to retrieve a stub Emulator object wrapping each active state.
+    These can be accessed normally, but can't be used to control emulation,
+    and should not be retained once emulation begins again.
+
+    These emulators will also support linear emulation.
+    This constrains the emulator to only explore one path;
+    if the path diverges, emulation halts,
+    and the frontier states can be examined using get_active_states().
+
+    This mode must be set before execution starts, and is not possible to change later.
+
+    """
+
+    @abc.abstractmethod
+    def enable_linear(self):
+        """Set this emulator to only support linear execution.
+
+        Linear execution means that the emulator will halt
+        when it encounters an unconstrained branch.
+        The frontier states will be available via get_active_states()
+        """
+        raise NotImplementedError("Abstract method")
+
+    @abc.abstractmethod
+    def get_active_states(self) -> typing.Generator[Emulator, None, None]:
+        """Access each active machine state currently considered by this emulator.
+
+        NOTE: This is only able to access the currently active states.
+        Some emulators also track dead-ended states,
+        but the interface for accessing them isn't generalizable.
+
+        WARNING: Do not retain the stub objects produced by this generator.
+        They are tied to parts of the internal state of the parent emulator
+        that will be invalidated once emulation resumes.
+
+        Yields:
+            Stub emulator objects wrapping each active machine state
+        """
+        raise NotImplementedError("Abstract method")
+
+
 __all__ = [
     "Emulator",
     "InstructionHookable",
@@ -1056,4 +1109,5 @@ __all__ = [
     "MemoryWriteHookable",
     "InterruptHookable",
     "ConstrainedEmulator",
+    "SymbolicEmulator",
 ]

--- a/smallworld/state/state.py
+++ b/smallworld/state/state.py
@@ -941,6 +941,26 @@ class Machine(StatefulSet):
             persistent_iters=iterations,
         )
 
+    def get_symbolic_states(
+        self, emulator: emulators.SymbolicEmulator
+    ) -> typing.Generator[Machine, None, None]:
+        """Get a Machine for each active state tracked by a symbolic emulator
+
+        Symbolic execution allows an emulator to consider multiple states at once,
+        one for each path the program could possibly take.
+        This function yields a Machine for each such state
+
+        Arguments:
+            emulator: The symbolic emulator to examine
+
+        Yields:
+            One Machine for each active state tracked by the emulator
+        """
+        for emu in emulator.get_active_states():
+            machine = copy.deepcopy(self)
+            machine.extract(emu)
+            yield machine
+
     def get_cpus(self):
         """Gets a list of :class:`~smallworld.state.cpus.cpu.CPU` attached to this machine.
 

--- a/tests/harness/legacy_matrix.py
+++ b/tests/harness/legacy_matrix.py
@@ -5166,6 +5166,13 @@ LEGACY_MATRIX = {
         {"name": "test_hooking_symbolic", "skip_reason": None},
         {"name": "test_square_symbolic", "skip_reason": None},
     ],
+    "SymbolicStateTests": [
+        {
+            "name": "test_amd64_angr",
+            "run_test": {"args": ["amd64.angr"], "kwargs": {}},
+            "skip_reason": None,
+        },
+    ],
     "SysVModelTests": [
         {
             "name": "test_aarch64",

--- a/tests/harness/manifest.py
+++ b/tests/harness/manifest.py
@@ -934,6 +934,15 @@ def _build_symbolic_cases() -> list[CaseSpec]:
     ]
 
 
+def _build_symbolic_state_cases() -> list[CaseSpec]:
+    return _build_legacy_case_command_cases(
+        ("SymbolicStateTests",),
+        case_prefix="symbolic_state",
+        scenario="symbolic_state",
+        tags=("scenario", "symbolic_state"),
+    )
+
+
 def _build_sysv_cases() -> list[CaseSpec]:
     return _build_legacy_script_cases(
         ("SysVModelTests",),
@@ -1508,6 +1517,7 @@ def all_cases() -> list[CaseSpec]:
         _build_exitpoint_cases,
         _build_unmapped_cases,
         _build_symbolic_cases,
+        _build_symbolic_state_cases,
         _build_sysv_cases,
         _build_structure_cases,
         _build_memhook_cases,

--- a/tests/harness/parity.py
+++ b/tests/harness/parity.py
@@ -40,6 +40,7 @@ GENERIC_SUITES = {
     "StaticBufferTests": ("static_buf", "static_buffer"),
     "StaticRelaTests": ("static_rela", None),
     "StrlenTests": ("strlen", "strlen"),
+    "SymbolicStateTests": ("symbolic_state", None),
     "SysVModelTests": ("sysv", None),
     "SyscallTests": ("syscall", None),
     "UnmappedTests": ("unmapped", "unmapped"),

--- a/tests/harness/scenarios/registry.py
+++ b/tests/harness/scenarios/registry.py
@@ -19,6 +19,7 @@ from . import (
     stack,
     static_buf,
     strlen,
+    symbolic_state,
     unmapped,
 )
 
@@ -34,6 +35,7 @@ REGISTERED_SCENARIOS = (
     ("model_return", "model_return", model_return),
     ("exitpoint", "exitpoint", exitpoint),
     ("unmapped", "unmapped", unmapped),
+    ("symbolic_state", "symbolic_state", symbolic_state),
     ("checked_heap.double_free", "checked_heap.double_free", checked_heap),
     ("checked_heap.read", "checked_heap.read", checked_heap),
     ("checked_heap.uaf", "checked_heap.uaf", checked_heap),

--- a/tests/harness/scenarios/symbolic_state.py
+++ b/tests/harness/scenarios/symbolic_state.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
+from .common import (
+    PlatformSpec,
+    load_raw_code,
+    make_emulator,
+    make_platform,
+    set_register,
+    split_variant,
+)
+from .raw_binary import RawBinarySpec
+
+_SPECS = {
+    "amd64": RawBinarySpec(
+        platform=PlatformSpec("X86_64", "LITTLE"),
+        pc_register="rip",
+        result_register="rax",
+        arg_register="rdi",
+        engines=("angr",),
+    )
+}
+
+
+def can_run(scenario: str, variant: str) -> bool:
+    if scenario != "symbolic_state":
+        return False
+    arch, engine = split_variant(variant)
+    return arch in _SPECS and engine in _SPECS[arch].engines
+
+
+def run_case(scenario: str, variant: str, args: Sequence[str]) -> int:
+    import smallworld
+
+    arch, engine = split_variant(variant)
+
+    spec = _SPECS[arch]
+
+    smallworld.logging.setup_logging(level=logging.INFO)
+
+    platform = make_platform(smallworld, spec.platform)
+    machine = smallworld.state.Machine()
+    cpu = smallworld.state.cpus.CPU.for_platform(platform)
+    machine.add(cpu)
+
+    code = load_raw_code(smallworld, "symbolic_state", arch)
+    machine.add(code)
+    set_register(cpu, spec.pc_register, code.address)
+    assert spec.arg_register is not None
+    getattr(cpu, spec.arg_register).set_label("arg1")
+
+    emulator = make_emulator(smallworld, platform, engine)
+    assert isinstance(emulator, smallworld.emulators.SymbolicEmulator)
+    assert isinstance(emulator, smallworld.emulators.Emulator)
+    emulator.enable_linear()
+    emulator.add_exit_point(code.address + code.get_capacity())
+
+    for m in machine.step(emulator):
+        print(m.get_cpu().rip)
+    results = list(machine.get_symbolic_states(emulator))
+
+    for m in results:
+        # Bit of a hack; I know by inspection there should be two constraints,
+        # and that both of them should reference arg1
+        for constraint in m.get_constraints():
+            if "arg1" not in constraint.variables:
+                raise ValueError(
+                    "Unexpected constraint for state at {m.get_cpu().rip}: {constraint}"
+                )
+
+    if len(results) != 2:
+        raise smallworld.exceptions.AnalysisError(
+            f"Expected 2 result states, got {len(results)}"
+        )
+
+    return 0

--- a/tests/symbolic_state/symbolic_state.amd64.s
+++ b/tests/symbolic_state/symbolic_state.amd64.s
@@ -1,0 +1,8 @@
+BITS 64;
+_start:
+        test    rdi, 100
+        jne     .L1
+        nop
+.L1:
+        nop
+        nop


### PR DESCRIPTION
This adds a unified `SymbolicEmulator` interface, currently only supported by angr.
This codifies the "enable linear" behavior,
and exposes a generator function that produces stub emulators for each active state.

This also adds `Machine.get_symbolic_states()` that generates Machines for each symbolic state.