### PR TITLE
fix: Fixed performance bottleneck in write bytes method

### DIFF
--- a/smallworld/state/memory/memory.py
+++ b/smallworld/state/memory/memory.py
@@ -181,7 +181,9 @@ class Memory(state.Stateful, dict[int, state.Value]):
                 # set content
                 if isinstance(segment, state.BytesValue):
                     assert isinstance(segment._content, bytearray)
-                    segment._content[part_start - segment_start:part_end - segment_start] = part
+                    segment._content[
+                        part_start - segment_start : part_end - segment_start
+                    ] = part
                 elif isinstance(segment, state.IntegerValue):
                     contents = segment.to_bytes()
                     prefix = contents[: part_start - segment_start]

--- a/smallworld/state/memory/memory.py
+++ b/smallworld/state/memory/memory.py
@@ -178,15 +178,16 @@ class Memory(state.Stateful, dict[int, state.Value]):
                         f"Tried to write {len(data)} bytes at {hex(address)}. Data at {hex(segment_start)} - {hex(segment_end)} is symbolic."
                     )
 
-                contents = segment.to_bytes()
-                prefix = contents[: part_start - segment_start]
-                suffix = contents[part_end - segment_start :]
-                new_segment_bytes = prefix + part + suffix
-
                 # set content
                 if isinstance(segment, state.BytesValue):
-                    segment.set_content(new_segment_bytes)
+                    assert isinstance(segment._content, bytearray)
+                    segment._content[part_start - segment_start:part_end - segment_start] = part
                 elif isinstance(segment, state.IntegerValue):
+                    contents = segment.to_bytes()
+                    prefix = contents[: part_start - segment_start]
+                    suffix = contents[part_end - segment_start :]
+                    new_segment_bytes = prefix + part + suffix
+
                     as_int = int.from_bytes(new_segment_bytes, segment.byteorder.value)
                     segment.set_content(as_int)
                 else:
@@ -195,6 +196,11 @@ class Memory(state.Stateful, dict[int, state.Value]):
                     if isinstance(segment_content, ctypes.Structure) or isinstance(
                         segment_content, ctypes.Union
                     ):
+                        contents = segment.to_bytes()
+                        prefix = contents[: part_start - segment_start]
+                        suffix = contents[part_end - segment_start :]
+                        new_segment_bytes = prefix + part + suffix
+
                         segment_type = segment_content.__class__
                         as_ctype = segment_type.from_buffer_copy(new_segment_bytes)
                         segment.set_content(as_ctype)

--- a/smallworld/state/state.py
+++ b/smallworld/state/state.py
@@ -369,7 +369,7 @@ class BytesValue(Value):
         self, content: typing.Union[bytes, bytearray], label: typing.Optional[str]
     ) -> None:
         super().__init__()
-        self._content = bytes(content)
+        self._content = bytearray(content)
         self._label = label
         self._size = len(self._content)
         self._type = ctypes.c_ubyte * self._size
@@ -378,9 +378,12 @@ class BytesValue(Value):
         return self._size
 
     def to_bytes(self) -> bytes:
-        if self._content is None or not isinstance(self._content, bytes):
+        if self._content is None or (
+            not isinstance(self._content, bytes) 
+            and not isinstance(self._content, bytearray)
+        ):
             raise ValueError("BytesValue must have a bytes value")
-        return self._content
+        return bytes(self._content)
 
 
 class Register(Value, Stateful):

--- a/smallworld/state/state.py
+++ b/smallworld/state/state.py
@@ -379,7 +379,7 @@ class BytesValue(Value):
 
     def to_bytes(self) -> bytes:
         if self._content is None or (
-            not isinstance(self._content, bytes) 
+            not isinstance(self._content, bytes)
             and not isinstance(self._content, bytearray)
         ):
             raise ValueError("BytesValue must have a bytes value")


### PR DESCRIPTION
Before, we stored BytesObjects contents as `bytes`,
forcing `Memory.write_bytes()` to split and merge, and thus copy, potentially-large byte arrays.
This turns into a serious performance bottleneck in large binaries with >10k relocation entries.