### PR TITLE
fix: give a value one colorizer color across registers and memory

### DIFF
--- a/smallworld/analyses/colorizer.py
+++ b/smallworld/analyses/colorizer.py
@@ -2,7 +2,6 @@ import copy
 import hashlib
 import logging
 import random
-import struct
 import typing
 
 import capstone
@@ -347,35 +346,26 @@ class Colorizer(analysis.Analysis):
     def _concrete_val_to_color(
         self, concrete_value: typing.Union[int, bytes, bytearray], size: int
     ) -> int:
-        # this concrete value can be an int (if it came from a register)
-        # or bytes (if it came from memory read)
-        # we want these in a common format so that we can see them as colors
-        the_bytes: bytes = b""
+        # A concrete value is either an int (from a register) or bytes (from a
+        # memory read). We fold both to one integer "color" so that the same
+        # value has the same color regardless of where it lives. Memory bytes
+        # are interpreted in the *target's* byte order, so a register value and
+        # its stored image agree on big-endian targets as well as little-endian
+        # ones -- otherwise a plain store looks like it creates a new value on
+        # big-endian.
+        byteorder = self.platform.byteorder.value  # "big" or "little"
         if type(concrete_value) is int:
-            if concrete_value < self.min_color:
-                return BAD_COLOR
-            the_bytes = concrete_value.to_bytes(size, byteorder="little")
+            n = concrete_value
         elif (type(concrete_value) is bytes) or (type(concrete_value) is bytearray):
-            # assuming little-endian
-            if int.from_bytes(concrete_value, byteorder="little") < self.min_color:
-                return BAD_COLOR
-            the_bytes = bytes(concrete_value)
+            n = int.from_bytes(concrete_value, byteorder=byteorder)
         else:
             assert 1 == 0
-        # let's make color a number
+        if n < self.min_color:
+            return BAD_COLOR
+        # A 128-bit value (xmm, ...) doesn't fit a 64-bit color; fold the halves.
         if size == 16:
-            q1 = (struct.unpack("<Q", the_bytes[:8]))[0]
-            q2 = (struct.unpack("<Q", the_bytes[8:]))[0]
-            # i mean this will otherwise be big so lets just combine them
-            return q1 ^ q2
-        if size == 8:
-            return struct.unpack("<Q", the_bytes)[0]
-        if size == 4:
-            return struct.unpack("<L", the_bytes)[0]
-        if size == 2:
-            return struct.unpack("<H", the_bytes)[0]
-        assert size == 1
-        return struct.unpack("<B", the_bytes)[0]
+            return (n & ((1 << 64) - 1)) ^ (n >> 64)
+        return n & ((1 << (8 * size)) - 1)
 
     def _add_color(
         self,

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -5967,6 +5967,78 @@ class ColorizerReadWriteFirstObsGuardTests(unittest.TestCase):
         self.assertEqual(info.addresses, [(3, 0xBEEF0)])
 
 
+class ColorizerBigEndianStoreLoadTests(unittest.TestCase):
+    """A value has the same colorizer color in a register and in memory, on
+    both byte orders.
+
+    The colorizer keys a register value by its integer value and a memory
+    value by ``int.from_bytes(bytes, target_byteorder)`` (colorizer.py
+    ``_concrete_val_to_color``). Interpreting memory in the target byte order
+    is what lets a stored register value keep its color on a big-endian
+    target; reading memory little-endian only would hash the value to
+    byteswap(V) in memory, so a plain store would be misreported as creating a
+    new value (write-def) instead of copying it (write-copy).
+
+    Program (MIPS32), the same instructions in both byte orders:
+        lui $t0, 0xABCD ; ori $t0, $t0, 0x1234 ; sw $t0, 0($sp) ; lw $t1, 0($sp)
+    The store of $t0 must be recognized as a copy under both byte orders.
+    """
+
+    # lui $t0,0xABCD ; ori $t0,$t0,0x1234 ; sw $t0,0($sp) ; lw $t1,0($sp)  (BE)
+    _CODE_BE = bytes.fromhex("3c08abcd" "35081234" "afa80000" "8fa90000")
+    _VALUE = 0xABCD1234
+    _SW_PC = 0x1008
+    _SP = 0x12000  # inside the mapped stack (not the exclusive top)
+
+    @staticmethod
+    def _swap_words(b):
+        return b"".join(b[i : i + 4][::-1] for i in range(0, len(b), 4))
+
+    def _store_write_hint(self, byteorder, code_bytes):
+        from smallworld.analyses.colorizer import Colorizer
+
+        platform = platforms.Platform(platforms.Architecture.MIPS32, byteorder)
+        machine = state.Machine()
+        cpu = state.cpus.CPU.for_platform(platform)
+        machine.add(state.memory.code.Executable.from_bytes(code_bytes, address=0x1000))
+        stack = state.memory.stack.Stack.for_platform(platform, 0x10000, 0x4000)
+        machine.add(stack)
+        cpu.sp.set(self._SP)
+        cpu.pc.set(0x1000)
+        machine.add(cpu)
+        machine.add_exit_point(0x1010)
+
+        hints: list = []
+        hinter = hinting.Hinter()
+        hinter.register(DynamicMemoryValueHint, lambda h: hints.append(h))
+        Colorizer(hinter, num_insns=8, exec_id=0).run(machine)
+
+        writes = [h for h in hints if h.pc == self._SW_PC and not h.use]
+        self.assertEqual(
+            len(writes), 1, f"expected exactly one store-write hint, got {writes}"
+        )
+        return writes[0]
+
+    def _assert_store_is_a_copy(self, byteorder, code_bytes):
+        h = self._store_write_hint(byteorder, code_bytes)
+        self.assertFalse(
+            h.new,
+            "store of a known register value should be a write-copy, got "
+            f"write-def with color 0x{h.color:x}",
+        )
+        self.assertEqual(h.color, self._VALUE)
+
+    def test_le_store_of_register_value_is_a_copy(self):
+        self._assert_store_is_a_copy(
+            platforms.Byteorder.LITTLE, self._swap_words(self._CODE_BE)
+        )
+
+    def test_be_store_of_register_value_is_a_copy(self):
+        # The big-endian case: the register value and its stored image must
+        # share one color, so the store is a copy rather than a new value.
+        self._assert_store_is_a_copy(platforms.Byteorder.BIG, self._CODE_BE)
+
+
 class _FakeAngrMallocEmulator(emulators.AngrEmulator):
     """Just enough AngrEmulator surface for MallocModel.model().
 


### PR DESCRIPTION
The colorizer keyed a register value by its integer value but keyed a memory value by int.from_bytes(bytes, "little") regardless of the target byte order. On big-endian targets the same value V therefore hashed to V in a register and byteswap(V) in memory, so a plain store of a known register value was misreported as creating a new value (write-def) instead of copying it (write-copy), splitting a value's provenance at the register/memory boundary.

_concrete_val_to_color now folds both a register int and memory bytes to a single integer color, interpreting memory in the target's byte order (self.platform.byteorder.value). Little-endian behavior is unchanged (the x86 colorizer truth test still reports "No unexpected results"). Also drops the now-unused `struct` import; the 128-bit half-fold is expressed in integer math.

ColorizerBigEndianStoreLoadTests runs the same MIPS32 store/load program under both byte orders and asserts the store is recognized as a copy either way.