### PR TITLE
fix: Removed bottleneck logging statement

### DIFF
--- a/smallworld/state/memory/elf/elf.py
+++ b/smallworld/state/memory/elf/elf.py
@@ -978,7 +978,6 @@ class ElfExecutable(Executable):
             for sym in syms:
                 for rela in sym.relas:
                     # Relocate!
-                    log.debug(f"Relocating {rela}")
                     self._relocator.relocate(self, rela)
         else:
             log.error(f"No platform defined; cannot relocate {name}!")


### PR DESCRIPTION
The representation of an ELF rela in smallworld includes the symbol, which in turn includes representations of all its associated relas. This doesn't cause infinte recusion, but some very large ELF files can have symbols with huge numbers of associated relas.

The ELF parser included a debug logging statement
that printed every rela.  Since the string gets formatted before the logging level is evaluated,
it always runs, and can cause a serious performance bottleneck.