### PR TITLE
refactor: source the SuperH Ghidra language ids from PlatformDef

### DIFF
--- a/smallworld/emulators/ghidra/machdefs/superh.py
+++ b/smallworld/emulators/ghidra/machdefs/superh.py
@@ -27,7 +27,6 @@ SH2A_CONTROL_REGISTERS = (
 class SH2AFPUMachineDef(GhidraMachineDef):
     arch = Architecture.SUPERH_SH2A_FPU
     byteorder = Byteorder.BIG
-    language_id = "SuperH:BE:32:SH-2A"
 
     # Ghidra folds a SuperH delay slot into the translation of the branch that
     # owns it, so one "step" covers both instructions and is safe. Compare

--- a/smallworld/emulators/ghidra/machdefs/superh4.py
+++ b/smallworld/emulators/ghidra/machdefs/superh4.py
@@ -36,8 +36,10 @@ SH4_GHIDRA_NAMES = {
 class SuperH4MachineDef(GhidraMachineDef):
     """Shared SH-4/SH-4A definition.
 
-    Has no ``byteorder`` or ``language_id``, so ``find_subclass`` never selects
-    it; the concrete subclasses below do.
+    Has no ``byteorder``, so ``find_subclass`` -- which selects on
+    ``arch``/``byteorder`` -- never picks it; the concrete subclasses below
+    carry the byte order and, through their platform definitions, the language
+    id.
     """
 
     arch = Architecture.SUPERH_SH4
@@ -84,12 +86,10 @@ class SuperH4MachineDef(GhidraMachineDef):
 
 class SuperH4BEMachineDef(SuperH4MachineDef):
     byteorder = Byteorder.BIG
-    language_id = "SuperH4:BE:32:default"
 
 
 class SuperH4ELMachineDef(SuperH4MachineDef):
     byteorder = Byteorder.LITTLE
-    language_id = "SuperH4:LE:32:default"
 
     # Undo sleigh's unswapped alternate-bank names; see the note on
     # `_registers` above. Measured on `SuperH4:LE:32:default`: xd0 sits at

--- a/smallworld/platforms/defs/superh.py
+++ b/smallworld/platforms/defs/superh.py
@@ -96,6 +96,7 @@ class SH2AFPU(PlatformDef):
 
     architecture = Architecture.SUPERH_SH2A_FPU
     byteorder = Byteorder.BIG
+    ghidra_language_id = "SuperH:BE:32:SH-2A"
 
     address_size = 4
 

--- a/smallworld/platforms/defs/superh4.py
+++ b/smallworld/platforms/defs/superh4.py
@@ -146,6 +146,7 @@ class SuperH4Def(PlatformDef):
 
 class SuperH4BE(SuperH4Def):
     byteorder = Byteorder.BIG
+    ghidra_language_id = "SuperH4:BE:32:default"
 
     capstone_mode = (
         capstone.CS_MODE_SH4A | capstone.CS_MODE_SHFPU | capstone.CS_MODE_BIG_ENDIAN
@@ -154,5 +155,6 @@ class SuperH4BE(SuperH4Def):
 
 class SuperH4EL(SuperH4Def):
     byteorder = Byteorder.LITTLE
+    ghidra_language_id = "SuperH4:LE:32:default"
 
     capstone_mode = capstone.CS_MODE_SH4A | capstone.CS_MODE_SHFPU

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -1847,6 +1847,84 @@ class GhidraMachdefTests(unittest.TestCase):
         self.run_test(platform)
 
 
+class GhidraMachdefLanguageIdTests(unittest.TestCase):
+    """The SLEIGH language id belongs to PlatformDef, not the machine defs.
+
+    ``GhidraMachineDef.language_id`` is a property that reads
+    ``PlatformDef.ghidra_language_id``, so the id has one home shared by the
+    Ghidra emulator and the p-code use/def analysis. A machine def that
+    declares its own ``language_id`` shadows that property, and the failure
+    is silent and one-sided: the emulator keeps working off the literal
+    while the platform definition reports ``None`` to everyone else. That
+    regressed once already, when the SuperH machine defs were written in
+    parallel with the refactor that centralized the ids, so assert it.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # machdefs/machdef.py imports Ghidra Java classes at module scope,
+        # so the JVM must be up before the module can be imported at all.
+        _ensure_pyghidra_started()
+
+    @staticmethod
+    def _machdefs():
+        """Every GhidraMachineDef subclass, abstract bases included."""
+        import smallworld.emulators.ghidra.machdefs  # noqa: F401  (registers them)
+        from smallworld.emulators.ghidra.machdefs.machdef import GhidraMachineDef
+
+        found, stack = [], list(GhidraMachineDef.__subclasses__())
+        while stack:
+            machdef = stack.pop()
+            found.append(machdef)
+            stack.extend(machdef.__subclasses__())
+        return found
+
+    def test_no_machdef_declares_its_own_language_id(self):
+        shadowed = sorted(
+            machdef.__name__
+            for machdef in self._machdefs()
+            if "language_id" in vars(machdef)
+        )
+        self.assertEqual(
+            shadowed,
+            [],
+            msg=f"machine defs shadowing the language_id property: {shadowed}; "
+            f"set ghidra_language_id on the platform definition instead",
+        )
+
+    def test_every_machdef_resolves_its_platform_language_id(self):
+        from smallworld.emulators.ghidra.machdefs.machdef import GhidraMachineDef
+
+        checked = 0
+        for machdef in self._machdefs():
+            arch = getattr(machdef, "arch", None)
+            byteorder = getattr(machdef, "byteorder", None)
+            if not isinstance(arch, platforms.Architecture) or not isinstance(
+                byteorder, platforms.Byteorder
+            ):
+                # A shared base (e.g. SuperH4MachineDef) that leaves one of
+                # them abstract; find_subclass never selects it.
+                continue
+            checked += 1
+            with self.subTest(machdef=machdef.__name__):
+                platdef = platforms.PlatformDef.for_platform(
+                    platforms.Platform(arch, byteorder)
+                )
+                self.assertIsNotNone(
+                    platdef.ghidra_language_id,
+                    msg=f"{machdef.__name__} is selectable for {arch}:{byteorder} "
+                    f"but {type(platdef).__name__} defines no ghidra_language_id",
+                )
+                # Read the property off the class rather than constructing:
+                # GhidraMachineDef.__init__ loads the SLEIGH language, which
+                # is far more work than resolving the id it is asked for.
+                resolved = GhidraMachineDef.language_id.fget(machdef)
+                self.assertEqual(resolved, platdef.ghidra_language_id)
+
+        # Guard against the loop silently skipping everything.
+        self.assertGreater(checked, 0, msg="no concrete machine defs found")
+
+
 class CoverageHarnessTests(unittest.TestCase):
     def test_wrap_python_command_passthrough_when_coverage_disabled(self):
         argv = [sys.executable, "demo.py"]


### PR DESCRIPTION
#433 moved every SLEIGH language id into `PlatformDef.ghidra_language_id` and made`GhidraMachineDef.language_id` a property that reads it, so the Ghidra emulator and the p-code use/def analysis share one JVM-free source of truth. #432 (SuperH) was written before that landed and merged the same day, adding three machine defs that declare their own `language_id` — harmless in itself, since a class attribute shadows the property, but the SuperH platform definitions never gained the id, so they report`None` to every other consumer. This moves the three ids onto `SH2AFPU`, `SuperH4BE` and `SuperH4EL`, drops the machine-def literals (no behavior change — the property  returns the same strings), and adds a test asserting the invariant, which nothing  previously checked.
