### PR TITLE
feat: Added a log wrapper for MMIO model objects

### DIFF
--- a/smallworld/state/models/defaultmmio.py
+++ b/smallworld/state/models/defaultmmio.py
@@ -278,6 +278,7 @@ class SparseMemoryMappedModel(MemoryMappedModel):
             hi = run_end - addr
             owner.on_write(emu, run_start, run_end - run_start, value[lo:hi])
 
+
 class LogAccessModel(MemoryMappedModel):
     """A default MMIO model that logs accesses and delegates to another model.
 
@@ -300,7 +301,7 @@ class LogAccessModel(MemoryMappedModel):
         self,
         inner: MemoryMappedModel,
         log: logging.Logger,
-        name: typing.Optional[str] = None
+        name: typing.Optional[str] = None,
     ):
         super().__init__(inner.address, inner.size)
         self.inner = inner
@@ -320,8 +321,7 @@ class LogAccessModel(MemoryMappedModel):
     ) -> None:
         self.log.debug(f"{self.name} write addr={hex(addr)} size={size}")
         self.inner.on_write(emulator, addr, size, value)
-            
-        
+
 
 __all__ = [
     "NullMemoryMappedModel",

--- a/smallworld/state/models/defaultmmio.py
+++ b/smallworld/state/models/defaultmmio.py
@@ -278,10 +278,55 @@ class SparseMemoryMappedModel(MemoryMappedModel):
             hi = run_end - addr
             owner.on_write(emu, run_start, run_end - run_start, value[lo:hi])
 
+class LogAccessModel(MemoryMappedModel):
+    """A default MMIO model that logs accesses and delegates to another model.
+
+    Wraps an existing ``MemoryMappedModel`` and logs every read and write
+    before forwarding the access to the wrapped model unchanged.  Useful for
+    observing what a program does to a modeled region without altering the
+    region's behavior -- e.g. layering logging over a :class:`RAMMemoryMappedModel`
+    or a device-specific model.  The wrapper spans the same address range as
+    the model it wraps.
+
+    Arguments:
+        inner: The model to wrap; its behavior is preserved and its
+            ``address``/``size`` become this wrapper's own.
+        log: The logger to emit read/write messages to (at ``DEBUG`` level).
+        name: Label used to identify this region in log messages.  Defaults
+            to the class name of ``inner``.
+    """
+
+    def __init__(
+        self,
+        inner: MemoryMappedModel,
+        log: logging.Logger,
+        name: typing.Optional[str] = None
+    ):
+        super().__init__(inner.address, inner.size)
+        self.inner = inner
+        self.log = log
+        if name is None:
+            name = self.inner.__class__.__name__
+        self.name = name
+
+    def on_read(
+        self, emulator: emulators.Emulator, addr: int, size: int, value: bytes
+    ) -> bytes:
+        self.log.debug(f"{self.name} read addr={hex(addr)} size={size}")
+        return self.inner.on_read(emulator, addr, size, value)
+
+    def on_write(
+        self, emulator: emulators.Emulator, addr: int, size: int, value: bytes
+    ) -> None:
+        self.log.debug(f"{self.name} write addr={hex(addr)} size={size}")
+        self.inner.on_write(emulator, addr, size, value)
+            
+        
 
 __all__ = [
     "NullMemoryMappedModel",
     "RAMMemoryMappedModel",
     "UnmappedMemoryMappedModel",
     "SparseMemoryMappedModel",
+    "LogAccessModel",
 ]

--- a/smallworld/state/models/defaultmmio.py
+++ b/smallworld/state/models/defaultmmio.py
@@ -311,7 +311,7 @@ class LogAccessModel(MemoryMappedModel):
 
     def on_read(
         self, emulator: emulators.Emulator, addr: int, size: int, value: bytes
-    ) -> bytes:
+    ) -> typing.Optional[bytes]:
         self.log.debug(f"{self.name} read addr={hex(addr)} size={size}")
         return self.inner.on_read(emulator, addr, size, value)
 

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -85,6 +85,7 @@ from smallworld.state.models.c99.stdio import Freopen, Vsprintf, Vsscanf
 from smallworld.state.models.c99.utils import _emu_memcmp, _emu_strncmp, _emu_strnlen
 from smallworld.state.models.cstd import ArgumentType
 from smallworld.state.models.defaultmmio import (
+    LogAccessModel,
     NullMemoryMappedModel,
     RAMMemoryMappedModel,
     SparseMemoryMappedModel,
@@ -3834,6 +3835,63 @@ class UnmappedMemoryMappedModelTests(unittest.TestCase):
         with self.assertRaises(exceptions.EmulationWriteUnmappedFailure) as ctx:
             self.model.on_write(self.emu, 0x1004, 4, b"\x00" * 4)
         self.assertEqual(ctx.exception.address, 0x1004)
+
+
+class LogAccessModelTests(unittest.TestCase):
+    """defaultmmio.py LogAccessModel: logs accesses, delegates to inner."""
+
+    def setUp(self):
+        self.log = logging.getLogger("test.logaccessmodel")
+        self.inner = RAMMemoryMappedModel(0x1000, 8)
+
+    def test_inherits_inner_address_and_size(self):
+        model = LogAccessModel(self.inner, self.log)
+        self.assertEqual(model.address, self.inner.address)
+        self.assertEqual(model.size, self.inner.size)
+
+    def test_name_defaults_to_inner_class_name(self):
+        model = LogAccessModel(self.inner, self.log)
+        self.assertEqual(model.name, "RAMMemoryMappedModel")
+
+    def test_explicit_name_is_used(self):
+        model = LogAccessModel(self.inner, self.log, name="uart0")
+        self.assertEqual(model.name, "uart0")
+
+    def test_read_delegates_to_inner(self):
+        self.inner.data[0:4] = bytes([0xDE, 0xAD, 0xBE, 0xEF])
+        model = LogAccessModel(self.inner, self.log)
+        out = model.on_read(None, 0x1000, 4, b"\x00" * 4)
+        self.assertEqual(out, bytes([0xDE, 0xAD, 0xBE, 0xEF]))
+
+    def test_write_delegates_to_inner(self):
+        model = LogAccessModel(self.inner, self.log)
+        model.on_write(None, 0x1000, 4, bytes([1, 2, 3, 4]))
+        self.assertEqual(self.inner.data[0:4], bytes([1, 2, 3, 4]))
+
+    def test_read_emits_expected_log_message(self):
+        model = LogAccessModel(self.inner, self.log, name="uart0")
+        with self.assertLogs(self.log, level=logging.DEBUG) as ctx:
+            model.on_read(None, 0x1004, 2, b"\x00" * 2)
+        self.assertEqual(
+            ctx.output, ["DEBUG:test.logaccessmodel:uart0 read addr=0x1004 size=2"]
+        )
+
+    def test_write_emits_expected_log_message(self):
+        model = LogAccessModel(self.inner, self.log, name="uart0")
+        with self.assertLogs(self.log, level=logging.DEBUG) as ctx:
+            model.on_write(None, 0x1004, 2, bytes([0xAA, 0xBB]))
+        self.assertEqual(
+            ctx.output, ["DEBUG:test.logaccessmodel:uart0 write addr=0x1004 size=2"]
+        )
+
+    def test_default_name_appears_in_log_message(self):
+        model = LogAccessModel(self.inner, self.log)
+        with self.assertLogs(self.log, level=logging.DEBUG) as ctx:
+            model.on_read(None, 0x1000, 4, b"\x00" * 4)
+        self.assertEqual(
+            ctx.output,
+            ["DEBUG:test.logaccessmodel:RAMMemoryMappedModel read addr=0x1000 size=4"],
+        )
 
 
 class NiceModelTests(ModelTestCase):


### PR DESCRIPTION
This takes an existing MMIO model class,
logs every access that fires on the model,
and passes the event to the inner model for handling.