### PR TITLE
fix: raise on Unicorn emu_start jump to NULL sentinel

### DIFF
--- a/smallworld/emulators/unicorn/unicorn.py
+++ b/smallworld/emulators/unicorn/unicorn.py
@@ -89,6 +89,20 @@ class UnicornEmulator(
         self.memory_map: utils.RangeCollection = utils.RangeCollection()
         self.state: EmulatorState = EmulatorState.SETUP
         self.curr_pc: int = 0
+
+        # Address passed as the `until` argument to unicorn's emu_start().
+        # Unicorn treats this address as a natural stopping point: if execution
+        # ever reaches it, emu_start() returns *cleanly* instead of faulting.
+        # We normally rely on hooks (emu_stop) and errors to end emulation, so
+        # this doubles as a sentinel for "the program jumped somewhere it
+        # shouldn't have" -- see _diagnose_clean_stop().
+        #
+        # It defaults to 0 (NULL) because a jump to NULL is almost always a
+        # bug we want to surface. A harness author should change it if the
+        # target legitimately executes at address 0 (e.g. the NULL page is
+        # mapped) or otherwise expects to jump there, so that a real jump to 0
+        # is not misreported. Pick a value the program can never reach.
+        self.exit_sentinel: int = 0
         # labels are per byte
 
         # We'll have one entry in this dictionary per full-width base
@@ -687,6 +701,51 @@ class UnicornEmulator(
 
         return pc
 
+    def _diagnose_clean_stop(self) -> None:
+        """Diagnose an emu_start() call that returned without raising.
+
+        Call this immediately after any emu_start() that did not raise a
+        unicorn.UcError. There are two ways emu_start() can return cleanly:
+
+        1. One of our hooks stopped it -- every such path sets
+           ``self.state = EmulatorState.EXIT`` before calling emu_stop(). This
+           is a legitimate single-step / block / exit-point boundary; nothing
+           to do.
+
+        2. Unicorn stopped on its own because PC reached ``self.exit_sentinel``
+           (the `until` address). We do not otherwise use `until` to end
+           emulation, so this means the program jumped to the sentinel. For the
+           default sentinel of 0 this is a jump to NULL, which unicorn quietly
+           reports as a clean stop rather than the fetch fault it really is.
+
+        Only case 2 needs handling: re-raise it as the fault (or, if the
+        sentinel happens to be a configured exit point / out of bounds, the
+        corresponding stop) that it should have been.
+        """
+        if self.state == EmulatorState.EXIT:
+            # Case 1: one of our hooks initiated this stop.
+            return
+
+        pc = self.read_register("pc")
+        if pc != self.exit_sentinel:
+            # Stopped cleanly for some other reason (e.g. a user hook called
+            # emu_stop() directly). Not a sentinel hit; leave it alone.
+            return
+
+        # Case 2: execution reached the sentinel address.
+        if pc in self._exit_points:
+            raise exceptions.EmulationExitpoint
+        if not self._bounds.is_empty() and not self._bounds.contains_value(pc):
+            raise exceptions.EmulationBounds
+
+        self.state = EmulatorState.EXIT
+        raise exceptions.EmulationFetchUnmappedFailure(
+            f"emulation reached the exit sentinel at 0x{pc:x} without hitting a "
+            "configured exit point (likely a jump to unmapped memory)",
+            pc,
+            address=pc,
+        )
+
     def step_instruction(self) -> None:
         self._check()
         self.state = EmulatorState.START_STEP
@@ -705,7 +764,8 @@ class UnicornEmulator(
                 logger.debug(f"single step at 0x{disas.address:x}: {disas}")
 
         try:
-            self.engine.emu_start(pc, 0x0)
+            self.engine.emu_start(pc, self.exit_sentinel)
+            self._diagnose_clean_stop()
         except unicorn.UcError as e:
             if (
                 e.errno == unicorn.UC_ERR_FETCH_UNMAPPED
@@ -728,12 +788,14 @@ class UnicornEmulator(
         logger.debug(f"step block at 0x{disas.address:x}: {disas}")
         try:
             self.state = EmulatorState.START_BLOCK
-            self.engine.emu_start(pc, 0x0)
+            self.engine.emu_start(pc, self.exit_sentinel)
+            self._diagnose_clean_stop()
 
             self.state = EmulatorState.BLOCK
             pc = self.read_register("pc")
             pc = self._handle_thumb_interwork(pc)
-            self.engine.emu_start(pc, 0x0)
+            self.engine.emu_start(pc, self.exit_sentinel)
+            self._diagnose_clean_stop()
         except unicorn.UcError as e:
             self._error(e, "exec")
 
@@ -748,7 +810,8 @@ class UnicornEmulator(
         try:
             pc = self.read_register("pc")
             pc = self._handle_thumb_interwork(pc)
-            self.engine.emu_start(pc, 0x0)
+            self.engine.emu_start(pc, self.exit_sentinel)
+            self._diagnose_clean_stop()
         except exceptions.EmulationStop:
             pass
         except unicorn.UcError as e:

--- a/smallworld/instructions/mips.py
+++ b/smallworld/instructions/mips.py
@@ -28,3 +28,30 @@ class MIPSELInstruction(MIPSInstruction):
     platform = platforms.Platform(
         platforms.Architecture.MIPS32, platforms.Byteorder.LITTLE
     )
+
+
+class MIPS64Instruction(MIPSInstruction):
+    angr_arch = "MIPS64"
+    cs_mode = capstone.CS_MODE_MIPS64 | capstone.CS_MODE_BIG_ENDIAN
+    platform = platforms.Platform(
+        platforms.Architecture.MIPS64, platforms.Byteorder.BIG
+    )
+
+    def _memory_reference(self, operand) -> MemoryReferenceOperand:
+        # Capstone does not expose a per-operand access size for MIPS (the width
+        # is encoded in the mnemonic, not the operand), so -- like the MIPS32
+        # class above and aarch64 -- we use a fixed pointer-width default. 8 for
+        # MIPS64.
+        return BSIDMemoryReferenceOperand(
+            segment=None,
+            base=self._instruction.reg_name(operand.value.mem.base),
+            offset=operand.value.mem.disp,
+            size=8,
+        )
+
+
+class MIPS64ELInstruction(MIPS64Instruction):
+    cs_mode = capstone.CS_MODE_MIPS64
+    platform = platforms.Platform(
+        platforms.Architecture.MIPS64, platforms.Byteorder.LITTLE
+    )

--- a/tests/harness/scenarios/null_pc.py
+++ b/tests/harness/scenarios/null_pc.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Sequence
+
+from .common import (
+    PlatformSpec,
+    build_specs,
+    load_raw_code,
+    make_emulator,
+    make_platform,
+    set_register,
+    split_variant,
+)
+from .spec import ScenarioInfo, from_arch_table, just_run
+
+NATIVE_PARITY = False
+
+
+@dataclasses.dataclass(frozen=True)
+class NullPcSpec:
+    # Architectural facts needed to load a raw blob and run it to the point
+    # where it computes a jump to address 0. Populated from ARCH_REGISTERS via
+    # build_specs(); see common.ARCH_REGISTERS for the per-arch values.
+    platform: PlatformSpec
+    pc_register: str
+    engines: tuple[str, ...]
+    stack_pointer_register: str
+    entry_offset: int = 0
+    # A synthetic return address left on the stack. It is deliberately non-zero
+    # so that, for the return-based programs (i386/tricore/xtensa), only the
+    # test's own zeroing of the return target -- not a leftover 0 on the stack
+    # -- can send control to NULL.
+    fake_return: int = 0xFFFFFFFF
+    fake_return_size: int = 8
+    stack_padding_bytes: int = 0
+
+
+# Every architecture whose null_pc.<arch>.bin computes a jump to address 0.
+# msp430 is intentionally excluded (its binary does not do what we want).
+_ARCHS = (
+    "aarch64",
+    "amd64",
+    "armel",
+    "armhf",
+    "i386",
+    "la64",
+    "m68k",
+    "mips",
+    "mipsel",
+    "mips64",
+    "mips64el",
+    "ppc",
+    "ppc64",
+    "riscv64",
+    "tricore",
+    "xtensa",
+)
+
+_SPECS = build_specs(NullPcSpec, _ARCHS)
+
+# ppc64 uses angr/pcode only: unicorn's ppc64 support is buggy (matches the
+# branch/unmapped scenarios). PANDA is a supported engine for several arches
+# but is mid-migration and not yet runnable, so its variants are skipped just
+# as they are in the unmapped scenario.
+_SKIP_REASONS = {
+    "ppc64": "Unicorn ppc64 support buggy",
+    "aarch64.panda": "Waiting for panda-ng",
+    "amd64.panda": "Waiting for panda-ng",
+    "armel.panda": "Waiting for panda-ng",
+    "armhf.panda": "Waiting for panda-ng",
+    "i386.panda": "Waiting for panda-ng",
+    "mips.panda": "Waiting for panda-ng",
+    "mipsel.panda": "Waiting for panda-ng",
+    "mips64.panda": "Waiting for panda-ng",
+    "mips64el.panda": "Waiting for panda-ng",
+    "ppc.panda": "Waiting for panda-ng",
+    "tricore.panda": "Waiting for panda-ng",
+}
+
+
+SCENARIO_PREFIXES = (("null_pc", "null_pc"),)
+
+SCENARIO_INFO = ScenarioInfo(
+    prefix="null_pc",
+    scenario="null_pc",
+    tags=("scenario", "null_pc"),
+    variants_source=from_arch_table(_SPECS, skip_reasons=_SKIP_REASONS),
+    run_factory=just_run(),
+)
+
+
+def can_run(scenario: str, variant: str) -> bool:
+    if scenario != "null_pc":
+        return False
+    if variant in _SKIP_REASONS:
+        return True
+    arch, engine = split_variant(variant)
+    return arch in _SPECS and engine in _SPECS[arch].engines
+
+
+def run_case(scenario: str, variant: str, args: Sequence[str]) -> int:
+    if variant in _SKIP_REASONS:
+        raise SystemExit(_SKIP_REASONS[variant])
+    if args:
+        raise SystemExit(f"{scenario} does not take arguments: {' '.join(args)}")
+
+    import smallworld
+
+    arch, engine = split_variant(variant)
+    spec = _SPECS[arch]
+
+    smallworld.logging.setup_logging(level=logging.INFO)
+
+    platform = make_platform(smallworld, spec.platform)
+    machine = smallworld.state.Machine()
+    cpu = smallworld.state.cpus.CPU.for_platform(platform)
+    machine.add(cpu)
+
+    code = load_raw_code(smallworld, "null_pc", arch)
+    machine.add(code)
+    set_register(cpu, spec.pc_register, code.address + spec.entry_offset)
+
+    stack = smallworld.state.memory.stack.Stack.for_platform(platform, 0x2000, 0x4000)
+    machine.add(stack)
+    if spec.stack_padding_bytes:
+        # PowerPC keeps ABI scratch data above SP; reserve it first if needed.
+        stack.push_bytes(b"\0" * spec.stack_padding_bytes, None)
+    stack.push_integer(spec.fake_return, spec.fake_return_size, "fake return address")
+    set_register(cpu, spec.stack_pointer_register, stack.get_pointer())
+
+    emulator = make_emulator(smallworld, platform, engine)
+    if engine == "angr" and isinstance(emulator, smallworld.emulators.AngrEmulator):
+        emulator.error_on_unmapped = True
+
+    # A non-zero exit point just past the code: it satisfies the emulator's
+    # "need an exit point or bound" check without reserving address 0, so a jump
+    # to NULL is reported as a fetch fault rather than mistaken for a clean exit.
+    emulator.add_exit_point(code.address + code.get_capacity())
+
+    try:
+        machine.emulate(emulator)
+    except smallworld.exceptions.EmulationFetchUnmappedFailure:
+        return 0
+    raise RuntimeError("Did not report jump to NULL (address 0)")

--- a/tests/null_pc/null_pc.aarch64.s
+++ b/tests/null_pc/null_pc.aarch64.s
@@ -1,0 +1,5 @@
+    .text
+test:
+    mov x0, 0
+    br  x0
+    nop

--- a/tests/null_pc/null_pc.amd64.s
+++ b/tests/null_pc/null_pc.amd64.s
@@ -1,0 +1,5 @@
+BITS 64;
+test:
+    xor rax, rax
+    jmp rax
+    nop

--- a/tests/null_pc/null_pc.armel.s
+++ b/tests/null_pc/null_pc.armel.s
@@ -1,0 +1,5 @@
+    .text
+test:
+    mov r0, #0
+    bx  r0
+    nop

--- a/tests/null_pc/null_pc.armhf.s
+++ b/tests/null_pc/null_pc.armhf.s
@@ -1,0 +1,5 @@
+    .text
+test:
+    mov r0, #0
+    bx  r0
+    nop

--- a/tests/null_pc/null_pc.i386.s
+++ b/tests/null_pc/null_pc.i386.s
@@ -1,0 +1,5 @@
+    .text
+test:
+    xor %eax,%eax
+    push %eax
+    ret

--- a/tests/null_pc/null_pc.la64.s
+++ b/tests/null_pc/null_pc.la64.s
@@ -1,0 +1,6 @@
+    .text
+test:
+    li.d    $t1, 0
+    jr      $t1
+    nop
+    nop

--- a/tests/null_pc/null_pc.m68k.s
+++ b/tests/null_pc/null_pc.m68k.s
@@ -1,0 +1,6 @@
+    .text
+test:
+    clr     %d0
+    mova.l  %d0, %a0
+    jmp     (%a0)
+    nop

--- a/tests/null_pc/null_pc.mips.s
+++ b/tests/null_pc/null_pc.mips.s
@@ -1,0 +1,6 @@
+    .text
+test:
+    li  $3,0
+    jr  $3
+    nop
+    nop

--- a/tests/null_pc/null_pc.mips64.s
+++ b/tests/null_pc/null_pc.mips64.s
@@ -1,0 +1,6 @@
+    .text
+test:
+    li  $3,0
+    jr  $3
+    nop
+    nop

--- a/tests/null_pc/null_pc.ppc.s
+++ b/tests/null_pc/null_pc.ppc.s
@@ -1,0 +1,6 @@
+    .text
+test:
+    li 3,0
+    mtctr 3
+    bctr
+    nop

--- a/tests/null_pc/null_pc.ppc64.s
+++ b/tests/null_pc/null_pc.ppc64.s
@@ -1,0 +1,6 @@
+    .text
+test:
+    li 3,0
+    mtctr 3
+    bctr
+    nop

--- a/tests/null_pc/null_pc.riscv64.s
+++ b/tests/null_pc/null_pc.riscv64.s
@@ -1,0 +1,5 @@
+    .text
+test:
+    li  a0,0
+    jr  a0
+    nop

--- a/tests/null_pc/null_pc.tricore.s
+++ b/tests/null_pc/null_pc.tricore.s
@@ -1,0 +1,6 @@
+    .text
+test:
+    mov %d0, 0
+    mov.a %a11, %d0
+    ret
+    nop

--- a/tests/null_pc/null_pc.xtensa.s
+++ b/tests/null_pc/null_pc.xtensa.s
@@ -1,0 +1,5 @@
+    .text
+test:
+    movi $a0, 0
+    ret
+    nop


### PR DESCRIPTION
Unicorn's emu_start(begin, until) treats `until` as a clean stopping point. Every call site passed until=0, so a program that computed a jump to address 0 (a NULL/uninitialized pointer) landed on the sentinel and emu_start returned *cleanly* instead of faulting -- emulation silently "succeeded" on a bug.

Add an `exit_sentinel` attribute (default 0) that a harness author can relocate when address 0 is a legitimate target (e.g. the NULL page is mapped), and a `_diagnose_clean_stop()` helper run after every emu_start: if a hook did not initiate the stop (state != EXIT) and PC sits on the sentinel, re-raise it as the EmulationFetchUnmappedFailure (or EmulationExitpoint / EmulationBounds) it should have been.

Also register MIPS64 capstone instruction formats, which were missing. Their absence made Instruction.from_capstone() raise for every MIPS64 instruction; _error swallowed that in a bare `except`, silently degrading all MIPS64 rich-error operand analysis. This is why a jump to NULL on MIPS64 was misreported as a read (the delay-slot read->fetch reclassification could never run) while MIPS32 was correct.

Add a null_pc test scenario across the supported arch/engine matrix that asserts a computed jump to address 0 is caught as a fetch fault. The assertion is intentionally strict (fetch-unmapped only) so any future exception misclassification fails loudly rather than being absorbed.