### PR TITLE
refactor: Ghidra language id now in PlatformDef

### DIFF
--- a/smallworld/emulators/ghidra/machdefs/aarch64.py
+++ b/smallworld/emulators/ghidra/machdefs/aarch64.py
@@ -5,7 +5,6 @@ from .machdef import GhidraMachineDef
 class AArch64MachineDef(GhidraMachineDef):
     arch = Architecture.AARCH64
     byteorder = Byteorder.LITTLE
-    language_id = "AARCH64:LE:64:v8A"
 
     _registers = {
         # *** General Purpose Registers ***

--- a/smallworld/emulators/ghidra/machdefs/amd64.py
+++ b/smallworld/emulators/ghidra/machdefs/amd64.py
@@ -7,7 +7,6 @@ from .machdef import GhidraMachineDef
 class AMD64MachineDef(GhidraMachineDef):
     arch: platforms.Architecture = platforms.Architecture.X86_64
     byteorder: platforms.Byteorder = platforms.Byteorder.LITTLE
-    language_id: str = "x86:LE:64:default"
 
     _registers: typing.Dict[str, typing.Optional[str]] = {
         # *** General Purpose Registers ***

--- a/smallworld/emulators/ghidra/machdefs/arm.py
+++ b/smallworld/emulators/ghidra/machdefs/arm.py
@@ -349,22 +349,18 @@ class ARMMachineMixinVFPEL:
 class ARMv5TMachineDef(ARMMachineMixinM, ARMMachineDef):
     arch = Architecture.ARM_V5T
     byteorder = Byteorder.LITTLE
-    language_id = "ARM:LE:32:v5t"
 
 
 class ARMv6MMachineDef(ARMMachineMixinFP, ARMMachineMixinM, ARMMachineDef):
     arch = Architecture.ARM_V6M
     byteorder = Byteorder.LITTLE
-    language_id = "ARM:LE:32:v6"
 
 
 class ARMv7MMachineDef(ARMMachineMixinFP, ARMMachineMixinM, ARMMachineDef):
     arch = Architecture.ARM_V7M
     byteorder = Byteorder.LITTLE
-    language_id = "ARM:LE:32:v7"
 
 
 class ARMv7AMachineDef(ARMMachineMixinVFPEL, ARMMachineMixinRA, ARMMachineDef):
     arch = Architecture.ARM_V7A
     byteorder = Byteorder.LITTLE
-    language_id = "ARM:LE:32:v7"

--- a/smallworld/emulators/ghidra/machdefs/i386.py
+++ b/smallworld/emulators/ghidra/machdefs/i386.py
@@ -5,7 +5,6 @@ from .machdef import GhidraMachineDef
 class i386MachineDef(GhidraMachineDef):
     arch = Architecture.X86_32
     byteorder = Byteorder.LITTLE
-    language_id = "x86:LE:32:default"
 
     _registers = {
         # *** General Purpose Registers ***

--- a/smallworld/emulators/ghidra/machdefs/loongarch.py
+++ b/smallworld/emulators/ghidra/machdefs/loongarch.py
@@ -156,7 +156,6 @@ class LoongArchMachineDef(GhidraMachineDef):
 
 class LoongArch64MachineDef(LoongArchMachineDef):
     arch = Architecture.LOONGARCH64
-    language_id = "Loongarch:LE:64:lp64d"
 
 
 __all__ = ["LoongArch64MachineDef"]

--- a/smallworld/emulators/ghidra/machdefs/m68k.py
+++ b/smallworld/emulators/ghidra/machdefs/m68k.py
@@ -7,7 +7,6 @@ class M68KMachineDef(GhidraMachineDef):
     byteorder = Byteorder.BIG
 
     # This refers specifically to the 68040.
-    language_id = "68000:BE:32:default"
 
     _registers = {
         "d0": "d0",

--- a/smallworld/emulators/ghidra/machdefs/machdef.py
+++ b/smallworld/emulators/ghidra/machdefs/machdef.py
@@ -5,6 +5,7 @@ from ghidra.app.plugin.processors.sleigh import SleighLanguageProvider
 from ghidra.program.model.lang import Language, LanguageID, Register
 
 from .... import exceptions, platforms, utils
+from ....platforms.defs.platformdef import PlatformDef
 
 
 class GhidraMachineDef:
@@ -23,10 +24,21 @@ class GhidraMachineDef:
         raise NotImplementedError("This is an abstract method")
 
     @property
-    @abc.abstractmethod
     def language_id(self) -> str:
-        """The Pcode language ID"""
-        raise NotImplementedError("This is an abstract method")
+        """The Pcode (SLEIGH) language id for this machine.
+
+        Sourced from the platform definition -- the single, JVM-free home
+        for this datum -- rather than duplicated on each machine def.
+        """
+        platdef = PlatformDef.for_platform(
+            platforms.Platform(self.arch, self.byteorder)
+        )
+        lang = platdef.ghidra_language_id
+        assert lang is not None, (
+            f"{type(platdef).__name__} has no ghidra_language_id for "
+            f"{self.arch}:{self.byteorder}"
+        )
+        return lang
 
     # Does Pcode support single-instruction stepping for this ISA.
     #

--- a/smallworld/emulators/ghidra/machdefs/mips.py
+++ b/smallworld/emulators/ghidra/machdefs/mips.py
@@ -155,9 +155,7 @@ class MIPSMachineDef(GhidraMachineDef):
 
 class MIPSELMachineDef(MIPSMachineDef):
     byteorder = Byteorder.LITTLE
-    language_id = "MIPS:LE:32:default"
 
 
 class MIPSBEMachineDef(MIPSMachineDef):
     byteorder = Byteorder.BIG
-    language_id = "MIPS:BE:32:default"

--- a/smallworld/emulators/ghidra/machdefs/mips64.py
+++ b/smallworld/emulators/ghidra/machdefs/mips64.py
@@ -179,9 +179,7 @@ class MIPS64MachineDef(GhidraMachineDef):
 
 class MIPS64ELMachineDef(MIPS64MachineDef):
     byteorder = Byteorder.LITTLE
-    language_id = "MIPS:LE:64:default"
 
 
 class MIPS64BEMachineDef(MIPS64MachineDef):
     byteorder = Byteorder.BIG
-    language_id = "MIPS:BE:64:default"

--- a/smallworld/emulators/ghidra/machdefs/msp430.py
+++ b/smallworld/emulators/ghidra/machdefs/msp430.py
@@ -36,10 +36,6 @@ class MSP430AbsMachineDef(GhidraMachineDef):
 class MSP430MachineDef(MSP430AbsMachineDef):
     arch = Architecture.MSP430
 
-    language_id = "TI_MSP430:LE:16:default"
-
 
 class MSP430XMachineDef(MSP430AbsMachineDef):
     arch = Architecture.MSP430X
-
-    language_id = "TI_MSP430X:LE:32:default"

--- a/smallworld/emulators/ghidra/machdefs/ppc.py
+++ b/smallworld/emulators/ghidra/machdefs/ppc.py
@@ -416,9 +416,7 @@ class PowerPCMachineDef(GhidraMachineDef):
 
 class PowerPC32MachineDef(PowerPCMachineDef):
     arch = Architecture.POWERPC32
-    language_id = "PowerPC:BE:32:default"
 
 
 class PowerPC64MachineDef(PowerPCMachineDef):
     arch = Architecture.POWERPC64
-    language_id = "PowerPC:BE:64:default"

--- a/smallworld/emulators/ghidra/machdefs/riscv.py
+++ b/smallworld/emulators/ghidra/machdefs/riscv.py
@@ -5,7 +5,6 @@ from .machdef import GhidraMachineDef
 class RISCV64MachineDef(GhidraMachineDef):
     arch = Architecture.RISCV64
     byteorder = Byteorder.LITTLE
-    language_id = "RISCV:LE:64:default"
 
     _registers = {
         # *** General-Purpose Registers ***

--- a/smallworld/emulators/ghidra/machdefs/tricore.py
+++ b/smallworld/emulators/ghidra/machdefs/tricore.py
@@ -12,7 +12,6 @@ from .machdef import GhidraMachineDef
 class TriCoreMachineDef(GhidraMachineDef):
     arch = Architecture.TRICORE
     byteorder = Byteorder.LITTLE
-    language_id = "tricore:LE:32:default"
 
     _registers: typing.Dict[str, typing.Optional[str]] = {
         **{f"a{i}": f"a{i}" for i in range(0, 16)},

--- a/smallworld/emulators/ghidra/machdefs/xtensa.py
+++ b/smallworld/emulators/ghidra/machdefs/xtensa.py
@@ -13,9 +13,11 @@ class XTensaMachineDef(GhidraMachineDef):
 
 class XTensaELMachineDef(XTensaMachineDef):
     byteorder = Byteorder.LITTLE
-    language_id = "Xtensa:LE:32:default"
 
 
 class XTensaBEMachineDef(XTensaMachineDef):
     byteorder = Byteorder.BIG
+    # No big-endian Xtensa PlatformDef exists yet, so this machine def keeps
+    # its literal language id until one is added; every other machdef sources
+    # it from PlatformDef.ghidra_language_id.
     language_id = "Xtensa:BE:32:default"

--- a/smallworld/emulators/ghidra/machdefs/xtensa.py
+++ b/smallworld/emulators/ghidra/machdefs/xtensa.py
@@ -17,7 +17,3 @@ class XTensaELMachineDef(XTensaMachineDef):
 
 class XTensaBEMachineDef(XTensaMachineDef):
     byteorder = Byteorder.BIG
-    # No big-endian Xtensa PlatformDef exists yet, so this machine def keeps
-    # its literal language id until one is added; every other machdef sources
-    # it from PlatformDef.ghidra_language_id.
-    language_id = "Xtensa:BE:32:default"

--- a/smallworld/platforms/defs/__init__.py
+++ b/smallworld/platforms/defs/__init__.py
@@ -11,7 +11,7 @@ from .platformdef import PlatformDef, RegisterAliasDef, RegisterDef
 from .powerpc import PowerPC32, PowerPC64
 from .riscv import RiscV64
 from .tricore import TriCore
-from .xtensa import Xtensa
+from .xtensa import Xtensa, XtensaBE
 
 __all__ = [
     "AArch64",
@@ -40,4 +40,5 @@ __all__ = [
     "RiscV64",
     "TriCore",
     "Xtensa",
+    "XtensaBE",
 ]

--- a/smallworld/platforms/defs/aarch64.py
+++ b/smallworld/platforms/defs/aarch64.py
@@ -7,6 +7,7 @@ from .platformdef import PlatformDef, RegisterAliasDef, RegisterDef
 class AArch64(PlatformDef):
     architecture = Architecture.AARCH64
     byteorder = Byteorder.LITTLE
+    ghidra_language_id = "AARCH64:LE:64:v8A"
 
     address_size = 8
     capstone_arch = capstone.CS_ARCH_ARM64

--- a/smallworld/platforms/defs/amd64.py
+++ b/smallworld/platforms/defs/amd64.py
@@ -324,6 +324,7 @@ class AMD64BasePlatformDef(PlatformDef):
 
 class AMD64(AMD64BasePlatformDef):
     architecture = Architecture.X86_64
+    ghidra_language_id = "x86:LE:64:default"
 
     registers = AMD64BasePlatformDef.registers | {
         # *** SSE/AVX/AVX2 registers ***

--- a/smallworld/platforms/defs/arm.py
+++ b/smallworld/platforms/defs/arm.py
@@ -482,12 +482,14 @@ class ARMv5T(ARMPlatformMixinM, ARMPlatformDef):
     """Platform definition for ARMv5t little-endian."""
 
     architecture = Architecture.ARM_V5T
+    ghidra_language_id = "ARM:LE:32:v5t"
 
 
 class ARMv6M(ARMPlatformMixinFPEL, ARMPlatformMixinM, ARMPlatformDef):
     """Platform definition for ARMv6m little-endian."""
 
     architecture = Architecture.ARM_V6M
+    ghidra_language_id = "ARM:LE:32:v6"
 
 
 class ARMv6MThumb(ARMv6M):
@@ -499,12 +501,17 @@ class ARMv6MThumb(ARMv6M):
     """
 
     architecture = Architecture.ARM_V6M_THUMB
+    # Don't inherit ARMv6M's language id: this platform has no Ghidra machine
+    # def, and main associated no Ghidra language with it. Leave it unset so
+    # the refactor introduces no new (Thumb -> v6) association.
+    ghidra_language_id = None
 
 
 class ARMv7M(ARMPlatformMixinFPEL, ARMPlatformMixinM, ARMPlatformDef):
     """Platform definition for ARMv7m little-endian"""
 
     architecture = Architecture.ARM_V7M
+    ghidra_language_id = "ARM:LE:32:v7"
 
 
 class ARMv7R(ARMPlatformMixinVFPEL, ARMPlatformMixinRA, ARMPlatformDef):
@@ -517,3 +524,4 @@ class ARMv7A(ARMPlatformMixinVFPEL, ARMPlatformMixinRA, ARMPlatformDef):
     """Platform definition for ARMv7a little-endian"""
 
     architecture = Architecture.ARM_V7A
+    ghidra_language_id = "ARM:LE:32:v7"

--- a/smallworld/platforms/defs/arm.py
+++ b/smallworld/platforms/defs/arm.py
@@ -501,10 +501,9 @@ class ARMv6MThumb(ARMv6M):
     """
 
     architecture = Architecture.ARM_V6M_THUMB
-    # Don't inherit ARMv6M's language id: this platform has no Ghidra machine
-    # def, and main associated no Ghidra language with it. Leave it unset so
-    # the refactor introduces no new (Thumb -> v6) association.
-    ghidra_language_id = None
+    # ARMv6-M is Thumb; Ghidra decodes Thumb via the TMode context register
+    # within the same SLEIGH language, so this shares ARMv6M's language id.
+    ghidra_language_id = "ARM:LE:32:v6"
 
 
 class ARMv7M(ARMPlatformMixinFPEL, ARMPlatformMixinM, ARMPlatformDef):

--- a/smallworld/platforms/defs/i386.py
+++ b/smallworld/platforms/defs/i386.py
@@ -7,6 +7,7 @@ from .platformdef import PlatformDef, RegisterAliasDef, RegisterDef
 class I386(PlatformDef):
     architecture = Architecture.X86_32
     byteorder = Byteorder.LITTLE
+    ghidra_language_id = "x86:LE:32:default"
 
     address_size = 4
 

--- a/smallworld/platforms/defs/loongarch.py
+++ b/smallworld/platforms/defs/loongarch.py
@@ -264,6 +264,7 @@ class LoongArchPlatformDef(PlatformDef):
 
 class LoongArch64(LoongArchPlatformDef):
     architecture = Architecture.LOONGARCH64
+    ghidra_language_id = "Loongarch:LE:64:lp64d"
     address_size = 8
 
 

--- a/smallworld/platforms/defs/m68k.py
+++ b/smallworld/platforms/defs/m68k.py
@@ -7,6 +7,7 @@ from .platformdef import PlatformDef, RegisterAliasDef, RegisterDef
 class M68K(PlatformDef):
     architecture = Architecture.M68K
     byteorder = Byteorder.BIG
+    ghidra_language_id = "68000:BE:32:default"
 
     address_size = 4
 

--- a/smallworld/platforms/defs/mips.py
+++ b/smallworld/platforms/defs/mips.py
@@ -289,6 +289,7 @@ class MIPSO32PlatformDef(PlatformDef):
 
 class MIPS32EL(MIPSO32PlatformDef):
     byteorder = Byteorder.LITTLE
+    ghidra_language_id = "MIPS:LE:32:default"
 
     def __init__(self):
         super().__init__()
@@ -313,6 +314,7 @@ class MIPS32EL(MIPSO32PlatformDef):
 
 class MIPS32BE(MIPSO32PlatformDef):
     byteorder = Byteorder.BIG
+    ghidra_language_id = "MIPS:BE:32:default"
 
     capstone_mode = capstone.CS_MODE_MIPS32 | capstone.CS_MODE_BIG_ENDIAN
 

--- a/smallworld/platforms/defs/mips64.py
+++ b/smallworld/platforms/defs/mips64.py
@@ -281,6 +281,7 @@ class MIPSN64PlatformDef(PlatformDef):
 
 class MIPS64EL(MIPSN64PlatformDef):
     byteorder = Byteorder.LITTLE
+    ghidra_language_id = "MIPS:LE:64:default"
 
     def __init__(self):
         super().__init__()
@@ -305,6 +306,7 @@ class MIPS64EL(MIPSN64PlatformDef):
 
 class MIPS64BE(MIPSN64PlatformDef):
     byteorder = Byteorder.BIG
+    ghidra_language_id = "MIPS:BE:64:default"
 
     capstone_mode = capstone.CS_MODE_MIPS64 | capstone.CS_MODE_BIG_ENDIAN
 

--- a/smallworld/platforms/defs/msp430.py
+++ b/smallworld/platforms/defs/msp430.py
@@ -94,6 +94,7 @@ class MSP430(MSP430Def):
     """Platform definition for TI msp430 16-bit CPUs"""
 
     architecture = Architecture.MSP430
+    ghidra_language_id = "TI_MSP430:LE:16:default"
     address_size = 2
 
 
@@ -101,4 +102,5 @@ class MSP430X(MSP430Def):
     """Platform definition for TI msp430x 20-bit CPUs"""
 
     architecture = Architecture.MSP430X
+    ghidra_language_id = "TI_MSP430X:LE:32:default"
     address_size = 4

--- a/smallworld/platforms/defs/platformdef.py
+++ b/smallworld/platforms/defs/platformdef.py
@@ -19,6 +19,11 @@ class RegisterAliasDef(RegisterDef):
 
 
 class PlatformDef(metaclass=abc.ABCMeta):
+    #: Ghidra/SLEIGH language id (arch+byteorder) -- the single source of
+    #: truth for both the Ghidra emulator's machine defs and the pcode
+    #: analysis. None if this platform has no Ghidra language.
+    ghidra_language_id: typing.Optional[str] = None
+
     @property
     @abc.abstractmethod
     def architecture(self) -> Architecture:

--- a/smallworld/platforms/defs/powerpc.py
+++ b/smallworld/platforms/defs/powerpc.py
@@ -575,6 +575,7 @@ class PowerPCPlatformDef(PlatformDef):
 
 class PowerPC32(PowerPCPlatformDef):
     architecture = Architecture.POWERPC32
+    ghidra_language_id = "PowerPC:BE:32:default"
 
     address_size = 4
     capstone_mode = capstone.CS_MODE_32 | capstone.CS_MODE_BIG_ENDIAN
@@ -582,6 +583,7 @@ class PowerPC32(PowerPCPlatformDef):
 
 class PowerPC64(PowerPCPlatformDef):
     architecture = Architecture.POWERPC64
+    ghidra_language_id = "PowerPC:BE:64:default"
 
     address_size = 8
     capstone_mode = capstone.CS_MODE_64 | capstone.CS_MODE_BIG_ENDIAN

--- a/smallworld/platforms/defs/riscv.py
+++ b/smallworld/platforms/defs/riscv.py
@@ -14,6 +14,7 @@ from .platformdef import PlatformDef, RegisterAliasDef, RegisterDef
 class RiscV64(PlatformDef):
     architecture = Architecture.RISCV64
     byteorder = Byteorder.LITTLE
+    ghidra_language_id = "RISCV:LE:64:default"
 
     address_size = 8
 

--- a/smallworld/platforms/defs/tricore.py
+++ b/smallworld/platforms/defs/tricore.py
@@ -27,6 +27,7 @@ TRICORE_REGISTER_ALIASES = {
 class TriCore(PlatformDef):
     architecture = Architecture.TRICORE
     byteorder = Byteorder.LITTLE
+    ghidra_language_id = "tricore:LE:32:default"
 
     address_size = 4
 

--- a/smallworld/platforms/defs/xtensa.py
+++ b/smallworld/platforms/defs/xtensa.py
@@ -95,3 +95,15 @@ class Xtensa(PlatformDef):
         # This thing is actually 6 bits.
         "sar": RegisterDef(name="sar", size=4),
     }
+
+
+class XtensaBE(Xtensa):
+    """Big-endian Xtensa.
+
+    Same register model as little-endian Xtensa -- register names don't depend
+    on byte order -- so only the byte order and the Ghidra language differ.
+    Capstone does not support Xtensa in either byte order (arch/mode -1).
+    """
+
+    byteorder = Byteorder.BIG
+    ghidra_language_id = "Xtensa:BE:32:default"

--- a/smallworld/platforms/defs/xtensa.py
+++ b/smallworld/platforms/defs/xtensa.py
@@ -12,6 +12,7 @@ from .platformdef import PlatformDef, RegisterAliasDef, RegisterDef
 class Xtensa(PlatformDef):
     architecture = Architecture.XTENSA
     byteorder = Byteorder.LITTLE
+    ghidra_language_id = "Xtensa:LE:32:default"
 
     address_size = 4
 


### PR DESCRIPTION
The Ghidra/SLEIGH language id (e.g. MIPS:BE:32:default) for each platform was hardcoded on the emulator's machine defs. This moves it to a JVM-free ghidra_language_id field on PlatformDef — keyed, like the machine defs, by (architecture, byteorder) — and makes GhidraMachineDef.language_id read it via PlatformDef.for_platform(), so the data lives in exactly one place. The Ghidra emulator is the only consumer (LanguageID(self.language_id) in the machdef constructor), so this is a pure relocation with no behavior change; it also gives the upcoming p-code use/def work a single place to read language ids from instead of re-hardcoding them on the instruction classes. Two small gaps are closed along the way: a big-endian Xtensa PlatformDef is added (so no machine def needs a hardcoded fallback), and ARMv6MThumb gets ARM:LE:32:v6 (Thumb is decoded via the TMode context of the same SLEIGH language). Verified with lint/mypy plus a runtime check that constructs all 21 machine defs and loads each one's Ghidra language through the new property.
