### PR TITLE
docs: Added event handler matrix to emulator documentation

### DIFF
--- a/docs/concepts/emulators/event_handler_support.csv
+++ b/docs/concepts/emulators/event_handler_support.csv
@@ -1,0 +1,6 @@
+,               angr,   ghidra,     panda,      unicorn
+Instruction,    Yes,    Yes,        Yes,        Yes
+Function,       Yes,    Yes,        Yes,        Yes
+Memory Access,  Yes,    Yes,        Yes,        Yes
+System Calls,   Yes,    No,         No,         No
+Interrupts,     No,     No,         Yes,        Yes

--- a/docs/concepts/emulators/interface.rst
+++ b/docs/concepts/emulators/interface.rst
@@ -502,3 +502,14 @@ and cause emulation to resume at a different instruction by setting the program 
 
 Both global and specific interrupt handlers can be registered at the same time.
 The order in which the callbacks fire is not guaranteed.
+
+Support
+*******
+
+The following is a matrix of which emulators support which event handler types.
+Specific caveats and details can be found in the documentation for specific backends.
+
+.. csv-table:: Event Handler Support
+    :file: event_handler_support.csv
+    :header-rows: 1
+    :stub-columns: 1


### PR DESCRIPTION
The specific event handlers supported by each emulator are documented in their respective deep-dives,
but are not easily accessible without reading
the entire detailed set of docs for each emulator.

This adds a matrix to the emulator interface docs
giving a high-level overview for ease of reference.