### PR TITLE
feat: Added basic default models

### DIFF
--- a/docs/concepts/state/hooks/hooks.rst
+++ b/docs/concepts/state/hooks/hooks.rst
@@ -203,6 +203,34 @@ to capture the behavior of ``puts()``:
     emu.run()  # Prints "Hello, world!" to stdout.
 
 
+Default Function Models
+-----------------------
+
+``ReturnConstant`` is a ready-made ``Model`` that ignores its arguments and
+returns a fixed value, using the correct return register(s) for the given
+platform and ABI.  It's handy for stubbing out a function whose return value
+you want to pin, without writing a bespoke model.
+
+Unlike the named C models, it is *parametric*, so construct it directly rather
+than via ``Model.lookup()``:
+
+.. code-block:: python
+
+    from smallworld.platforms import ABI, Architecture, Byteorder, Platform
+    from smallworld.state.models import ReturnConstant
+    from smallworld.state.models.cstd import ArgumentType
+
+    platform = Platform(Architecture.X86_64, Byteorder.LITTLE)
+
+    # Force the function at 0x2000 to return 0.
+    model = ReturnConstant(0x2000, platform, ABI.SYSTEMV, value=0)
+    machine.add(model)
+
+``value`` defaults to ``0``.  ``return_type`` (default
+``ArgumentType.POINTER``) controls which register(s) are written and how the
+value is encoded; pass ``ArgumentType.VOID`` for a no-op model that consumes
+the call and returns without writing a value.
+
 MMIO Models
 -----------
 

--- a/docs/concepts/state/hooks/hooks.rst
+++ b/docs/concepts/state/hooks/hooks.rst
@@ -336,3 +336,65 @@ to capture reads and writes to a certain location:
 
     # Print the final value of our variable
     print(myint.curr_value)
+
+Default MMIO Models
+-------------------
+
+Three ready-made ``MemoryMappedModel`` subclasses cover common cases so you
+don't have to write ``on_read()``/``on_write()`` by hand.  All handle partial
+and straddling accesses for you.
+
+``NullMemoryMappedModel`` makes a region inert: reads report zeroes and writes
+have no visible effect.  Useful for stubbing out an unmodeled peripheral so a
+driver doesn't fault on it.
+
+.. code-block:: python
+
+    from smallworld.state.models import NullMemoryMappedModel
+
+    machine.add(NullMemoryMappedModel(0x40000000, 0x1000))
+
+``RAMMemoryMappedModel`` makes a region behave like ordinary memory: bytes
+written are stored and read back.  The backing bytes are exposed as ``.data``
+(initially zeroed) so a harness can inspect or seed them.
+
+.. code-block:: python
+
+    from smallworld.state.models import RAMMemoryMappedModel
+
+    ram = RAMMemoryMappedModel(0x40000000, 0x1000)
+    machine.add(ram)
+    # ... after emulation, inspect what was written:
+    print(ram.data[0:4])
+
+``SparseMemoryMappedModel`` models a large region that is sparsely populated
+with registers.  A single model owns the whole region; register handlers for
+individual sub-regions with ``add_register()``.  Anything not covered is
+served by a "slack" model -- ``"null"`` (default) or ``"ram"``.  Each
+registered handler only ever sees accesses contained within its own
+sub-region, so you never deal with straddling accesses yourself.
+
+.. code-block:: python
+
+    from smallworld.state.models import (
+        RAMMemoryMappedModel,
+        SparseMemoryMappedModel,
+    )
+
+    # A 4KB device region, zero-filled except for two modeled registers.
+    device = SparseMemoryMappedModel(0x40000000, 0x1000, slack="null")
+
+    # A plain RAM-backed data register...
+    data_reg = device.add_register(RAMMemoryMappedModel(0x40000010, 4))
+
+    # ...and a custom status register that always reads "ready".
+    class StatusRegister(MemoryMappedModel):
+        def on_read(self, emu, addr, size, data):
+            return b"\x01" * size
+
+        def on_write(self, emu, addr, size, value):
+            pass
+
+    device.add_register(StatusRegister(0x40000020, 4))
+
+    machine.add(device)

--- a/docs/concepts/state/hooks/hooks.rst
+++ b/docs/concepts/state/hooks/hooks.rst
@@ -340,7 +340,7 @@ to capture reads and writes to a certain location:
 Default MMIO Models
 -------------------
 
-Three ready-made ``MemoryMappedModel`` subclasses cover common cases so you
+Four ready-made ``MemoryMappedModel`` subclasses cover common cases so you
 don't have to write ``on_read()``/``on_write()`` by hand.  All handle partial
 and straddling accesses for you.
 
@@ -367,12 +367,23 @@ written are stored and read back.  The backing bytes are exposed as ``.data``
     # ... after emulation, inspect what was written:
     print(ram.data[0:4])
 
+``UnmappedMemoryMappedModel`` faults on any access: reads raise
+``EmulationReadUnmappedFailure`` and writes raise
+``EmulationWriteUnmappedFailure``, as though the region were not mapped.
+
+.. code-block:: python
+
+    from smallworld.state.models import UnmappedMemoryMappedModel
+
+    machine.add(UnmappedMemoryMappedModel(0x40000000, 0x1000))
+
 ``SparseMemoryMappedModel`` models a large region that is sparsely populated
 with registers.  A single model owns the whole region; register handlers for
 individual sub-regions with ``add_register()``.  Anything not covered is
-served by a "slack" model -- ``"null"`` (default) or ``"ram"``.  Each
-registered handler only ever sees accesses contained within its own
-sub-region, so you never deal with straddling accesses yourself.
+served by a "slack" model -- ``"null"`` (default), ``"ram"``, or
+``"unmapped"`` (fault on access).  Each registered handler only ever sees
+accesses contained within its own sub-region, so you never deal with
+straddling accesses yourself.
 
 .. code-block:: python
 

--- a/smallworld/state/models/__init__.py
+++ b/smallworld/state/models/__init__.py
@@ -15,6 +15,11 @@ from . import (
     powerpc,
     riscv64,
 )
+from .defaultmmio import (
+    NullMemoryMappedModel,
+    RAMMemoryMappedModel,
+    SparseMemoryMappedModel,
+)
 from .mmio import MemoryMappedModel
 from .model import *  # noqa: F401, F403
 from .model import __all__ as __model__
@@ -22,6 +27,9 @@ from .returnconstant import ReturnConstant
 
 __all__ = __model__ + [
     "MemoryMappedModel",
+    "NullMemoryMappedModel",
+    "RAMMemoryMappedModel",
+    "SparseMemoryMappedModel",
     "ReturnConstant",
     "aarch64",
     "amd64",

--- a/smallworld/state/models/__init__.py
+++ b/smallworld/state/models/__init__.py
@@ -19,6 +19,7 @@ from .defaultmmio import (
     NullMemoryMappedModel,
     RAMMemoryMappedModel,
     SparseMemoryMappedModel,
+    UnmappedMemoryMappedModel,
 )
 from .mmio import MemoryMappedModel
 from .model import *  # noqa: F401, F403
@@ -29,6 +30,7 @@ __all__ = __model__ + [
     "MemoryMappedModel",
     "NullMemoryMappedModel",
     "RAMMemoryMappedModel",
+    "UnmappedMemoryMappedModel",
     "SparseMemoryMappedModel",
     "ReturnConstant",
     "aarch64",

--- a/smallworld/state/models/__init__.py
+++ b/smallworld/state/models/__init__.py
@@ -18,9 +18,11 @@ from . import (
 from .mmio import MemoryMappedModel
 from .model import *  # noqa: F401, F403
 from .model import __all__ as __model__
+from .returnconstant import ReturnConstant
 
 __all__ = __model__ + [
     "MemoryMappedModel",
+    "ReturnConstant",
     "aarch64",
     "amd64",
     "armel",

--- a/smallworld/state/models/cstd.py
+++ b/smallworld/state/models/cstd.py
@@ -105,6 +105,36 @@ class CStdCallingContext(metaclass=abc.ABCMeta):
                 f"No CStdCallingContext for {platform.architecture}:{platform.byteorder}"
             )
 
+    @classmethod
+    def for_platform_and_abi(cls, platform: platforms.Platform, abi: platforms.ABI):
+        """Find the calling context for a specific platform and ABI.
+
+        Unlike for_platform, this disambiguates by ABI, and skips function
+        models (which need a hook address to construct), so it resolves the
+        pure calling-context base (e.g. AMD64SysVCallingContext).
+
+        Arguments:
+            platform: The platform you want
+            abi: The ABI you want
+
+        Returns:
+            An instance of the appropriate CStdCallingContext
+
+        Raises:
+            ValueError: If no CStdCallingContext subclass matches your request
+        """
+        try:
+            return utils.find_subclass(
+                cls,
+                lambda x: x.platform == platform
+                and x.abi == abi
+                and not issubclass(x, Model),
+            )
+        except ValueError:
+            raise ValueError(
+                f"No CStdCallingContext for {platform} with ABI '{abi}'"
+            )
+
     # *** Integer arithmetic constants ***
     #
     # Generalized bitmasks for specific types,

--- a/smallworld/state/models/cstd.py
+++ b/smallworld/state/models/cstd.py
@@ -131,9 +131,7 @@ class CStdCallingContext(metaclass=abc.ABCMeta):
                 and not issubclass(x, Model),
             )
         except ValueError:
-            raise ValueError(
-                f"No CStdCallingContext for {platform} with ABI '{abi}'"
-            )
+            raise ValueError(f"No CStdCallingContext for {platform} with ABI '{abi}'")
 
     # *** Integer arithmetic constants ***
     #

--- a/smallworld/state/models/defaultmmio.py
+++ b/smallworld/state/models/defaultmmio.py
@@ -1,7 +1,7 @@
 import logging
 import typing
 
-from ... import emulators
+from ... import emulators, exceptions
 from .mmio import MemoryMappedModel
 
 logger = logging.getLogger(__name__)
@@ -106,6 +106,39 @@ class RAMMemoryMappedModel(MemoryMappedModel):
         self.data[reg_off : reg_off + length] = value[acc_off : acc_off + length]
 
 
+class UnmappedMemoryMappedModel(MemoryMappedModel):
+    """A default MMIO model that faults on any access.
+
+    Any read raises ``EmulationReadUnmappedFailure`` and any write raises
+    ``EmulationWriteUnmappedFailure``, as though the region were not mapped.
+    Useful as the slack for :class:`SparseMemoryMappedModel`, so that
+    accesses to the gaps between registers fault like unmapped memory
+    instead of silently succeeding.
+
+    Arguments:
+        address: Starting address of the MMIO region.
+        size: Size of the MMIO region in bytes.
+    """
+
+    def on_read(
+        self, emu: emulators.Emulator, addr: int, size: int, data: bytes
+    ) -> typing.Optional[bytes]:
+        raise exceptions.EmulationReadUnmappedFailure(
+            f"read from unmapped MMIO region at {addr:#x}",
+            emu.read_register("pc"),
+            address=addr,
+        )
+
+    def on_write(
+        self, emu: emulators.Emulator, addr: int, size: int, value: bytes
+    ) -> None:
+        raise exceptions.EmulationWriteUnmappedFailure(
+            f"write to unmapped MMIO region at {addr:#x}",
+            emu.read_register("pc"),
+            address=addr,
+        )
+
+
 class SparseMemoryMappedModel(MemoryMappedModel):
     """A default MMIO model for a large, sparsely-populated region.
 
@@ -126,9 +159,9 @@ class SparseMemoryMappedModel(MemoryMappedModel):
         size: Size of the region in bytes.
         slack: Behavior for bytes not covered by a registered handler.
             ``"null"`` (default) reports zeroes and discards writes; ``"ram"``
-            stores writes and reads them back.  A ``MemoryMappedModel``
-            instance spanning the whole region may be passed for custom
-            behavior.
+            stores writes and reads them back; ``"unmapped"`` faults on any
+            access.  A ``MemoryMappedModel`` instance spanning the whole
+            region may be passed for custom behavior.
     """
 
     def __init__(
@@ -146,6 +179,8 @@ class SparseMemoryMappedModel(MemoryMappedModel):
             self.slack = NullMemoryMappedModel(address, size)
         elif slack == "ram":
             self.slack = RAMMemoryMappedModel(address, size)
+        elif slack == "unmapped":
+            self.slack = UnmappedMemoryMappedModel(address, size)
         else:
             raise ValueError(f"unknown slack policy {slack!r}")
         # Kept sorted by address; guaranteed non-overlapping by add_register.
@@ -247,5 +282,6 @@ class SparseMemoryMappedModel(MemoryMappedModel):
 __all__ = [
     "NullMemoryMappedModel",
     "RAMMemoryMappedModel",
+    "UnmappedMemoryMappedModel",
     "SparseMemoryMappedModel",
 ]

--- a/smallworld/state/models/defaultmmio.py
+++ b/smallworld/state/models/defaultmmio.py
@@ -1,0 +1,251 @@
+import logging
+import typing
+
+from ... import emulators
+from .mmio import MemoryMappedModel
+
+logger = logging.getLogger(__name__)
+
+
+def _overlap(
+    model: MemoryMappedModel, addr: int, size: int
+) -> typing.Optional[typing.Tuple[int, int, int]]:
+    """Intersect an access with the modeled region.
+
+    Returns ``(access_offset, region_offset, length)`` where ``access_offset``
+    is the offset into the access, ``region_offset`` the offset into the
+    region, and ``length`` the number of overlapping bytes -- or ``None`` if
+    the access does not overlap the region at all.
+    """
+    start = max(addr, model.address)
+    end = min(addr + size, model.address + model.size)
+    if start >= end:
+        return None
+    return (start - addr, start - model.address, end - start)
+
+
+class NullMemoryMappedModel(MemoryMappedModel):
+    """A default MMIO model that does nothing.
+
+    Reads within the region report zeroes and writes to it have no visible
+    effect.  Useful for mapping a device region inert -- e.g. to stop a
+    driver faulting on an unmodeled peripheral without caring what it reads
+    back.
+
+    Arguments:
+        address: Starting address of the MMIO region.
+        size: Size of the MMIO region in bytes.
+    """
+
+    def on_read(
+        self, emu: emulators.Emulator, addr: int, size: int, data: bytes
+    ) -> typing.Optional[bytes]:
+        # An access may overlap our region only partially (it can start
+        # before or extend past the region), and the emulator writes the
+        # whole returned buffer back -- so zero only the overlapping bytes
+        # and pass the rest of `data` through untouched.
+        overlap = _overlap(self, addr, size)
+        if overlap is None:
+            return None
+        acc_off, _, length = overlap
+        result = bytearray(data)
+        result[acc_off : acc_off + length] = b"\x00" * length
+        return bytes(result)
+
+    def on_write(
+        self, emu: emulators.Emulator, addr: int, size: int, value: bytes
+    ) -> None:
+        # Nothing to do.  Write hooks are observational (no return channel);
+        # the emulator still stores the bytes to real memory itself.  We
+        # simply never surface them, since on_read always reports zeroes.
+        pass
+
+
+class RAMMemoryMappedModel(MemoryMappedModel):
+    """A default MMIO model that behaves like plain memory.
+
+    Bytes written are stored in the model object and returned by a
+    corresponding read, so the region acts like ordinary RAM while still
+    routing through the MMIO hooks (e.g. so a harness can inspect what a
+    program wrote).  The backing bytes are exposed as ``self.data`` and
+    start out zeroed.
+
+    Arguments:
+        address: Starting address of the MMIO region.
+        size: Size of the MMIO region in bytes.
+    """
+
+    def __init__(self, address: int, size: int):
+        super().__init__(address, size)
+        self.data = bytearray(size)
+
+    def on_read(
+        self, emu: emulators.Emulator, addr: int, size: int, data: bytes
+    ) -> typing.Optional[bytes]:
+        # Substitute our stored bytes only for the portion of the access
+        # that falls within the region; leave any straddling bytes as read.
+        overlap = _overlap(self, addr, size)
+        if overlap is None:
+            return None
+        acc_off, reg_off, length = overlap
+        result = bytearray(data)
+        result[acc_off : acc_off + length] = self.data[reg_off : reg_off + length]
+        return bytes(result)
+
+    def on_write(
+        self, emu: emulators.Emulator, addr: int, size: int, value: bytes
+    ) -> None:
+        # Record only the portion of the write that lands in the region.
+        # Bytes outside the region are stored to real memory by the emulator
+        # itself; write hooks have no return channel, so out-of-region bytes
+        # are neither our concern nor something we could forward.
+        overlap = _overlap(self, addr, size)
+        if overlap is None:
+            return
+        acc_off, reg_off, length = overlap
+        self.data[reg_off : reg_off + length] = value[acc_off : acc_off + length]
+
+
+class SparseMemoryMappedModel(MemoryMappedModel):
+    """A default MMIO model for a large, sparsely-populated region.
+
+    A single model owns the whole region -- the emulator only allows one
+    hook per address range, so a big region with scattered registers must be
+    served by one model that dispatches internally.  Register handlers for
+    individual sub-regions with :meth:`add_register`; everything not covered
+    by a registered handler is served by a "slack" model (zeroed by default,
+    or RAM-backed).
+
+    Handlers only ever see accesses fully contained within their own
+    sub-region.  This model splits each access at sub-region boundaries and
+    routes the pieces, so authors never have to deal with partial or
+    straddling accesses themselves.
+
+    Arguments:
+        address: Starting address of the region.
+        size: Size of the region in bytes.
+        slack: Behavior for bytes not covered by a registered handler.
+            ``"null"`` (default) reports zeroes and discards writes; ``"ram"``
+            stores writes and reads them back.  A ``MemoryMappedModel``
+            instance spanning the whole region may be passed for custom
+            behavior.
+    """
+
+    def __init__(
+        self,
+        address: int,
+        size: int,
+        slack: typing.Union[str, MemoryMappedModel] = "null",
+    ):
+        super().__init__(address, size)
+        if isinstance(slack, MemoryMappedModel):
+            if slack.address != address or slack.size != size:
+                raise ValueError("slack model must span the whole region")
+            self.slack: MemoryMappedModel = slack
+        elif slack == "null":
+            self.slack = NullMemoryMappedModel(address, size)
+        elif slack == "ram":
+            self.slack = RAMMemoryMappedModel(address, size)
+        else:
+            raise ValueError(f"unknown slack policy {slack!r}")
+        # Kept sorted by address; guaranteed non-overlapping by add_register.
+        self._children: typing.List[MemoryMappedModel] = []
+
+    def add_register(self, child: MemoryMappedModel) -> MemoryMappedModel:
+        """Register a handler for a sub-region.
+
+        ``child`` is any ``MemoryMappedModel`` whose own ``address``/``size``
+        place it within this region.  Returns ``child`` for convenience.
+
+        Raises:
+            ValueError: If the child does not fit within the region, or
+                overlaps an already-registered child.
+        """
+        if (
+            child.address < self.address
+            or child.address + child.size > self.address + self.size
+        ):
+            raise ValueError(
+                f"register [{child.address:#x}, {child.address + child.size:#x}) "
+                f"does not fit within region "
+                f"[{self.address:#x}, {self.address + self.size:#x})"
+            )
+        for existing in self._children:
+            if (
+                child.address < existing.address + existing.size
+                and existing.address < child.address + child.size
+            ):
+                raise ValueError(
+                    f"register [{child.address:#x}, "
+                    f"{child.address + child.size:#x}) overlaps "
+                    f"[{existing.address:#x}, {existing.address + existing.size:#x})"
+                )
+        self._children.append(child)
+        self._children.sort(key=lambda c: c.address)
+        return child
+
+    def _runs(
+        self, start: int, end: int
+    ) -> typing.Iterator[typing.Tuple[int, int, MemoryMappedModel]]:
+        """Split ``[start, end)`` into maximal runs, each owned by one model.
+
+        Yields ``(run_start, run_end, owner)`` where ``owner`` is the child
+        covering the run, or the slack model for a gap between children.
+        """
+        pos = start
+        while pos < end:
+            owner: typing.Optional[MemoryMappedModel] = None
+            run_end = end
+            for c in self._children:
+                if c.address <= pos < c.address + c.size:
+                    # `pos` is inside this child; the run lasts to its end.
+                    owner = c
+                    run_end = min(end, c.address + c.size)
+                    break
+                if c.address > pos:
+                    # Children are sorted, so this is the next one; the run of
+                    # slack lasts until it begins.
+                    run_end = min(end, c.address)
+                    break
+            if owner is None:
+                owner = self.slack
+            yield pos, run_end, owner
+            pos = run_end
+
+    def on_read(
+        self, emu: emulators.Emulator, addr: int, size: int, data: bytes
+    ) -> typing.Optional[bytes]:
+        if _overlap(self, addr, size) is None:
+            return None
+        result = bytearray(data)
+        c_start = max(addr, self.address)
+        c_end = min(addr + size, self.address + self.size)
+        for run_start, run_end, owner in self._runs(c_start, c_end):
+            lo = run_start - addr
+            hi = run_end - addr
+            # Each owner sees only its own contained sub-access.
+            sub = owner.on_read(
+                emu, run_start, run_end - run_start, bytes(result[lo:hi])
+            )
+            if sub is not None:
+                result[lo:hi] = sub
+        return bytes(result)
+
+    def on_write(
+        self, emu: emulators.Emulator, addr: int, size: int, value: bytes
+    ) -> None:
+        if _overlap(self, addr, size) is None:
+            return
+        c_start = max(addr, self.address)
+        c_end = min(addr + size, self.address + self.size)
+        for run_start, run_end, owner in self._runs(c_start, c_end):
+            lo = run_start - addr
+            hi = run_end - addr
+            owner.on_write(emu, run_start, run_end - run_start, value[lo:hi])
+
+
+__all__ = [
+    "NullMemoryMappedModel",
+    "RAMMemoryMappedModel",
+    "SparseMemoryMappedModel",
+]

--- a/smallworld/state/models/returnconstant.py
+++ b/smallworld/state/models/returnconstant.py
@@ -1,7 +1,7 @@
 import logging
 import typing
 
-from ... import emulators, platforms, utils
+from ... import emulators, platforms
 from .cstd import ArgumentType, CStdCallingContext
 from .model import Model
 
@@ -66,17 +66,11 @@ class ReturnConstant(Model):
         self.abi = abi
         self.value = value
 
-        # Borrow the ABI-specific return machinery.  We match on platform AND
-        # abi (CStdCallingContext.for_platform ignores the abi), and exclude
-        # Model subclasses so we resolve the pure calling-context base (e.g.
-        # AMD64SysVCallingContext) rather than a concrete function model that
-        # happens to share the platform.
+        # Borrow the ABI-specific return machinery from the calling context
+        # for this platform/ABI (the pure context base, not a function model).
         try:
-            self._context: CStdCallingContext = utils.find_subclass(
-                CStdCallingContext,
-                lambda x: x.platform == platform
-                and x.abi == abi
-                and not issubclass(x, Model),
+            self._context: CStdCallingContext = (
+                CStdCallingContext.for_platform_and_abi(platform, abi)
             )
         except ValueError:
             raise ValueError(f"no calling context for {platform} with ABI '{abi}'")

--- a/smallworld/state/models/returnconstant.py
+++ b/smallworld/state/models/returnconstant.py
@@ -69,8 +69,8 @@ class ReturnConstant(Model):
         # Borrow the ABI-specific return machinery from the calling context
         # for this platform/ABI (the pure context base, not a function model).
         try:
-            self._context: CStdCallingContext = (
-                CStdCallingContext.for_platform_and_abi(platform, abi)
+            self._context: CStdCallingContext = CStdCallingContext.for_platform_and_abi(
+                platform, abi
             )
         except ValueError:
             raise ValueError(f"no calling context for {platform} with ABI '{abi}'")

--- a/smallworld/state/models/returnconstant.py
+++ b/smallworld/state/models/returnconstant.py
@@ -1,0 +1,99 @@
+import logging
+import typing
+
+from ... import emulators, platforms, utils
+from .cstd import ArgumentType, CStdCallingContext
+from .model import Model
+
+logger = logging.getLogger(__name__)
+
+
+class ReturnConstant(Model):
+    """A model that ignores its arguments and returns a fixed value.
+
+    This is a "default" function model: rather than modeling the semantics
+    of a particular library function, it simply consumes the call and
+    returns a constant according to the ABI.  It's handy for stubbing out
+    functions whose return value you want to pin (e.g. force ``fork`` to
+    return 0) without writing a bespoke model.
+
+    Unlike the named library-function models, this one is *parametric*, so
+    it is constructed directly rather than obtained via :meth:`Model.lookup`::
+
+        model = ReturnConstant(address, platform, abi, value=0)
+        machine.add(model)
+
+    Returning is an ABI-specific operation, but that logic is already
+    abstracted by :class:`CStdCallingContext`.  Instead of defining a
+    subclass per ABI, this model looks up the calling context for the
+    requested platform/ABI and delegates to its ``set_return_value``.  As a
+    result it works on every ABI the framework supports, for free.
+
+    A ``return_type`` of :attr:`ArgumentType.VOID` produces a no-op model:
+    the call is consumed and control returns to the caller, but no return
+    register is written.
+
+    Arguments:
+        address: The instruction address which the model will hook.
+        platform: The platform for which this model is defined.
+        abi: The ABI according to which this model returns.
+        value: The constant to return.  Must be an ``int`` for integral or
+            pointer return types, or a ``float`` for ``FLOAT``/``DOUBLE``.
+            Ignored when ``return_type`` is ``VOID``.
+        return_type: The C type of the return value.  Determines which
+            register(s) are written and how ``value`` is encoded.  Defaults
+            to :attr:`ArgumentType.POINTER` (register-width, no truncation).
+    """
+
+    # These override the abstract properties on Model with concrete class
+    # attributes so ReturnConstant is directly instantiable.  They are
+    # replaced with the real values per-instance in __init__.
+    name = "return-constant"
+    platform = None  # type: ignore[assignment]
+    abi = None  # type: ignore[assignment]
+
+    def __init__(
+        self,
+        address: int,
+        platform: platforms.Platform,
+        abi: platforms.ABI,
+        value: typing.Union[int, float] = 0,
+        return_type: ArgumentType = ArgumentType.POINTER,
+    ):
+        # platform/abi must be set before Model.__init__, which builds
+        # self.platdef from self.platform.
+        self.platform = platform
+        self.abi = abi
+        self.value = value
+
+        # Borrow the ABI-specific return machinery.  We match on platform AND
+        # abi (CStdCallingContext.for_platform ignores the abi), and exclude
+        # Model subclasses so we resolve the pure calling-context base (e.g.
+        # AMD64SysVCallingContext) rather than a concrete function model that
+        # happens to share the platform.
+        try:
+            self._context: CStdCallingContext = utils.find_subclass(
+                CStdCallingContext,
+                lambda x: x.platform == platform
+                and x.abi == abi
+                and not issubclass(x, Model),
+            )
+        except ValueError:
+            raise ValueError(f"no calling context for {platform} with ABI '{abi}'")
+        self._context.return_type = return_type
+
+        super().__init__(address)
+
+    def model(self, emulator: emulators.Emulator) -> None:
+        super().model(emulator)
+
+        if self._context.return_type == ArgumentType.VOID:
+            # No-op: consume the call and return without writing a value.
+            logger.debug("return-constant modeling void return")
+            return
+
+        logger.debug(f"return-constant returning {self.value!r}")
+        self._context.set_return_value(emulator, self.value)
+
+
+__all__ = ["ReturnConstant"]

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -88,6 +88,7 @@ from smallworld.state.models.defaultmmio import (
     NullMemoryMappedModel,
     RAMMemoryMappedModel,
     SparseMemoryMappedModel,
+    UnmappedMemoryMappedModel,
 )
 from smallworld.state.models.filedesc import BytesIO as SWBytesIO
 from smallworld.state.models.filedesc import FileDescriptorManager
@@ -3799,6 +3800,38 @@ class SparseMemoryMappedModelTests(unittest.TestCase):
     def test_bad_slack_policy_raises(self):
         with self.assertRaises(ValueError):
             SparseMemoryMappedModel(0x1000, 0x100, slack="bogus")
+
+    def test_unmapped_slack_faults_on_gap_but_not_registers(self):
+        sparse = SparseMemoryMappedModel(0x1000, 0x100, slack="unmapped")
+        reg = sparse.add_register(RAMMemoryMappedModel(0x1010, 4))
+        reg.data[:] = bytes([1, 2, 3, 4])
+        emu = SimpleNamespace(read_register=lambda name: 0x400000)
+
+        # A registered sub-region still works normally...
+        self.assertEqual(sparse.on_read(emu, 0x1010, 4, b"\x00" * 4), bytes([1, 2, 3, 4]))
+        # ...but the gap between registers faults like unmapped memory.
+        with self.assertRaises(exceptions.EmulationReadUnmappedFailure):
+            sparse.on_read(emu, 0x1000, 4, b"\x00" * 4)
+        with self.assertRaises(exceptions.EmulationWriteUnmappedFailure):
+            sparse.on_write(emu, 0x1000, 4, b"\x00" * 4)
+
+
+class UnmappedMemoryMappedModelTests(unittest.TestCase):
+    """defaultmmio.py UnmappedMemoryMappedModel: any access faults."""
+
+    def setUp(self):
+        self.emu = SimpleNamespace(read_register=lambda name: 0x400000)
+        self.model = UnmappedMemoryMappedModel(0x1000, 8)
+
+    def test_read_raises_unmapped(self):
+        with self.assertRaises(exceptions.EmulationReadUnmappedFailure) as ctx:
+            self.model.on_read(self.emu, 0x1000, 4, b"\x00" * 4)
+        self.assertEqual(ctx.exception.address, 0x1000)
+
+    def test_write_raises_unmapped(self):
+        with self.assertRaises(exceptions.EmulationWriteUnmappedFailure) as ctx:
+            self.model.on_write(self.emu, 0x1004, 4, b"\x00" * 4)
+        self.assertEqual(ctx.exception.address, 0x1004)
 
 
 class NiceModelTests(ModelTestCase):

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -95,6 +95,7 @@ from smallworld.state.models.model import Model
 from smallworld.state.models.posix.filedesc import SockaddrIn, SocketIO
 from smallworld.state.models.posix.filedesc.sockaddr import SockaddrIn6
 from smallworld.state.models.posix.procinfo import ProcInfoManager
+from smallworld.state.models.returnconstant import ReturnConstant
 from smallworld.state.models.riscv64.systemv.systemv import RiscV64SysVCallingContext
 
 logging.getLogger("angr").setLevel(logging.ERROR)
@@ -3581,6 +3582,66 @@ class Dup2ModelTests(ModelTestCase):
         self.assertIn(7, fdmgr._fds)
         self.assertEqual(fdmgr.get_fd(7).name, fdmgr.get_fd(1).name)
         self.assertTrue(fdmgr.get_fd(7).writable())
+
+
+class ReturnConstantModelTests(ModelTestCase):
+    """returnconstant.py ReturnConstant: parametric default model."""
+
+    def make(self, value=0, return_type=ArgumentType.POINTER, platform=MODELS_AMD64):
+        return ReturnConstant(
+            MODELS_HOOK_ADDR, platform, MODELS_SYSV, value=value, return_type=return_type
+        )
+
+    def test_pointer_constant_written_to_rax(self):
+        model = self.make(value=0xDEADBEEF)
+        model.model(self.emu)
+        # amd64 SysV returns pointer/8-byte values in rax.
+        self.assertEqual(self.emu.read_register("rax"), 0xDEADBEEF)
+
+    def test_default_value_is_zero(self):
+        model = self.make()
+        model.model(self.emu)
+        self.assertEqual(self.emu.read_register("rax"), 0)
+
+    def test_int_return_two_complements_negative(self):
+        model = self.make(value=-1, return_type=ArgumentType.INT)
+        model.model(self.emu)
+        # int returns land in eax (low 32 bits of rax).
+        self.assertEqual(self.emu.read_register("eax"), 0xFFFFFFFF)
+
+    def test_void_writes_no_register(self):
+        # Pre-seed the return register with a sentinel; a void model must
+        # consume the call without touching it.
+        self.emu.write_register("rax", 0x1111111111111111)
+        model = self.make(return_type=ArgumentType.VOID)
+        model.model(self.emu)
+        self.assertEqual(self.emu.read_register("rax"), 0x1111111111111111)
+
+    def test_argument_registers_are_left_untouched(self):
+        # The model returns a constant regardless of arguments, and must not
+        # clobber the argument registers it never reads.
+        args = {"rdi": 0xA, "rsi": 0xB, "rdx": 0xC, "rcx": 0xD, "r8": 0xE, "r9": 0xF}
+        for reg, value in args.items():
+            self.emu.write_register(reg, value)
+        model = self.make(value=7)
+        model.model(self.emu)
+        self.assertEqual(self.emu.read_register("rax"), 7)
+        for reg, value in args.items():
+            self.assertEqual(self.emu.read_register(reg), value)
+
+    def test_resolves_calling_context_per_platform(self):
+        # No per-ABI subclass exists: the model borrows the pure calling
+        # context for the requested platform/ABI (not a function model).
+        self.assertIsInstance(
+            self.make(platform=MODELS_AMD64)._context, AMD64SysVCallingContext
+        )
+        self.assertIsInstance(
+            self.make(platform=MODELS_AARCH64)._context, AArch64SysVCallingContext
+        )
+
+    def test_unknown_abi_raises(self):
+        with self.assertRaises(ValueError):
+            ReturnConstant(MODELS_HOOK_ADDR, MODELS_AMD64, platforms.ABI.NONE)
 
 
 class NiceModelTests(ModelTestCase):

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -3808,7 +3808,9 @@ class SparseMemoryMappedModelTests(unittest.TestCase):
         emu = SimpleNamespace(read_register=lambda name: 0x400000)
 
         # A registered sub-region still works normally...
-        self.assertEqual(sparse.on_read(emu, 0x1010, 4, b"\x00" * 4), bytes([1, 2, 3, 4]))
+        self.assertEqual(
+            sparse.on_read(emu, 0x1010, 4, b"\x00" * 4), bytes([1, 2, 3, 4])
+        )
         # ...but the gap between registers faults like unmapped memory.
         with self.assertRaises(exceptions.EmulationReadUnmappedFailure):
             sparse.on_read(emu, 0x1000, 4, b"\x00" * 4)

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -3594,7 +3594,11 @@ class ReturnConstantModelTests(ModelTestCase):
 
     def make(self, value=0, return_type=ArgumentType.POINTER, platform=MODELS_AMD64):
         return ReturnConstant(
-            MODELS_HOOK_ADDR, platform, MODELS_SYSV, value=value, return_type=return_type
+            MODELS_HOOK_ADDR,
+            platform,
+            MODELS_SYSV,
+            value=value,
+            return_type=return_type,
         )
 
     def test_pointer_constant_written_to_rax(self):
@@ -3747,7 +3751,9 @@ class SparseMemoryMappedModelTests(unittest.TestCase):
         # reg1 (4) + slack gap (12) + reg2 (4) in a single 20-byte read.
         out = self.sparse.on_read(None, 0x1010, 0x14, b"\x00" * 0x14)
         expected = (
-            bytes([0xDE, 0xAD, 0xBE, 0xEF]) + bytes(12) + bytes([0x11, 0x22, 0x33, 0x44])
+            bytes([0xDE, 0xAD, 0xBE, 0xEF])
+            + bytes(12)
+            + bytes([0x11, 0x22, 0x33, 0x44])
         )
         self.assertEqual(out, expected)
 

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -84,6 +84,11 @@ from smallworld.state.models.c99.libc import C99Libc
 from smallworld.state.models.c99.stdio import Freopen, Vsprintf, Vsscanf
 from smallworld.state.models.c99.utils import _emu_memcmp, _emu_strncmp, _emu_strnlen
 from smallworld.state.models.cstd import ArgumentType
+from smallworld.state.models.defaultmmio import (
+    NullMemoryMappedModel,
+    RAMMemoryMappedModel,
+    SparseMemoryMappedModel,
+)
 from smallworld.state.models.filedesc import BytesIO as SWBytesIO
 from smallworld.state.models.filedesc import FileDescriptorManager
 from smallworld.state.models.mips64.systemv.systemv import MIPS64SysVCallingContext
@@ -3642,6 +3647,152 @@ class ReturnConstantModelTests(ModelTestCase):
     def test_unknown_abi_raises(self):
         with self.assertRaises(ValueError):
             ReturnConstant(MODELS_HOOK_ADDR, MODELS_AMD64, platforms.ABI.NONE)
+
+
+class NullMemoryMappedModelTests(unittest.TestCase):
+    """defaultmmio.py NullMemoryMappedModel: reads zero, writes vanish."""
+
+    def test_read_reports_zeroes(self):
+        null = NullMemoryMappedModel(0x1000, 8)
+        self.assertEqual(null.on_read(None, 0x1000, 4, b"\xaa" * 4), b"\x00" * 4)
+
+    def test_write_is_a_noop(self):
+        null = NullMemoryMappedModel(0x1000, 8)
+        self.assertIsNone(null.on_write(None, 0x1000, 4, b"\xaa" * 4))
+
+    def test_straddle_end_preserves_neighbor_bytes(self):
+        # Access starts inside the region and runs past its end; only the
+        # in-region bytes (the first two of the access) are zeroed.
+        null = NullMemoryMappedModel(0x1000, 8)
+        out = null.on_read(None, 0x1006, 4, bytes([0xDE, 0xAD, 0xBE, 0xEF]))
+        self.assertEqual(out, bytes([0x00, 0x00, 0xBE, 0xEF]))
+
+    def test_straddle_start_preserves_neighbor_bytes(self):
+        # Access starts before the region; only the last two bytes are ours.
+        null = NullMemoryMappedModel(0x1000, 8)
+        out = null.on_read(None, 0x0FFE, 4, bytes([0x11, 0x22, 0x33, 0x44]))
+        self.assertEqual(out, bytes([0x11, 0x22, 0x00, 0x00]))
+
+    def test_access_outside_region_is_ignored(self):
+        null = NullMemoryMappedModel(0x1000, 8)
+        self.assertIsNone(null.on_read(None, 0x2000, 4, b"\x77" * 4))
+
+
+class RAMMemoryMappedModelTests(unittest.TestCase):
+    """defaultmmio.py RAMMemoryMappedModel: written bytes read back."""
+
+    def test_write_then_read_roundtrip(self):
+        ram = RAMMemoryMappedModel(0x1000, 8)
+        ram.on_write(None, 0x1000, 4, bytes([1, 2, 3, 4]))
+        self.assertEqual(ram.data[0:4], bytes([1, 2, 3, 4]))
+        self.assertEqual(ram.on_read(None, 0x1000, 4, b"\x00" * 4), bytes([1, 2, 3, 4]))
+
+    def test_straddle_write_records_only_overlap(self):
+        ram = RAMMemoryMappedModel(0x1000, 8)
+        # Write starts before the region; only its last two bytes land in it.
+        ram.on_write(None, 0x0FFE, 4, bytes([0xA, 0xB, 0xC, 0xD]))
+        self.assertEqual(ram.data[0:2], bytes([0xC, 0xD]))
+        self.assertEqual(ram.data[2:], bytes(6))
+
+    def test_straddle_read_preserves_neighbor_bytes(self):
+        ram = RAMMemoryMappedModel(0x1000, 8)
+        ram.data[6:8] = bytes([0x01, 0x02])
+        out = ram.on_read(None, 0x1006, 4, bytes([0xDE, 0xAD, 0xBE, 0xEF]))
+        self.assertEqual(out, bytes([0x01, 0x02, 0xBE, 0xEF]))
+
+    def test_access_outside_region_is_ignored(self):
+        ram = RAMMemoryMappedModel(0x1000, 8)
+        self.assertIsNone(ram.on_read(None, 0x2000, 4, b"\x77" * 4))
+
+
+class SparseMemoryMappedModelTests(unittest.TestCase):
+    """defaultmmio.py SparseMemoryMappedModel: routes to sub-registers."""
+
+    def setUp(self):
+        # Region [0x1000, 0x1100) with two 4-byte RAM registers and a gap.
+        self.sparse = SparseMemoryMappedModel(0x1000, 0x100, slack="null")
+        self.reg1 = self.sparse.add_register(RAMMemoryMappedModel(0x1010, 4))
+        self.reg2 = self.sparse.add_register(RAMMemoryMappedModel(0x1020, 4))
+        self.reg1.data[:] = bytes([0xDE, 0xAD, 0xBE, 0xEF])
+        self.reg2.data[:] = bytes([0x11, 0x22, 0x33, 0x44])
+
+    def test_read_whole_child_register(self):
+        out = self.sparse.on_read(None, 0x1010, 4, b"\x00" * 4)
+        self.assertEqual(out, bytes([0xDE, 0xAD, 0xBE, 0xEF]))
+
+    def test_read_subsection_of_child(self):
+        # A single byte in the middle of reg1.
+        self.assertEqual(self.sparse.on_read(None, 0x1012, 1, b"\x00"), bytes([0xBE]))
+        # Two bytes spanning the middle of reg1.
+        self.assertEqual(
+            self.sparse.on_read(None, 0x1011, 2, b"\x00" * 2), bytes([0xAD, 0xBE])
+        )
+
+    def test_write_subsection_of_child(self):
+        self.sparse.on_write(None, 0x1012, 2, bytes([0xAA, 0xBB]))
+        self.assertEqual(self.reg1.data, bytes([0xDE, 0xAD, 0xAA, 0xBB]))
+        # The rest of the region is undisturbed.
+        self.assertEqual(self.reg2.data, bytes([0x11, 0x22, 0x33, 0x44]))
+
+    def test_read_slack_reports_zeroes(self):
+        # 0x1000 is in the gap before reg1; null slack reports zeroes.
+        self.assertEqual(self.sparse.on_read(None, 0x1000, 4, b"\xff" * 4), b"\x00" * 4)
+
+    def test_read_straddling_slack_and_child_boundary(self):
+        # [0x100e, 0x1012): two slack bytes then the first two of reg1.
+        out = self.sparse.on_read(None, 0x100E, 4, b"\x00" * 4)
+        self.assertEqual(out, bytes([0x00, 0x00, 0xDE, 0xAD]))
+
+    def test_read_spanning_two_children_and_gap(self):
+        # reg1 (4) + slack gap (12) + reg2 (4) in a single 20-byte read.
+        out = self.sparse.on_read(None, 0x1010, 0x14, b"\x00" * 0x14)
+        expected = (
+            bytes([0xDE, 0xAD, 0xBE, 0xEF]) + bytes(12) + bytes([0x11, 0x22, 0x33, 0x44])
+        )
+        self.assertEqual(out, expected)
+
+    def test_null_slack_write_is_discarded(self):
+        self.sparse.on_write(None, 0x1000, 4, bytes([1, 2, 3, 4]))
+        self.assertEqual(self.sparse.on_read(None, 0x1000, 4, b"\x00" * 4), b"\x00" * 4)
+
+    def test_ram_slack_roundtrip_and_boundary_write(self):
+        sparse = SparseMemoryMappedModel(0x1000, 0x100, slack="ram")
+        reg = sparse.add_register(RAMMemoryMappedModel(0x1010, 4))
+        # Write straddles the slack/register boundary at 0x1010.
+        sparse.on_write(None, 0x100E, 4, bytes([0xA, 0xB, 0xC, 0xD]))
+        # First two bytes go to the RAM slack, last two into the register.
+        self.assertEqual(sparse.slack.data[0x0E:0x10], bytes([0xA, 0xB]))
+        self.assertEqual(reg.data[0:2], bytes([0xC, 0xD]))
+        # And it reads back intact across the same boundary.
+        out = sparse.on_read(None, 0x100E, 4, b"\x00" * 4)
+        self.assertEqual(out, bytes([0xA, 0xB, 0xC, 0xD]))
+
+    def test_composite_straddle_passes_through_outside_bytes(self):
+        # Access begins before the whole region; those bytes are preserved.
+        out = self.sparse.on_read(None, 0x0FFE, 4, bytes([0x11, 0x22, 0x33, 0x44]))
+        self.assertEqual(out, bytes([0x11, 0x22, 0x00, 0x00]))
+
+    def test_access_entirely_outside_region_is_ignored(self):
+        self.assertIsNone(self.sparse.on_read(None, 0x2000, 4, b"\x77" * 4))
+        # A write fully outside must not raise.
+        self.sparse.on_write(None, 0x2000, 4, b"\x77" * 4)
+
+    def test_add_register_out_of_bounds_raises(self):
+        with self.assertRaises(ValueError):
+            self.sparse.add_register(RAMMemoryMappedModel(0x2000, 4))
+
+    def test_add_register_partially_out_of_bounds_raises(self):
+        # Ends one byte past the region.
+        with self.assertRaises(ValueError):
+            self.sparse.add_register(RAMMemoryMappedModel(0x10FE, 4))
+
+    def test_add_register_overlap_raises(self):
+        with self.assertRaises(ValueError):
+            self.sparse.add_register(RAMMemoryMappedModel(0x1012, 4))
+
+    def test_bad_slack_policy_raises(self):
+        with self.assertRaises(ValueError):
+            SparseMemoryMappedModel(0x1000, 0x100, slack="bogus")
 
 
 class NiceModelTests(ModelTestCase):


### PR DESCRIPTION
Added the following:

- Function model that always returns a constant, or just void.
- MMIO model that always reads zeroes, nops on write
- MMIO model that mimics the behavior of RAM
- MMIO model that orchestrates many smaller models on top of a null or RAM-style model, in order to model a large MMIO region.