### PR TITLE
feat: Added more value collection to trace and colorizer

### DIFF
--- a/smallworld/analyses/colorizer_read_write.py
+++ b/smallworld/analyses/colorizer_read_write.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 import typing
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from ..hinting import DynamicMemoryValueHint, DynamicRegisterValueHint
 from ..instructions.bsid import BSIDMemoryReferenceOperand
@@ -42,16 +42,22 @@ class RegisterInfo(Info):
 class MemoryLvalInfo(Info):
     bsid: BSIDMemoryReferenceOperand
     size: int
-    # addresses: typing.List[int]
+    # Concrete (instruction_count, address) pairs, one per dynamic access of
+    # this memory lval observed during tracing (a bsid such as [rax + rcx*4]
+    # accumulates several as it strides an array).  Excluded from eq/hash so it
+    # never affects lval identity or graph dedup; it is metadata accumulated as
+    # hints are processed.  Consumers pick the access they care about by ic.
+    addresses: typing.List[typing.Tuple[int, int]] = field(
+        default_factory=list, compare=False
+    )
 
     def __str__(self: typing.Any):
         return (
             "(MemoryLvalInfo(,"
             + f"bsid={self.bsid},"
             + f"size={self.size},"
-            + f"color={self.color}"
-            # + f"dynvals={[d for d in self.dynvals]},"
-            # + f"addresses={[hex(a) for a in self.addresses]}))"
+            + f"color={self.color},"
+            + f"addresses={[(ic, hex(a)) for ic, a in self.addresses]}))"
         )
 
     def short_str(self):
@@ -229,6 +235,13 @@ class WRGraph:
             wi = WriteInfo(dvk_to_info(dvk))
             node.writes.append(wi)
             return wi
+
+    def record_address(self, dvk: DvKey, ic: int, address: int):
+        """Accumulate one concrete (instruction_count, address) access on the
+        MemoryLvalInfo for `dvk`.  No-op for register dvks (no address)."""
+        rwi = self.get_or_add_rw_from_dvk(dvk)
+        if type(rwi.info) is MemoryLvalInfo:
+            rwi.info.addresses.append((ic, address))
 
     def add_edge(self, firstobs: DvKey, read: DvKey):
         # logger.info(f"add_edge {firstobs} {read}")
@@ -471,6 +484,10 @@ class ColorizerReadWrite(analysis.Analysis):
                     firstobskey = compute_dv_key(hint)
                     firstobskey.color = dvk2num[firstobskey]
                     self.graph.get_or_add_rw_from_dvk(firstobskey)
+                    if type(hint) is DynamicMemoryValueHint:
+                        self.graph.record_address(
+                            firstobskey, hint.instruction_num, hint.address
+                        )
                 else:
                     if hint.use:
                         # A color flow, i.e. a use of a previously
@@ -488,6 +505,10 @@ class ColorizerReadWrite(analysis.Analysis):
                         dst_key = compute_dv_key(hint)
                         dst_key.color = true_color
                         self.graph.add_edge(src_key, dst_key)
+                        if type(hint) is DynamicMemoryValueHint:
+                            self.graph.record_address(
+                                dst_key, hint.instruction_num, hint.address
+                            )
                     else:
                         # hint is a not new def ...
                         # that's just a copy right?

--- a/smallworld/analyses/trace_execution.py
+++ b/smallworld/analyses/trace_execution.py
@@ -22,29 +22,66 @@ class TraceExecutionCBPoint(Enum):
     AFTER_INSTRUCTION = 2
 
 
+def _concrete_cmp_value(
+    operand,
+    emulator: smallworld.emulators.Emulator,
+    byteorder: typing.Literal["little", "big"],
+) -> typing.Optional[int]:
+    """Concrete integer value of a cmp operand, read from the live emulator.
+
+    A register operand yields its current value; a memory operand yields the
+    integer loaded from its effective address (decoded with `byteorder`).
+    Returns None if the value can't be read -- e.g. the memory operand's address
+    is unmapped -- so a bad read degrades to "unknown" rather than aborting the
+    trace.
+    """
+    try:
+        v = operand.concretize(emulator)
+    except Exception:
+        return None
+    if v is None:
+        return None
+    if isinstance(v, (bytes, bytearray)):
+        return int.from_bytes(v, byteorder)
+    return int(v)
+
+
 def get_cmp_info(
     platform: smallworld.platforms.Platform,
     emulator: smallworld.emulators.Emulator,
     cs_insn: capstone.CsInsn,
-) -> typing.Tuple[typing.List[CmpInfo], typing.List[int]]:
+) -> typing.Tuple[
+    typing.List[CmpInfo], typing.List[typing.Optional[int]], typing.List[int]
+]:
     pdefs = platforms.defs.PlatformDef.for_platform(platform)
     if cs_insn.mnemonic in pdefs.compare_mnemonics:
-        # it's a compare -- return list of "reads'
+        # it's a compare -- return list of "reads", the concrete value of each
+        # (read now, while the emulator sits exactly at this compare), and the
+        # immediates.  cmp_values is index-aligned with cmp_info.
         sw_insn = smallworld.instructions.Instruction.from_capstone(cs_insn)
-        cmp_info = []
+        byteorder: typing.Literal["little", "big"] = (
+            "little" if pdefs.byteorder is platforms.Byteorder.LITTLE else "big"
+        )
+        cmp_info: typing.List[CmpInfo] = []
+        cmp_values: typing.List[typing.Optional[int]] = []
         for op in cs_insn.operands:
             if op.type == capstone.CS_OP_MEM and (op.access & capstone.CS_AC_READ):
-                cmp_info.append(sw_insn._memory_reference_operand(op))
+                mem_op = sw_insn._memory_reference_operand(op)
+                cmp_info.append(mem_op)
+                cmp_values.append(_concrete_cmp_value(mem_op, emulator, byteorder))
             if op.type == capstone.CS_OP_REG and (op.access & capstone.CS_AC_READ):
-                cmp_info.append(RegisterOperand(cs_insn.reg_name(op.value.reg)))
+                reg_op = RegisterOperand(cs_insn.reg_name(op.value.reg))
+                cmp_info.append(reg_op)
+                cmp_values.append(_concrete_cmp_value(reg_op, emulator, byteorder))
             if op.type == capstone.CS_OP_IMM:
                 cmp_info.append(op.value.imm)
+                cmp_values.append(op.value.imm)
         immediates = []
         for op in cs_insn.operands:
             if op.type == capstone.x86.X86_OP_IMM:
                 immediates.append(op.value.imm)
-        return (cmp_info, immediates)
-    return ([], [])
+        return (cmp_info, cmp_values, immediates)
+    return ([], [], [])
 
 
 class TraceExecution(analysis.Analysis):
@@ -134,10 +171,19 @@ class TraceExecution(analysis.Analysis):
                     f"no decodable instruction at pc {pc:#x}"
                 )
                 break
-            cmp_info, imm_info = get_cmp_info(self.platform, self.emulator, cs_insn)
+            cmp_info, cmp_values, imm_info = get_cmp_info(
+                self.platform, self.emulator, cs_insn
+            )
             branch_info = cs_insn.mnemonic in pdefs.conditional_branch_mnemonics
             te = TraceElement(
-                pc, i, cs_insn.mnemonic, cs_insn.op_str, cmp_info, branch_info, imm_info
+                pc,
+                i,
+                cs_insn.mnemonic,
+                cs_insn.op_str,
+                cmp_info,
+                branch_info,
+                imm_info,
+                cmp_values,
             )
             trace.append(te)
             # run any callbacks

--- a/smallworld/analyses/trace_execution_types.py
+++ b/smallworld/analyses/trace_execution_types.py
@@ -1,6 +1,6 @@
 import json
 import typing
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 from smallworld.instructions import BSIDMemoryReferenceOperand, RegisterOperand
@@ -25,6 +25,15 @@ class TraceElement:
     cmp: typing.List[CmpInfo]
     branch: bool
     immediates: typing.List[int]
+    # Concrete value of each entry in `cmp`, read from the live emulator at the
+    # moment this compare is about to execute (see get_cmp_info).  Index-aligned
+    # with `cmp`: an immediate maps to itself, a register/memory operand to its
+    # concrete integer value, or None if it could not be read.  Excluded from
+    # eq/repr so it does not affect trace identity, comparison, or logging/golden
+    # output, and so older pickled traces (which lack it) stay compatible.
+    cmp_values: typing.List[typing.Optional[int]] = field(
+        default_factory=list, compare=False, repr=False
+    )
 
     def __str__(self):
         return f"{self.ic} 0x{self.pc:x} [{self.mnemonic} {self.op_str}] {self.cmp} {self.branch} {self.immediates}"


### PR DESCRIPTION
TraceExecution collected various things whilst single-stepping through instructions including some register values. Now it collects also the values read out of memory used in cmps.  And the colorizer which used to collect addresses used in load/store instructions (code was commented out) now does that again.  Both are need by auto-harnessing coverage.py.  Note that there are additional uses for all of these (not yet implemented).  Such as an analysis that looks at the sequence of concrete addresses for a load/store instruction in order to conclude the likelihood that it is an array being accessed.