### PR TITLE
feat: split EmulationExitpoint from EmulationBounds in trace results

### DIFF
--- a/smallworld/analyses/trace_execution.py
+++ b/smallworld/analyses/trace_execution.py
@@ -195,12 +195,17 @@ class TraceExecution(analysis.Analysis):
                 i += 1
                 logger.debug(cs_insn)
                 self.emulator.step()
-            except (
-                smallworld.exceptions.EmulationBounds,
-                smallworld.exceptions.EmulationExitpoint,
-            ):
-                # this one really isnt an error of any kind; we
-                # encountered code we were not supposed to execute
+            except smallworld.exceptions.EmulationExitpoint:
+                # Reached a designated exit point (the harnessed function's
+                # ret/end): a clean, intended completion. Kept distinct from
+                # ER_BOUNDS so callers can tell "the function returned" from
+                # "control escaped the allowed region."
+                emu_result = TraceRes.ER_EXITPOINT
+                break
+            except smallworld.exceptions.EmulationBounds:
+                # Execution left the allowed bounds without hitting an exit
+                # point -- e.g. an indirect jump through a garbage pointer. Not
+                # a hard emulation fault, but not a clean return either.
                 emu_result = TraceRes.ER_BOUNDS
                 break
             except Exception as e:

--- a/smallworld/analyses/trace_execution_types.py
+++ b/smallworld/analyses/trace_execution_types.py
@@ -13,6 +13,11 @@ class TraceRes(Enum):
     ER_BOUNDS = 1
     ER_MAX_INSNS = 2
     ER_FAIL = 3
+    # Reached a designated exit point (e.g. the harnessed function's ret) -- a
+    # clean, intended completion. Distinct from ER_BOUNDS, which is execution
+    # escaping the allowed region (e.g. an indirect jump through a garbage
+    # pointer). Both were formerly collapsed into ER_BOUNDS.
+    ER_EXITPOINT = 4
 
 
 # one element in a trace


### PR DESCRIPTION
Add TraceRes.ER_EXITPOINT and stop collapsing a designated exit point (the harnessed function's ret/end -- a clean, intended completion) into ER_BOUNDS (control escaping the allowed region, e.g. an indirect jump through a garbage pointer). The two were caught by a single except clause, both labelled ER_BOUNDS, and the distinguishing exception discarded ("this one really isnt an error of any kind"). They are now distinct results, so callers can tell "the function returned" from "control escaped bounds."