### PR TITLE
fix: track address vs value register roles in p-code use/def 

### DIFF
--- a/smallworld/analyses/__init__.py
+++ b/smallworld/analyses/__init__.py
@@ -39,7 +39,7 @@ except ImportError:
 
 from .loop_detection import LoopDetection
 from .trace_execution import TraceExecution
-from .trace_execution_types import CmpInfo, TraceElement, TraceRes
+from .trace_execution_types import CmpEntry, CmpInfo, TraceElement, TraceRes
 
 __all__ += [
     "Colorizer",
@@ -48,6 +48,7 @@ __all__ += [
     "TraceExecution",
     "TraceElement",
     "TraceRes",
+    "CmpEntry",
     "CmpInfo",
     "LoopDetection",
     "CoverageFrontier",

--- a/smallworld/analyses/trace_execution.py
+++ b/smallworld/analyses/trace_execution.py
@@ -51,29 +51,15 @@ def get_cmp_info(
     emulator: smallworld.emulators.Emulator,
     cs_insn: capstone.CsInsn,
 ) -> typing.List[CmpEntry]:
-    """For a comparison instruction, report what is being compared.
+    """What a comparison instruction compares: one CmpEntry per compared
+    thing, each carrying the value observed at this point in the trace.
 
-    One CmpEntry per compared thing: the locations the compare reads —
-    register and memory Operands, from the pcode-based use/def analysis
-    (Instruction.reads) — and its immediate operands, each carrying the
-    concrete value observed while the emulator sits exactly at this
-    compare. Empty for anything that is not a compare, and for a compare
-    whose use/def cannot be interpreted (degrading rather than aborting
-    the trace).
-
-    Registers that only serve to form an included memory operand's
-    address (rbp in 'cmp [rbp-0x1c], 47') are omitted: the compared
-    value is the memory cell, not the pointer. Location entries are
-    deduplicated and sorted by repr — stable run to run, and a compare
-    of a location against itself (test al, al) reports it once — with
-    immediates after them in decode order. No lhs/rhs order is promised.
-
-    Immediates come from the decoded operands: use/def reports
-    locations, and a constant is not a location. Compare-and-branch
-    instructions (pdefs.compare_branch_mnemonics: MIPS beq, AArch64
-    cbz/tbz, x86 jrcxz, PPC bdnz) are included — they embed the
-    comparison the branch decides on — but their final immediate is the
-    branch target, not a compared value, and is excluded.
+    Locations come from Instruction.reads, deduplicated and repr-sorted
+    (test al, al reports al once; no lhs/rhs order is promised);
+    immediates follow in decode order. Compare-and-branch instructions
+    (compare_branch_mnemonics) are included, minus their final immediate
+    -- the branch target. Empty means not a compare, or one whose use/def
+    could not be interpreted (degrade, never abort the trace).
     """
     pdefs = platforms.defs.PlatformDef.for_platform(platform)
     is_compare = cs_insn.mnemonic in pdefs.compare_mnemonics
@@ -81,19 +67,10 @@ def get_cmp_info(
     if not (is_compare or is_compare_branch):
         return []
     try:
-        # This runs per instruction inside a live trace: an uninterpretable
-        # compare degrades to "no cmp info" rather than aborting the run.
-        # reads itself degrades internally (see Instruction._pcode_result),
-        # so the expected raiser here is from_bytes's ValueError for an
-        # ISA with no Instruction subclass (superh, riscv, tricore, ...),
-        # all of which define compare_mnemonics. Anything else is a bug or
-        # new behavior and propagates.
-        #
-        # from_bytes with the caller's platform, NOT from_capstone: the
-        # capstone arch/mode pair is ambiguous where platforms share it
-        # (every ARM-mode variant), and from_capstone picked an arbitrary
-        # one -- ARMV7R, whose platform has no Ghidra language, silently
-        # downgrading every ARM compare to the Capstone fallback.
+        # from_bytes with the caller's platform -- from_capstone selects by
+        # capstone arch/mode, which is ambiguous across the ARM variants.
+        # The expected ValueError is an ISA with no Instruction subclass;
+        # anything else is a bug and propagates.
         sw_insn = smallworld.instructions.Instruction.from_bytes(
             bytes(cs_insn.bytes), cs_insn.address, platform
         )
@@ -107,25 +84,15 @@ def get_cmp_info(
             for name in (op.base, op.index):
                 if name is not None:
                     address_regs.add(name)
-    # The compared locations: the read set, minus operands whose role is
-    # not "a compared value" --
-    #  * registers that only form an included memory operand's address
-    #    (rbp in `cmp [rbp-0x1c], 47` is a pointer, not a quantity).
-    #    KNOWN IMPRECISION: this assumes the address-forming and compared
-    #    roles are disjoint. `cmp rax, [rax]` violates that -- rax is both
-    #    -- and gets reported as [rax] alone; telling the roles apart needs
-    #    per-operand provenance a read SET does not carry.
-    #  * the platform's status register: ARM data-processing reads the
-    #    carry through the barrel shifter, so under the flags mapping a
-    #    plain `cmp r0, r1` reads cpsr -- a dependency, but not a compared
-    #    value.
+    # Compared locations: reads, minus non-value roles -- address-forming
+    # registers (rbp in `cmp [rbp-0x1c], 47`) and the status register (a
+    # plain ARM cmp reads the carry via the barrel shifter). KNOWN
+    # IMPRECISION: `cmp rax, [rax]` reports only [rax] -- rax is both
+    # pointer and compared value, and a read SET cannot say which.
     locations = sorted(
         (
             op
             for op in reads
-            # The isinstance narrows Operand to what a CmpEntry can carry as
-            # well as filtering: reads can in principle hold other Operand
-            # kinds, which have no place in a compare report.
             if isinstance(op, (RegisterOperand, BSIDMemoryReferenceOperand))
             and not (
                 isinstance(op, RegisterOperand)

--- a/smallworld/analyses/trace_execution.py
+++ b/smallworld/analyses/trace_execution.py
@@ -50,22 +50,23 @@ def get_cmp_info(
     platform: smallworld.platforms.Platform,
     emulator: smallworld.emulators.Emulator,
     cs_insn: capstone.CsInsn,
-) -> typing.List[CmpEntry]:
-    """What a comparison instruction compares: one CmpEntry per compared
-    thing, each carrying the value observed at this point in the trace.
+) -> typing.Tuple[typing.List[CmpEntry], typing.List[int]]:
+    """What a comparison instruction compares: (locations, immediates).
 
     Locations come from Instruction.reads, deduplicated and repr-sorted
-    (test al, al reports al once; no lhs/rhs order is promised);
-    immediates follow in decode order. Compare-and-branch instructions
-    (compare_branch_mnemonics) are included, minus their final immediate
-    -- the branch target. Empty means not a compare, or one whose use/def
-    could not be interpreted (degrade, never abort the trace).
+    (test al, al reports al once; no lhs/rhs order is promised), each with
+    the value observed at this point in the trace. Immediates are in
+    decode order -- two independent lists, not aligned. Compare-and-branch
+    instructions (compare_branch_mnemonics) are included, minus their
+    final immediate, the branch target. Empty means not a compare, or one
+    whose use/def could not be interpreted (degrade, never abort the
+    trace).
     """
     pdefs = platforms.defs.PlatformDef.for_platform(platform)
     is_compare = cs_insn.mnemonic in pdefs.compare_mnemonics
     is_compare_branch = cs_insn.mnemonic in pdefs.compare_branch_mnemonics
     if not (is_compare or is_compare_branch):
-        return []
+        return ([], [])
     try:
         # from_bytes with the caller's platform -- from_capstone selects by
         # capstone arch/mode, which is ambiguous across the ARM variants.
@@ -77,7 +78,7 @@ def get_cmp_info(
         reads = sw_insn.reads
     except ValueError as exc:
         logger.info(f"get_cmp_info: no Instruction for {cs_insn.mnemonic}: {exc}")
-        return []
+        return ([], [])
     address_regs = set()
     for op in reads:
         if isinstance(op, BSIDMemoryReferenceOperand):
@@ -108,10 +109,13 @@ def get_cmp_info(
     byteorder: typing.Literal["little", "big"] = (
         "little" if pdefs.byteorder is platforms.Byteorder.LITTLE else "big"
     )
-    return [
-        CmpEntry(source=op, value=_concrete_cmp_value(op, emulator, byteorder))
-        for op in locations
-    ] + [CmpEntry(source=int(op.value.imm), value=int(op.value.imm)) for op in imm_ops]
+    return (
+        [
+            CmpEntry(source=op, value=_concrete_cmp_value(op, emulator, byteorder))
+            for op in locations
+        ],
+        [int(op.value.imm) for op in imm_ops],
+    )
 
 
 class TraceExecution(analysis.Analysis):
@@ -201,21 +205,16 @@ class TraceExecution(analysis.Analysis):
                     f"no decodable instruction at pc {pc:#x}"
                 )
                 break
-            cmp_entries = get_cmp_info(self.platform, self.emulator, cs_insn)
+            cmp_entries, cmp_imms = get_cmp_info(self.platform, self.emulator, cs_insn)
             branch_info = cs_insn.mnemonic in pdefs.conditional_branch_mnemonics
-            # TraceElement keeps its historical parallel-list shape (cmp /
-            # immediates / index-aligned cmp_values): its pickled form and
-            # its consumers (magrathea) depend on it. Derived here from the
-            # self-contained entries; immediates are the int-sourced ones.
             te = TraceElement(
                 pc,
                 i,
                 cs_insn.mnemonic,
                 cs_insn.op_str,
-                [e.source for e in cmp_entries],
+                cmp_entries,
                 branch_info,
-                [e.source for e in cmp_entries if isinstance(e.source, int)],
-                [e.value for e in cmp_entries],
+                cmp_imms,
             )
             trace.append(te)
             # run any callbacks

--- a/smallworld/analyses/trace_execution.py
+++ b/smallworld/analyses/trace_execution.py
@@ -84,11 +84,19 @@ def get_cmp_info(
         # This runs per instruction inside a live trace: an uninterpretable
         # compare degrades to "no cmp info" rather than aborting the run.
         # reads itself degrades internally (see Instruction._pcode_result),
-        # so the expected raiser here is from_capstone's ValueError for an
+        # so the expected raiser here is from_bytes's ValueError for an
         # ISA with no Instruction subclass (superh, riscv, tricore, ...),
         # all of which define compare_mnemonics. Anything else is a bug or
         # new behavior and propagates.
-        sw_insn = smallworld.instructions.Instruction.from_capstone(cs_insn)
+        #
+        # from_bytes with the caller's platform, NOT from_capstone: the
+        # capstone arch/mode pair is ambiguous where platforms share it
+        # (every ARM-mode variant), and from_capstone picked an arbitrary
+        # one -- ARMV7R, whose platform has no Ghidra language, silently
+        # downgrading every ARM compare to the Capstone fallback.
+        sw_insn = smallworld.instructions.Instruction.from_bytes(
+            bytes(cs_insn.bytes), cs_insn.address, platform
+        )
         reads = sw_insn.reads
     except ValueError as exc:
         logger.info(f"get_cmp_info: no Instruction for {cs_insn.mnemonic}: {exc}")
@@ -99,6 +107,18 @@ def get_cmp_info(
             for name in (op.base, op.index):
                 if name is not None:
                     address_regs.add(name)
+    # The compared locations: the read set, minus operands whose role is
+    # not "a compared value" --
+    #  * registers that only form an included memory operand's address
+    #    (rbp in `cmp [rbp-0x1c], 47` is a pointer, not a quantity).
+    #    KNOWN IMPRECISION: this assumes the address-forming and compared
+    #    roles are disjoint. `cmp rax, [rax]` violates that -- rax is both
+    #    -- and gets reported as [rax] alone; telling the roles apart needs
+    #    per-operand provenance a read SET does not carry.
+    #  * the platform's status register: ARM data-processing reads the
+    #    carry through the barrel shifter, so under the flags mapping a
+    #    plain `cmp r0, r1` reads cpsr -- a dependency, but not a compared
+    #    value.
     locations = sorted(
         (
             op
@@ -107,7 +127,10 @@ def get_cmp_info(
             # well as filtering: reads can in principle hold other Operand
             # kinds, which have no place in a compare report.
             if isinstance(op, (RegisterOperand, BSIDMemoryReferenceOperand))
-            and not (isinstance(op, RegisterOperand) and op.name in address_regs)
+            and not (
+                isinstance(op, RegisterOperand)
+                and (op.name in address_regs or op.name == pdefs.status_register)
+            )
         ),
         key=repr,
     )

--- a/smallworld/analyses/trace_execution.py
+++ b/smallworld/analyses/trace_execution.py
@@ -7,7 +7,7 @@ from enum import Enum
 import capstone
 
 import smallworld
-from smallworld.analyses.trace_execution_types import CmpInfo, TraceElement, TraceRes
+from smallworld.analyses.trace_execution_types import CmpEntry, TraceElement, TraceRes
 from smallworld.instructions import BSIDMemoryReferenceOperand, RegisterOperand
 
 from .. import platforms
@@ -50,50 +50,36 @@ def get_cmp_info(
     platform: smallworld.platforms.Platform,
     emulator: smallworld.emulators.Emulator,
     cs_insn: capstone.CsInsn,
-) -> typing.Tuple[
-    typing.List[CmpInfo], typing.List[typing.Optional[int]], typing.List[int]
-]:
+) -> typing.List[CmpEntry]:
     """For a comparison instruction, report what is being compared.
 
-    Returns (cmp_info, cmp_values, immediates). cmp_info holds the
-    locations the compare reads — register and memory Operands, taken
-    from the pcode-based use/def analysis (Instruction.reads) —
-    followed by any immediate operands. Registers that only serve to
-    form an included memory operand's address (rbp in
-    'cmp [rbp-0x1c], 47') are omitted: the compared value is the memory
-    cell, not the pointer.
+    One CmpEntry per compared thing: the locations the compare reads —
+    register and memory Operands, from the pcode-based use/def analysis
+    (Instruction.reads) — and its immediate operands, each carrying the
+    concrete value observed while the emulator sits exactly at this
+    compare. Empty for anything that is not a compare, and for a compare
+    whose use/def cannot be interpreted (degrading rather than aborting
+    the trace).
 
-    The location entries are deduplicated and sorted by repr; the
-    immediates follow, in decode order. Repr order (not operand order)
-    is deliberate and matches how the colorizer orders its own
-    read/write tuples: it makes traces stable run to run regardless of
-    the order the analysis happens to yield reads, and lets a compare
-    of a location against itself (test al, al) report it once.
-    cmp_values below is aligned to this final order, so consumers must
-    not assume operand (destination-first) order.
-
-    If the pcode use/def analysis cannot interpret this instruction,
-    the three lists come back empty rather than aborting the trace.
-
-    cmp_values is index-aligned with cmp_info: the concrete value of
-    each entry read from the live emulator now, while it sits exactly
-    at this compare (an immediate maps to itself; a register/memory
-    operand to its integer value, or None if it could not be read).
+    Registers that only serve to form an included memory operand's
+    address (rbp in 'cmp [rbp-0x1c], 47') are omitted: the compared
+    value is the memory cell, not the pointer. Location entries are
+    deduplicated and sorted by repr — stable run to run, and a compare
+    of a location against itself (test al, al) reports it once — with
+    immediates after them in decode order. No lhs/rhs order is promised.
 
     Immediates come from the decoded operands: use/def reports
-    locations, and a constant is not a location.
-
-    Compare-and-branch instructions (pdefs.compare_branch_mnemonics:
-    MIPS beq, AArch64 cbz/tbz, x86 jrcxz, PPC bdnz) are reported too —
-    they embed the comparison the branch decides on. For those, the
-    final immediate operand is the branch target, not a compared
-    value, so it is excluded.
+    locations, and a constant is not a location. Compare-and-branch
+    instructions (pdefs.compare_branch_mnemonics: MIPS beq, AArch64
+    cbz/tbz, x86 jrcxz, PPC bdnz) are included — they embed the
+    comparison the branch decides on — but their final immediate is the
+    branch target, not a compared value, and is excluded.
     """
     pdefs = platforms.defs.PlatformDef.for_platform(platform)
     is_compare = cs_insn.mnemonic in pdefs.compare_mnemonics
     is_compare_branch = cs_insn.mnemonic in pdefs.compare_branch_mnemonics
     if not (is_compare or is_compare_branch):
-        return ([], [], [])
+        return []
     try:
         # This runs per instruction inside a live trace: an uninterpretable
         # compare degrades to "no cmp info" rather than aborting the run.
@@ -106,18 +92,18 @@ def get_cmp_info(
         reads = sw_insn.reads
     except ValueError as exc:
         logger.info(f"get_cmp_info: no Instruction for {cs_insn.mnemonic}: {exc}")
-        return ([], [], [])
+        return []
     address_regs = set()
     for op in reads:
         if isinstance(op, BSIDMemoryReferenceOperand):
             for name in (op.base, op.index):
                 if name is not None:
                     address_regs.add(name)
-    cmp_info: typing.List[CmpInfo] = sorted(
+    locations = sorted(
         (
             op
             for op in reads
-            # The isinstance narrows Operand to what CmpInfo can carry as
+            # The isinstance narrows Operand to what a CmpEntry can carry as
             # well as filtering: reads can in principle hold other Operand
             # kinds, which have no place in a compare report.
             if isinstance(op, (RegisterOperand, BSIDMemoryReferenceOperand))
@@ -128,24 +114,14 @@ def get_cmp_info(
     imm_ops = [op for op in cs_insn.operands if op.type == capstone.CS_OP_IMM]
     if is_compare_branch and imm_ops:
         imm_ops = imm_ops[:-1]  # drop the branch target
-    immediates = [int(op.value.imm) for op in imm_ops]
-    cmp_info.extend(immediates)
 
-    # Concrete value of each cmp_info entry, read while the emulator is
-    # positioned at this compare. Index-aligned with the final cmp_info
-    # order (locations first, then immediates).
     byteorder: typing.Literal["little", "big"] = (
         "little" if pdefs.byteorder is platforms.Byteorder.LITTLE else "big"
     )
-    cmp_values: typing.List[typing.Optional[int]] = [
-        (
-            entry
-            if isinstance(entry, int)
-            else _concrete_cmp_value(entry, emulator, byteorder)
-        )
-        for entry in cmp_info
-    ]
-    return (cmp_info, cmp_values, immediates)
+    return [
+        CmpEntry(source=op, value=_concrete_cmp_value(op, emulator, byteorder))
+        for op in locations
+    ] + [CmpEntry(source=int(op.value.imm), value=int(op.value.imm)) for op in imm_ops]
 
 
 class TraceExecution(analysis.Analysis):
@@ -235,19 +211,21 @@ class TraceExecution(analysis.Analysis):
                     f"no decodable instruction at pc {pc:#x}"
                 )
                 break
-            cmp_info, cmp_values, imm_info = get_cmp_info(
-                self.platform, self.emulator, cs_insn
-            )
+            cmp_entries = get_cmp_info(self.platform, self.emulator, cs_insn)
             branch_info = cs_insn.mnemonic in pdefs.conditional_branch_mnemonics
+            # TraceElement keeps its historical parallel-list shape (cmp /
+            # immediates / index-aligned cmp_values): its pickled form and
+            # its consumers (magrathea) depend on it. Derived here from the
+            # self-contained entries; immediates are the int-sourced ones.
             te = TraceElement(
                 pc,
                 i,
                 cs_insn.mnemonic,
                 cs_insn.op_str,
-                cmp_info,
+                [e.source for e in cmp_entries],
                 branch_info,
-                imm_info,
-                cmp_values,
+                [e.source for e in cmp_entries if isinstance(e.source, int)],
+                [e.value for e in cmp_entries],
             )
             trace.append(te)
             # run any callbacks

--- a/smallworld/analyses/trace_execution.py
+++ b/smallworld/analyses/trace_execution.py
@@ -94,14 +94,18 @@ def get_cmp_info(
     is_compare_branch = cs_insn.mnemonic in pdefs.compare_branch_mnemonics
     if not (is_compare or is_compare_branch):
         return ([], [], [])
-    sw_insn = smallworld.instructions.Instruction.from_capstone(cs_insn)
     try:
+        # Broad on purpose: this runs per instruction inside a live trace,
+        # and one uninterpretable compare must degrade to "no cmp info",
+        # not abort the run. The failure taxonomy is open-ended -- Capstone
+        # and JPype raise types that share no useful ancestor -- and
+        # from_capstone belongs inside too: it raises ValueError for any
+        # ISA without an Instruction subclass (superh, riscv, tricore,
+        # ...), all of which define compare_mnemonics.
+        sw_insn = smallworld.instructions.Instruction.from_capstone(cs_insn)
         reads = sw_insn.reads
     except Exception as exc:
-        # A compare whose pcode use/def can't be interpreted must not
-        # take down the whole trace; report it as "no cmp info" and
-        # keep going, mirroring the degrade-to-unknown handling below.
-        logger.warning(f"get_cmp_info: reads() failed for {cs_insn.mnemonic}: {exc}")
+        logger.warning(f"get_cmp_info: no use/def for {cs_insn.mnemonic}: {exc}")
         return ([], [], [])
     address_regs = set()
     for op in reads:

--- a/smallworld/analyses/trace_execution.py
+++ b/smallworld/analyses/trace_execution.py
@@ -8,7 +8,7 @@ import capstone
 
 import smallworld
 from smallworld.analyses.trace_execution_types import CmpInfo, TraceElement, TraceRes
-from smallworld.instructions import RegisterOperand
+from smallworld.instructions import BSIDMemoryReferenceOperand, RegisterOperand
 
 from .. import platforms
 from ..hinting.hints import TraceExecutionHint
@@ -53,35 +53,95 @@ def get_cmp_info(
 ) -> typing.Tuple[
     typing.List[CmpInfo], typing.List[typing.Optional[int]], typing.List[int]
 ]:
+    """For a comparison instruction, report what is being compared.
+
+    Returns (cmp_info, cmp_values, immediates). cmp_info holds the
+    locations the compare reads — register and memory Operands, taken
+    from the pcode-based use/def analysis (Instruction.reads) —
+    followed by any immediate operands. Registers that only serve to
+    form an included memory operand's address (rbp in
+    'cmp [rbp-0x1c], 47') are omitted: the compared value is the memory
+    cell, not the pointer.
+
+    The location entries are deduplicated and sorted by repr; the
+    immediates follow, in decode order. Repr order (not operand order)
+    is deliberate and matches how the colorizer orders its own
+    read/write tuples: it makes traces stable run to run regardless of
+    the order the analysis happens to yield reads, and lets a compare
+    of a location against itself (test al, al) report it once.
+    cmp_values below is aligned to this final order, so consumers must
+    not assume operand (destination-first) order.
+
+    If the pcode use/def analysis cannot interpret this instruction,
+    the three lists come back empty rather than aborting the trace.
+
+    cmp_values is index-aligned with cmp_info: the concrete value of
+    each entry read from the live emulator now, while it sits exactly
+    at this compare (an immediate maps to itself; a register/memory
+    operand to its integer value, or None if it could not be read).
+
+    Immediates come from the decoded operands: use/def reports
+    locations, and a constant is not a location.
+
+    Compare-and-branch instructions (pdefs.compare_branch_mnemonics:
+    MIPS beq, AArch64 cbz/tbz, x86 jrcxz, PPC bdnz) are reported too —
+    they embed the comparison the branch decides on. For those, the
+    final immediate operand is the branch target, not a compared
+    value, so it is excluded.
+    """
     pdefs = platforms.defs.PlatformDef.for_platform(platform)
-    if cs_insn.mnemonic in pdefs.compare_mnemonics:
-        # it's a compare -- return list of "reads", the concrete value of each
-        # (read now, while the emulator sits exactly at this compare), and the
-        # immediates.  cmp_values is index-aligned with cmp_info.
-        sw_insn = smallworld.instructions.Instruction.from_capstone(cs_insn)
-        byteorder: typing.Literal["little", "big"] = (
-            "little" if pdefs.byteorder is platforms.Byteorder.LITTLE else "big"
+    is_compare = cs_insn.mnemonic in pdefs.compare_mnemonics
+    is_compare_branch = cs_insn.mnemonic in pdefs.compare_branch_mnemonics
+    if not (is_compare or is_compare_branch):
+        return ([], [], [])
+    sw_insn = smallworld.instructions.Instruction.from_capstone(cs_insn)
+    try:
+        reads = sw_insn.reads
+    except Exception as exc:
+        # A compare whose pcode use/def can't be interpreted must not
+        # take down the whole trace; report it as "no cmp info" and
+        # keep going, mirroring the degrade-to-unknown handling below.
+        logger.warning(f"get_cmp_info: reads() failed for {cs_insn.mnemonic}: {exc}")
+        return ([], [], [])
+    address_regs = set()
+    for op in reads:
+        if isinstance(op, BSIDMemoryReferenceOperand):
+            for name in (op.base, op.index):
+                if name is not None:
+                    address_regs.add(name)
+    cmp_info: typing.List[CmpInfo] = sorted(
+        (
+            op
+            for op in reads
+            # The isinstance narrows Operand to what CmpInfo can carry as
+            # well as filtering: reads can in principle hold other Operand
+            # kinds, which have no place in a compare report.
+            if isinstance(op, (RegisterOperand, BSIDMemoryReferenceOperand))
+            and not (isinstance(op, RegisterOperand) and op.name in address_regs)
+        ),
+        key=repr,
+    )
+    imm_ops = [op for op in cs_insn.operands if op.type == capstone.CS_OP_IMM]
+    if is_compare_branch and imm_ops:
+        imm_ops = imm_ops[:-1]  # drop the branch target
+    immediates = [int(op.value.imm) for op in imm_ops]
+    cmp_info.extend(immediates)
+
+    # Concrete value of each cmp_info entry, read while the emulator is
+    # positioned at this compare. Index-aligned with the final cmp_info
+    # order (locations first, then immediates).
+    byteorder: typing.Literal["little", "big"] = (
+        "little" if pdefs.byteorder is platforms.Byteorder.LITTLE else "big"
+    )
+    cmp_values: typing.List[typing.Optional[int]] = [
+        (
+            entry
+            if isinstance(entry, int)
+            else _concrete_cmp_value(entry, emulator, byteorder)
         )
-        cmp_info: typing.List[CmpInfo] = []
-        cmp_values: typing.List[typing.Optional[int]] = []
-        for op in cs_insn.operands:
-            if op.type == capstone.CS_OP_MEM and (op.access & capstone.CS_AC_READ):
-                mem_op = sw_insn._memory_reference_operand(op)
-                cmp_info.append(mem_op)
-                cmp_values.append(_concrete_cmp_value(mem_op, emulator, byteorder))
-            if op.type == capstone.CS_OP_REG and (op.access & capstone.CS_AC_READ):
-                reg_op = RegisterOperand(cs_insn.reg_name(op.value.reg))
-                cmp_info.append(reg_op)
-                cmp_values.append(_concrete_cmp_value(reg_op, emulator, byteorder))
-            if op.type == capstone.CS_OP_IMM:
-                cmp_info.append(op.value.imm)
-                cmp_values.append(op.value.imm)
-        immediates = []
-        for op in cs_insn.operands:
-            if op.type == capstone.x86.X86_OP_IMM:
-                immediates.append(op.value.imm)
-        return (cmp_info, cmp_values, immediates)
-    return ([], [], [])
+        for entry in cmp_info
+    ]
+    return (cmp_info, cmp_values, immediates)
 
 
 class TraceExecution(analysis.Analysis):

--- a/smallworld/analyses/trace_execution.py
+++ b/smallworld/analyses/trace_execution.py
@@ -101,17 +101,11 @@ def get_cmp_info(
         # so the expected raiser here is from_capstone's ValueError for an
         # ISA with no Instruction subclass (superh, riscv, tricore, ...),
         # all of which define compare_mnemonics. Anything else is a bug or
-        # new behavior: warned with a traceback, but still degraded.
+        # new behavior and propagates.
         sw_insn = smallworld.instructions.Instruction.from_capstone(cs_insn)
         reads = sw_insn.reads
     except ValueError as exc:
         logger.info(f"get_cmp_info: no Instruction for {cs_insn.mnemonic}: {exc}")
-        return ([], [], [])
-    except Exception as exc:
-        logger.warning(
-            f"get_cmp_info: unexpected failure on {cs_insn.mnemonic}: {exc!r}",
-            exc_info=True,
-        )
         return ([], [], [])
     address_regs = set()
     for op in reads:

--- a/smallworld/analyses/trace_execution.py
+++ b/smallworld/analyses/trace_execution.py
@@ -95,17 +95,23 @@ def get_cmp_info(
     if not (is_compare or is_compare_branch):
         return ([], [], [])
     try:
-        # Broad on purpose: this runs per instruction inside a live trace,
-        # and one uninterpretable compare must degrade to "no cmp info",
-        # not abort the run. The failure taxonomy is open-ended -- Capstone
-        # and JPype raise types that share no useful ancestor -- and
-        # from_capstone belongs inside too: it raises ValueError for any
-        # ISA without an Instruction subclass (superh, riscv, tricore,
-        # ...), all of which define compare_mnemonics.
+        # This runs per instruction inside a live trace: an uninterpretable
+        # compare degrades to "no cmp info" rather than aborting the run.
+        # reads itself degrades internally (see Instruction._pcode_result),
+        # so the expected raiser here is from_capstone's ValueError for an
+        # ISA with no Instruction subclass (superh, riscv, tricore, ...),
+        # all of which define compare_mnemonics. Anything else is a bug or
+        # new behavior: warned with a traceback, but still degraded.
         sw_insn = smallworld.instructions.Instruction.from_capstone(cs_insn)
         reads = sw_insn.reads
+    except ValueError as exc:
+        logger.info(f"get_cmp_info: no Instruction for {cs_insn.mnemonic}: {exc}")
+        return ([], [], [])
     except Exception as exc:
-        logger.warning(f"get_cmp_info: no use/def for {cs_insn.mnemonic}: {exc}")
+        logger.warning(
+            f"get_cmp_info: unexpected failure on {cs_insn.mnemonic}: {exc!r}",
+            exc_info=True,
+        )
         return ([], [], [])
     address_regs = set()
     for op in reads:

--- a/smallworld/analyses/trace_execution_types.py
+++ b/smallworld/analyses/trace_execution_types.py
@@ -8,6 +8,27 @@ from smallworld.instructions import BSIDMemoryReferenceOperand, RegisterOperand
 CmpInfo = typing.Union[RegisterOperand, BSIDMemoryReferenceOperand, int]
 
 
+@dataclass(frozen=True)
+class CmpEntry:
+    """One thing a comparison compares, with its observed value.
+
+    `source` is a register or memory Operand for a location, or the int
+    itself for an immediate. `value` is the concrete value read from the
+    live emulator at the moment the compare was about to execute -- an
+    immediate maps to itself; None means the location could not be read.
+
+    Self-contained on purpose: the previous contract returned parallel
+    lists ("cmp_values is index-aligned with cmp_info"), pushing the
+    bookkeeping onto every consumer. The entries carry no lhs/rhs order
+    -- they come from the use/def read SET, deduplicated (test al, al
+    reports al once) and repr-sorted for run-to-run stability -- so no
+    order is promised.
+    """
+
+    source: CmpInfo
+    value: typing.Optional[int]
+
+
 class TraceRes(Enum):
     ER_NONE = 0
     ER_BOUNDS = 1

--- a/smallworld/analyses/trace_execution_types.py
+++ b/smallworld/analyses/trace_execution_types.py
@@ -5,28 +5,26 @@ from enum import Enum
 
 from smallworld.instructions import BSIDMemoryReferenceOperand, RegisterOperand
 
-CmpInfo = typing.Union[RegisterOperand, BSIDMemoryReferenceOperand, int]
+#: Kept as an alias for CmpEntry.source's type; magrathea imports it.
+CmpInfo = typing.Union[RegisterOperand, BSIDMemoryReferenceOperand]
 
 
 @dataclass(frozen=True)
 class CmpEntry:
-    """One thing a comparison compares, with its observed value.
+    """One LOCATION a comparison compares -- a register or memory operand
+    -- with the value observed there at that point in the trace.
 
-    `source` is a register or memory Operand for a location, or the int
-    itself for an immediate. `value` is the concrete value read from the
-    live emulator at the moment the compare was about to execute -- an
-    immediate maps to itself; None means the location could not be read.
+    Immediates are not entries: they live in the separate immediates list
+    (a constant is not a location, and needs no observation).
 
-    Self-contained on purpose: the previous contract returned parallel
-    lists ("cmp_values is index-aligned with cmp_info"), pushing the
-    bookkeeping onto every consumer. The entries carry no lhs/rhs order
-    -- they come from the use/def read SET, deduplicated (test al, al
-    reports al once) and repr-sorted for run-to-run stability -- so no
-    order is promised.
+    `value` is excluded from equality and repr on purpose: trace identity
+    and golden logging must not depend on the seeded runtime values, the
+    same rule TraceElement.cmp_values carried before this type subsumed
+    it. None means the location could not be read.
     """
 
     source: CmpInfo
-    value: typing.Optional[int]
+    value: typing.Optional[int] = field(default=None, compare=False, repr=False)
 
 
 class TraceRes(Enum):
@@ -48,18 +46,13 @@ class TraceElement:
     ic: int  # instruction count
     mnemonic: str
     op_str: str
-    cmp: typing.List[CmpInfo]
+    # The locations this instruction compares (CmpEntry: operand + observed
+    # value) and, separately, the immediates it compares against. NOTE: this
+    # shape is a deliberate break from the older mixed cmp list plus
+    # index-aligned cmp_values; old pickled traces do not load.
+    cmp: typing.List[CmpEntry]
     branch: bool
     immediates: typing.List[int]
-    # Concrete value of each entry in `cmp`, read from the live emulator at the
-    # moment this compare is about to execute (see get_cmp_info).  Index-aligned
-    # with `cmp`: an immediate maps to itself, a register/memory operand to its
-    # concrete integer value, or None if it could not be read.  Excluded from
-    # eq/repr so it does not affect trace identity, comparison, or logging/golden
-    # output, and so older pickled traces (which lack it) stay compatible.
-    cmp_values: typing.List[typing.Optional[int]] = field(
-        default_factory=list, compare=False, repr=False
-    )
 
     def __str__(self):
         return f"{self.ic} 0x{self.pc:x} [{self.mnemonic} {self.op_str}] {self.cmp} {self.branch} {self.immediates}"

--- a/smallworld/instructions/instructions.py
+++ b/smallworld/instructions/instructions.py
@@ -202,7 +202,7 @@ class Instruction(metaclass=abc.ABCMeta):
         cls,
         instruction: capstone.CsInsn,
         use_def_backend: str = DEFAULT_USE_DEF_BACKEND,
-    ):
+    ) -> "Instruction":
         """Construct from an existing Capstone instruction.
 
         Arguments:
@@ -230,7 +230,7 @@ class Instruction(metaclass=abc.ABCMeta):
         block,
         arch: str,
         use_def_backend: str = DEFAULT_USE_DEF_BACKEND,
-    ):
+    ) -> "Instruction":
         """Construct from an angr disassembler instruction.
 
         Arguments:
@@ -258,7 +258,7 @@ class Instruction(metaclass=abc.ABCMeta):
         address: int,
         platform: Platform,
         use_def_backend: str = DEFAULT_USE_DEF_BACKEND,
-    ):
+    ) -> "Instruction":
         """Construct from a byte string."""
         try:
             return utils.find_subclass(

--- a/smallworld/instructions/instructions.py
+++ b/smallworld/instructions/instructions.py
@@ -299,15 +299,23 @@ class Instruction(metaclass=abc.ABCMeta):
         answer, or None with a warning when there is no trustworthy one.
 
         `purpose` names what the caller wanted ("use", "def", "fetch") in
-        the warnings. Every degrade returns None rather than raising:
+        the log messages. Every degrade returns None rather than raising:
         callers are properties and methods reached from Unicorn's fault
         handler and the colorizer's per-instruction callbacks, and the
-        Capstone backend never raised at them. The catch is broader than
-        UseDefError on purpose -- a missing optional pyghidra, a JPype
-        exception and an out-of-range address are none of them UseDefError,
-        and all used to escape.
+        Capstone backend never raised at them.
+
+        Failures are told apart by type:
+
+        * UseDefError -- the analysis met semantics it cannot express (a
+          masked address, a bare CALLOTHER trap). Routine; logged at info.
+        * ValueError -- how pyghidra reports configuration problems: no
+          GHIDRA_INSTALL_DIR, an invalid language id. Actionable by the
+          user and identical for every instruction, so warned once.
+        * anything else -- a bug here or new Ghidra behavior; warned WITH
+          a traceback so it is loud in logs and CI, but still degraded
+          rather than raised into a fault handler already mid-failure.
         """
-        from .pcode_use_def import analyze
+        from .pcode_use_def import UseDefError, analyze
 
         language_id = platdef.ghidra_language_id
         if language_id is None:
@@ -326,10 +334,24 @@ class Instruction(metaclass=abc.ABCMeta):
             # branch's.
             raw = self.instruction[: self._instruction.size]
             result = analyze(raw, language_id, self.address)
+        except UseDefError as e:
+            logger.info(
+                f"pcode analysis cannot express {self.instruction.hex()} on "
+                f"{language_id}: {e}; {purpose} set is empty"
+            )
+            return None
+        except ValueError as e:
+            _log_fallback_once(
+                f"pcode analysis unavailable on {language_id} ({e}); "
+                f"use/def sets are empty"
+            )
+            return None
         except Exception as e:
             logger.warning(
-                f"pcode analysis failed for {self.instruction.hex()} on "
-                f"{language_id}: {e!r}; {purpose} set is empty"
+                f"unexpected pcode analysis failure for "
+                f"{self.instruction.hex()} on {language_id}: {e!r}; "
+                f"{purpose} set is empty",
+                exc_info=True,
             )
             return None
         if result is None:

--- a/smallworld/instructions/instructions.py
+++ b/smallworld/instructions/instructions.py
@@ -311,9 +311,10 @@ class Instruction(metaclass=abc.ABCMeta):
         * ValueError -- how pyghidra reports configuration problems: no
           GHIDRA_INSTALL_DIR, an invalid language id. Actionable by the
           user and identical for every instruction, so warned once.
-        * anything else -- a bug here or new Ghidra behavior; warned WITH
-          a traceback so it is loud in logs and CI, but still degraded
-          rather than raised into a fault handler already mid-failure.
+        Anything else propagates: with the expected cases typed, a
+        different exception is a bug here or new Ghidra behavior, and
+        should fail loudly rather than be reclassified as "the
+        instruction could not be analyzed" -- which would be false.
         """
         from .pcode_use_def import UseDefError, analyze
 
@@ -344,14 +345,6 @@ class Instruction(metaclass=abc.ABCMeta):
             _log_fallback_once(
                 f"pcode analysis unavailable on {language_id} ({e}); "
                 f"use/def sets are empty"
-            )
-            return None
-        except Exception as e:
-            logger.warning(
-                f"unexpected pcode analysis failure for "
-                f"{self.instruction.hex()} on {language_id}: {e!r}; "
-                f"{purpose} set is empty",
-                exc_info=True,
             )
             return None
         if result is None:

--- a/smallworld/platforms/defs/aarch64.py
+++ b/smallworld/platforms/defs/aarch64.py
@@ -116,6 +116,15 @@ class AArch64(PlatformDef):
         "cbhlt",
     }
 
+    # Branches that compare a register directly instead of reading
+    # flags set by an earlier compare.
+    compare_branch_mnemonics = {
+        "cbz",
+        "cbnz",
+        "tbz",
+        "tbnz",
+    }
+
     # TODO: Should arithmetic operations that impact flags be compares?
     compare_mnemonics = {
         # Integer comparison

--- a/smallworld/platforms/defs/aarch64.py
+++ b/smallworld/platforms/defs/aarch64.py
@@ -8,6 +8,7 @@ class AArch64(PlatformDef):
     architecture = Architecture.AARCH64
     byteorder = Byteorder.LITTLE
     ghidra_language_id = "AARCH64:LE:64:v8A"
+    status_register = "nzcv"
 
     address_size = 8
     capstone_arch = capstone.CS_ARCH_ARM64

--- a/smallworld/platforms/defs/amd64.py
+++ b/smallworld/platforms/defs/amd64.py
@@ -333,6 +333,7 @@ class AMD64BasePlatformDef(PlatformDef):
 class AMD64(AMD64BasePlatformDef):
     architecture = Architecture.X86_64
     ghidra_language_id = "x86:LE:64:default"
+    status_register = "rflags"
 
     registers = AMD64BasePlatformDef.registers | {
         # *** SSE/AVX/AVX2 registers ***

--- a/smallworld/platforms/defs/amd64.py
+++ b/smallworld/platforms/defs/amd64.py
@@ -56,6 +56,14 @@ class AMD64BasePlatformDef(PlatformDef):
         "jecxz",
         "jcxz",
     }
+
+    # Branches that compare a register directly instead of reading
+    # flags set by an earlier compare.
+    compare_branch_mnemonics = {
+        "jrcxz",
+        "jecxz",
+        "jcxz",
+    }
     # TODO: Should arithmetic operations that impact flags be compares?
     compare_mnemonics = {
         # Basic integer comparisons.

--- a/smallworld/platforms/defs/arm.py
+++ b/smallworld/platforms/defs/arm.py
@@ -178,6 +178,7 @@ class ARMPlatformMixinM:
     """
 
     ghidra_register_aliases = _flag_aliases("psr")
+    status_register: typing.Optional[str] = "psr"
 
     def __init__(self):
         super().__init__()
@@ -226,6 +227,7 @@ class ARMPlatformMixinRA:
     """
 
     ghidra_register_aliases = _flag_aliases("cpsr")
+    status_register: typing.Optional[str] = "cpsr"
 
     def __init__(self):
         super().__init__()

--- a/smallworld/platforms/defs/i386.py
+++ b/smallworld/platforms/defs/i386.py
@@ -54,6 +54,13 @@ class I386(PlatformDef):
         "jecxz",
         "jcxz",
     }
+
+    # Branches that compare a register directly instead of reading
+    # flags set by an earlier compare.
+    compare_branch_mnemonics = {
+        "jecxz",
+        "jcxz",
+    }
     # TODO: Should arithmetic operations that impact flags be compares?
     compare_mnemonics = {
         # Basic integer comparisons.

--- a/smallworld/platforms/defs/i386.py
+++ b/smallworld/platforms/defs/i386.py
@@ -8,6 +8,7 @@ class I386(PlatformDef):
     architecture = Architecture.X86_32
     byteorder = Byteorder.LITTLE
     ghidra_language_id = "x86:LE:32:default"
+    status_register = "eflags"
 
     address_size = 4
 

--- a/smallworld/platforms/defs/mips.py
+++ b/smallworld/platforms/defs/mips.py
@@ -51,7 +51,7 @@ class MIPSO32PlatformDef(PlatformDef):
         "bltz",
         # Conditional branch-and-link
         "bgezal",
-        "bltzal"
+        "bltzal",
         # Likely conditional branch
         # Skip the delay slot if they are not taken.
         "beql",
@@ -66,11 +66,18 @@ class MIPSO32PlatformDef(PlatformDef):
         "bltzall",
     }
 
+    # Every MIPS conditional branch compares general-purpose register
+    # values directly (there are no condition flags).
+    compare_branch_mnemonics = conditional_branch_mnemonics
+
     compare_mnemonics = {
-        # MIPS doesn't really have integer comparison instructions
-        # All of the conditional branches include a comparsion
-        # relative to zero; the compiler needs to reduce
-        # all conditional tests to comparisons against zero.
+        # Integer comparison: set-less-than writes a boolean to a GPR;
+        # this is how compilers materialize integer compares that
+        # aren't folded into a conditional branch.
+        "slt",
+        "slti",
+        "sltu",
+        "sltiu",
         # Floating-point comparison
         # Save to FCC
         # NOTE: Unlike branches, compares only support eq, lt, and le

--- a/smallworld/platforms/defs/mips64.py
+++ b/smallworld/platforms/defs/mips64.py
@@ -83,7 +83,7 @@ class MIPSN64PlatformDef(PlatformDef):
         "bltz",
         # Conditional branch-and-link
         "bgezal",
-        "bltzal"
+        "bltzal",
         # Likely conditional branch
         # Skip the delay slot if they are not taken.
         "beql",
@@ -98,11 +98,18 @@ class MIPSN64PlatformDef(PlatformDef):
         "bltzall",
     }
 
+    # Every MIPS conditional branch compares general-purpose register
+    # values directly (there are no condition flags).
+    compare_branch_mnemonics = conditional_branch_mnemonics
+
     compare_mnemonics = {
-        # MIPS doesn't really have integer comparison instructions
-        # All of the conditional branches include a comparsion
-        # relative to zero; the compiler needs to reduce
-        # all conditional tests to comparisons against zero.
+        # Integer comparison: set-less-than writes a boolean to a GPR;
+        # this is how compilers materialize integer compares that
+        # aren't folded into a conditional branch.
+        "slt",
+        "slti",
+        "sltu",
+        "sltiu",
         # Floating-point comparison
         # Save to FCC
         # NOTE: Unlike branches, compares only support eq, lt, and le

--- a/smallworld/platforms/defs/platformdef.py
+++ b/smallworld/platforms/defs/platformdef.py
@@ -86,6 +86,12 @@ class PlatformDef(metaclass=abc.ABCMeta):
     memory directly (MIPS beq, AArch64 cbz, x86 jrcxz) rather than
     condition flags set by an earlier compare."""
 
+    status_register: typing.Optional[str] = None
+    """The register holding the condition flags (rflags, cpsr, nzcv), or
+    None where the platform models none. Named so analyses can tell it
+    apart from data registers: a compare's read of it (ARM data-processing
+    reads the carry through the barrel shifter) is not a compared value."""
+
     @property
     @abc.abstractmethod
     def pc_register(self) -> str:

--- a/smallworld/platforms/defs/platformdef.py
+++ b/smallworld/platforms/defs/platformdef.py
@@ -81,6 +81,11 @@ class PlatformDef(metaclass=abc.ABCMeta):
     implicit_dereference_mnemonics: typing.Set[str] = set()
     """Set of mnemonics for instructions that implicitly dereference a register"""
 
+    compare_branch_mnemonics: typing.Set[str] = set()
+    """Conditional branch mnemonics whose comparison reads registers or
+    memory directly (MIPS beq, AArch64 cbz, x86 jrcxz) rather than
+    condition flags set by an earlier compare."""
+
     @property
     @abc.abstractmethod
     def pc_register(self) -> str:

--- a/smallworld/platforms/defs/powerpc.py
+++ b/smallworld/platforms/defs/powerpc.py
@@ -102,6 +102,14 @@ class PowerPCPlatformDef(PlatformDef):
         _branch_to_label_all | _branch_to_lr_all | _branch_to_ctr_all
     )
 
+    # Branches that compare a register directly instead of reading a
+    # condition-register field set by an earlier compare: the
+    # decrement-ctr-and-branch family tests ctr against zero.
+    compare_branch_mnemonics = {
+        "bdnz",
+        "bdz",
+    }
+
     compare_mnemonics = {
         # Compare registers
         "cmpd",

--- a/tests/pcode_use_def/test.py
+++ b/tests/pcode_use_def/test.py
@@ -579,7 +579,7 @@ class GetCmpInfoDegradationTests(unittest.TestCase):
         md.detail = True
         insn = next(md.disasm(bytes.fromhex("3450"), 0x1000))  # cmp/eq r5,r4
         self.assertEqual(insn.mnemonic, "cmp/eq")
-        self.assertEqual(get_cmp_info(platform, None, insn), [])
+        self.assertEqual(get_cmp_info(platform, None, insn), ([], []))
 
 
 class MemoryOperandIdentityTests(unittest.TestCase):

--- a/tests/pcode_use_def/test.py
+++ b/tests/pcode_use_def/test.py
@@ -531,6 +531,29 @@ class PcodeUseDefDegradationTests(unittest.TestCase):
             self.assertTrue(insn.reads)
 
 
+class GetCmpInfoDegradationTests(unittest.TestCase):
+    """get_cmp_info runs per instruction inside a live trace, so an
+    uninterpretable compare must degrade to no-cmp-info, not abort the
+    run. Needs no pyghidra and no emulator: the degrade happens first."""
+
+    def test_compare_on_an_isa_with_no_instruction_subclass_degrades(self):
+        """SuperH (and riscv, tricore, m68k, ...) define compare_mnemonics
+        but have no Instruction subclass, so from_capstone raises
+        ValueError -- which used to escape because it sat outside the
+        function's try."""
+        import capstone as cs
+
+        from smallworld.analyses.trace_execution import get_cmp_info
+        from smallworld.platforms import Architecture, Byteorder, Platform
+
+        platform = Platform(Architecture.SUPERH_SH2A_FPU, Byteorder.BIG)
+        md = cs.Cs(cs.CS_ARCH_SH, cs.CS_MODE_SH2A | cs.CS_MODE_BIG_ENDIAN)
+        md.detail = True
+        insn = next(md.disasm(bytes.fromhex("3450"), 0x1000))  # cmp/eq r5,r4
+        self.assertEqual(insn.mnemonic, "cmp/eq")
+        self.assertEqual(get_cmp_info(platform, None, insn), ([], [], []))
+
+
 class MemoryOperandIdentityTests(unittest.TestCase):
     """Two accesses to one address at different widths are different
     accesses. Needs no pyghidra."""

--- a/tests/pcode_use_def/test.py
+++ b/tests/pcode_use_def/test.py
@@ -496,11 +496,11 @@ class PcodeUseDefDegradationTests(unittest.TestCase):
         self.assertTrue(any("synthetic" in line for line in logs.output))
         self.assertFalse(any(line.startswith("WARNING") for line in logs.output))
 
-    def test_unexpected_analysis_failure_warns_with_traceback(self):
-        """Anything that is not UseDefError/ValueError is a bug or new
-        Ghidra behavior: still degraded (the callers include a fault
-        handler mid-failure) but warned loudly, with the traceback."""
-        import smallworld.instructions.instructions as instructions_mod
+    def test_unexpected_analysis_failure_propagates(self):
+        """Anything that is not UseDefError/ValueError is a bug here or new
+        Ghidra behavior, and propagates (tleek's call): reclassifying it as
+        "the instruction could not be analyzed" would be false, and a bug
+        that only warns is a bug that hides."""
         from smallworld.instructions import Instruction
         from smallworld.platforms import Architecture, Byteorder, Platform
 
@@ -516,13 +516,10 @@ class PcodeUseDefDegradationTests(unittest.TestCase):
         real = pcode_use_def.analyze
         pcode_use_def.analyze = _raise
         try:
-            with self.assertLogs(instructions_mod.logger, level="WARNING") as logs:
-                self.assertEqual(insn.reads, set())
+            with self.assertRaises(KeyError):
+                insn.reads
         finally:
             pcode_use_def.analyze = real
-        joined = "\n".join(logs.output)
-        self.assertIn("unexpected", joined)
-        self.assertIn("Traceback", joined)
 
     def test_capstone_writes_does_not_resolve_a_platform_def(self):
         """PlatformDef.for_platform walks every subclass uncached, costing

--- a/tests/pcode_use_def/test.py
+++ b/tests/pcode_use_def/test.py
@@ -579,7 +579,7 @@ class GetCmpInfoDegradationTests(unittest.TestCase):
         md.detail = True
         insn = next(md.disasm(bytes.fromhex("3450"), 0x1000))  # cmp/eq r5,r4
         self.assertEqual(insn.mnemonic, "cmp/eq")
-        self.assertEqual(get_cmp_info(platform, None, insn), ([], [], []))
+        self.assertEqual(get_cmp_info(platform, None, insn), [])
 
 
 class MemoryOperandIdentityTests(unittest.TestCase):

--- a/tests/pcode_use_def/test.py
+++ b/tests/pcode_use_def/test.py
@@ -486,12 +486,43 @@ class PcodeUseDefDegradationTests(unittest.TestCase):
         real = pcode_use_def.analyze
         pcode_use_def.analyze = _raise
         try:
-            with self.assertLogs(instructions_mod.logger, level="WARNING") as logs:
+            # UseDefError is the ROUTINE limitation case, logged at info;
+            # warnings are reserved for configuration problems and bugs.
+            with self.assertLogs(instructions_mod.logger, level="INFO") as logs:
                 self.assertEqual(insn.reads, set())
                 self.assertEqual(insn.writes, set())
         finally:
             pcode_use_def.analyze = real
         self.assertTrue(any("synthetic" in line for line in logs.output))
+        self.assertFalse(any(line.startswith("WARNING") for line in logs.output))
+
+    def test_unexpected_analysis_failure_warns_with_traceback(self):
+        """Anything that is not UseDefError/ValueError is a bug or new
+        Ghidra behavior: still degraded (the callers include a fault
+        handler mid-failure) but warned loudly, with the traceback."""
+        import smallworld.instructions.instructions as instructions_mod
+        from smallworld.instructions import Instruction
+        from smallworld.platforms import Architecture, Byteorder, Platform
+
+        pcode_use_def = importlib.import_module("smallworld.instructions.pcode_use_def")
+        platform = Platform(Architecture.X86_64, Byteorder.LITTLE)
+        insn = Instruction.from_bytes(
+            bytes.fromhex("89cb"), 0x1000, platform, use_def_backend="pcode"
+        )
+
+        def _raise(*args, **kwargs):
+            raise KeyError("synthetic-bug")
+
+        real = pcode_use_def.analyze
+        pcode_use_def.analyze = _raise
+        try:
+            with self.assertLogs(instructions_mod.logger, level="WARNING") as logs:
+                self.assertEqual(insn.reads, set())
+        finally:
+            pcode_use_def.analyze = real
+        joined = "\n".join(logs.output)
+        self.assertIn("unexpected", joined)
+        self.assertIn("Traceback", joined)
 
     def test_capstone_writes_does_not_resolve_a_platform_def(self):
         """PlatformDef.for_platform walks every subclass uncached, costing

--- a/tests/trace_executor/test_branch_and_cmp_info.py
+++ b/tests/trace_executor/test_branch_and_cmp_info.py
@@ -1,6 +1,6 @@
 from trace_test import test
 
-from smallworld.instructions.bsid import x86BSIDMemoryReferenceOperand
+from smallworld.instructions.bsid import BSIDMemoryReferenceOperand
 from smallworld.instructions.instructions import RegisterOperand
 
 if __name__ == "__main__":
@@ -51,32 +51,35 @@ if __name__ == "__main__":
         f"num branches is {branches} but is supposed to be 9",
     )
 
+    # cmp_info lists the locations the compare reads (deduplicated,
+    # sorted by repr, without address-forming registers like rbp),
+    # followed by immediate operands.
     truth_cmps = [
-        (8558, [x86BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C), 47]),
-        (8568, [x86BSIDMemoryReferenceOperand(base="rbp", offset=-0x20), 0]),
+        (8558, [BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C), 47]),
+        (8568, [BSIDMemoryReferenceOperand(base="rbp", offset=-0x20), 0]),
         (
             8706,
             [
+                BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C),
                 RegisterOperand("eax"),
-                x86BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C),
             ],
         ),
-        (8637, [RegisterOperand("al"), RegisterOperand("al")]),
+        (8637, [RegisterOperand("al")]),
         (8688, [RegisterOperand("al"), 42]),
         (
             8706,
             [
+                BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C),
                 RegisterOperand("eax"),
-                x86BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C),
             ],
         ),
-        (8637, [RegisterOperand("al"), RegisterOperand("al")]),
+        (8637, [RegisterOperand("al")]),
         (8688, [RegisterOperand("al"), 42]),
         (
             8706,
             [
+                BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C),
                 RegisterOperand("eax"),
-                x86BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C),
             ],
         ),
     ]

--- a/tests/trace_executor/test_branch_and_cmp_info.py
+++ b/tests/trace_executor/test_branch_and_cmp_info.py
@@ -1,5 +1,6 @@
 from trace_test import test
 
+from smallworld.analyses.trace_execution_types import CmpEntry
 from smallworld.instructions.bsid import BSIDMemoryReferenceOperand
 from smallworld.instructions.instructions import RegisterOperand
 
@@ -51,37 +52,21 @@ if __name__ == "__main__":
         f"num branches is {branches} but is supposed to be 9",
     )
 
-    # cmp_info lists the locations the compare reads (deduplicated,
-    # sorted by repr, without address-forming registers like rbp),
-    # followed by immediate operands.
+    # .cmp holds the LOCATIONS the compare reads (CmpEntry, deduplicated,
+    # sorted by repr, without address-forming registers like rbp); the
+    # immediates compared against live separately in .immediates.
+    _mem1c = CmpEntry(source=BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C))
+    _cmp_8706 = [_mem1c, CmpEntry(source=RegisterOperand("eax"))]
     truth_cmps = [
-        (8558, [BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C), 47]),
-        (8568, [BSIDMemoryReferenceOperand(base="rbp", offset=-0x20), 0]),
-        (
-            8706,
-            [
-                BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C),
-                RegisterOperand("eax"),
-            ],
-        ),
-        (8637, [RegisterOperand("al")]),
-        (8688, [RegisterOperand("al"), 42]),
-        (
-            8706,
-            [
-                BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C),
-                RegisterOperand("eax"),
-            ],
-        ),
-        (8637, [RegisterOperand("al")]),
-        (8688, [RegisterOperand("al"), 42]),
-        (
-            8706,
-            [
-                BSIDMemoryReferenceOperand(base="rbp", offset=-0x1C),
-                RegisterOperand("eax"),
-            ],
-        ),
+        (8558, [_mem1c]),
+        (8568, [CmpEntry(source=BSIDMemoryReferenceOperand(base="rbp", offset=-0x20))]),
+        (8706, _cmp_8706),
+        (8637, [CmpEntry(source=RegisterOperand("al"))]),
+        (8688, [CmpEntry(source=RegisterOperand("al"))]),
+        (8706, _cmp_8706),
+        (8637, [CmpEntry(source=RegisterOperand("al"))]),
+        (8688, [CmpEntry(source=RegisterOperand("al"))]),
+        (8706, _cmp_8706),
     ]
 
     truth_imms = [(8558, [47]), (8568, [0]), (8688, [42]), (8688, [42])]

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -38,6 +38,7 @@ from harness.scenarios import fuzz as fuzz_scenario
 from harness.scenarios import static_buf as static_buf_scenario
 from pcode_use_def.test import (  # noqa: F401 - registers the TestCases
     AddressMaskingTests,
+    GetCmpInfoDegradationTests,
     GhidraMachdefRegisterAliasTests,
     InstructionFetchesTests,
     InstructionUseDefTests,

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -66,7 +66,7 @@ from smallworld.analyses.crash_triage.printer import CrashTriagePrinter
 from smallworld.analyses.field_detection import field_analysis
 from smallworld.analyses.field_detection.hints import UnknownFieldHint
 from smallworld.analyses.field_detection.malloc import MallocModel
-from smallworld.analyses.trace_execution_types import CmpEntry, TraceElement, TraceRes
+from smallworld.analyses.trace_execution_types import CmpEntry, TraceRes
 from smallworld.analyses.unstable.pointer_finder import PointerFinder
 from smallworld.arch import amd64_arch
 from smallworld.emulators.angr.exceptions import PathTerminationSignal
@@ -6741,13 +6741,13 @@ class GetCmpInfoTests(unittest.TestCase):
         self.assertEqual(cs_insn.mnemonic, "cmp")
         self.emu.write_register("rax", 0x1234)
 
-        entries = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
-        self.assertEqual(len(entries), 2)
+        entries, imms = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
+        self.assertEqual(len(entries), 1)
         self.assertIsInstance(entries[0].source, RegisterOperand)
         self.assertEqual(entries[0].source.name, "rax")
         self.assertEqual(entries[0].value, 0x1234)
-        # An immediate is its own source AND value.
-        self.assertEqual(entries[1], CmpEntry(source=5, value=5))
+        # Immediates are not locations; they come back separately.
+        self.assertEqual(imms, [5])
 
     def test_memory_operand_compare_reads_mapped_value(self):
         # cmp qword ptr [0x2000], rax
@@ -6759,12 +6759,13 @@ class GetCmpInfoTests(unittest.TestCase):
         )
         self.emu.write_register("rax", 99)
 
-        entries = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
+        entries, imms = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
         self.assertEqual(len(entries), 2)
         self.assertIsInstance(entries[0].source, BSIDMemoryReferenceOperand)
         self.assertEqual(entries[0].value, 0x1122334455667788)
         self.assertIsInstance(entries[1].source, RegisterOperand)
         self.assertEqual(entries[1].value, 99)
+        self.assertEqual(imms, [])
 
     def test_memory_operand_compare_unmapped_yields_none(self):
         # cmp qword ptr [0x6000], rax -- 0x6000 is not mapped
@@ -6772,7 +6773,7 @@ class GetCmpInfoTests(unittest.TestCase):
         self.assertEqual(cs_insn.mnemonic, "cmp")
         self.emu.write_register("rax", 7)
 
-        entries = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
+        entries, imms = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
         self.assertEqual(len(entries), 2)
         self.assertIsNone(entries[0].value)
         self.assertEqual(entries[1].value, 7)
@@ -6797,7 +6798,7 @@ class GetCmpInfoTests(unittest.TestCase):
             capstone.CS_ARCH_ARM,
             capstone.CS_MODE_ARM,
         )  # cmp r0, r1
-        entries = trace_execution.get_cmp_info(arm, emu, cs_insn)
+        entries, _ = trace_execution.get_cmp_info(arm, emu, cs_insn)
         self.assertEqual(
             sorted((e.source.name, e.value) for e in entries),
             [("r0", 11), ("r1", 22)],
@@ -6814,7 +6815,7 @@ class GetCmpInfoTests(unittest.TestCase):
         cs_insn = self._decode(b"\x48\x3b\x00")  # cmp rax, [rax]
         self.emu.write_register("rax", 0x2000)
         self.emu.map_memory(0x2000, 0x1000)
-        entries = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
+        entries, _ = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
         self.assertEqual(len(entries), 1)
         self.assertIsInstance(entries[0].source, BSIDMemoryReferenceOperand)
 
@@ -6823,29 +6824,26 @@ class GetCmpInfoTests(unittest.TestCase):
         cs_insn = self._decode(b"\x48\xc7\xc0\x05\x00\x00\x00")
         self.assertEqual(cs_insn.mnemonic, "mov")
         self.assertEqual(
-            trace_execution.get_cmp_info(self.platform, self.emu, cs_insn), []
+            trace_execution.get_cmp_info(self.platform, self.emu, cs_insn), ([], [])
         )
 
 
-class TraceElementCmpValuesTests(unittest.TestCase):
-    """TraceElement.cmp_values: optional, excluded from __eq__ and repr."""
+class CmpEntryIdentityTests(unittest.TestCase):
+    """CmpEntry.value is excluded from __eq__ and repr: trace identity and
+    golden logging must not depend on seeded runtime values -- the rule
+    TraceElement.cmp_values carried before CmpEntry subsumed it."""
 
-    @staticmethod
-    def _element(**kwargs):
-        return TraceElement(0x1000, 0, "cmp", "rax, 5", [], False, [5], **kwargs)
+    def test_equality_ignores_value(self):
+        rax = RegisterOperand("rax")
+        self.assertEqual(CmpEntry(source=rax, value=0x1234), CmpEntry(source=rax))
+        self.assertNotEqual(
+            CmpEntry(source=rax), CmpEntry(source=RegisterOperand("rbx"))
+        )
 
-    def test_construct_without_cmp_values_defaults_empty(self):
-        te = self._element()
-        self.assertEqual(te.cmp_values, [])
-
-    def test_equality_ignores_cmp_values(self):
-        te_a = self._element(cmp_values=[0x1234, 5])
-        te_b = self._element(cmp_values=[0x9999, None])
-        self.assertEqual(te_a, te_b)
-
-    def test_repr_excludes_cmp_values(self):
-        te = self._element(cmp_values=[0x1234, 5])
-        self.assertNotIn("cmp_values", repr(te))
+    def test_repr_excludes_value(self):
+        self.assertNotIn(
+            "value", repr(CmpEntry(source=RegisterOperand("rax"), value=0x1234))
+        )
 
 
 class TraceExecutionUndecodableInsnTests(unittest.TestCase):

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -6777,6 +6777,47 @@ class GetCmpInfoTests(unittest.TestCase):
         self.assertIsNone(entries[0].value)
         self.assertEqual(entries[1].value, 7)
 
+    def test_arm_compare_filters_the_status_register(self):
+        """Two fixes pinned together. get_cmp_info builds the instruction
+        from its platform ARGUMENT (from_capstone picked an arbitrary
+        ARM-mode subclass -- V7R, whose platform has no Ghidra language,
+        silently downgrading ARM compares to the Capstone fallback), and
+        the platform's status register is not a compared value: ARM
+        data-processing reads the carry through the barrel shifter, so a
+        plain cmp reads cpsr under the flags mapping."""
+        arm = platforms.Platform(
+            platforms.Architecture.ARM_V7A, platforms.Byteorder.LITTLE
+        )
+        emu = emulators.UnicornEmulator(arm)
+        emu.write_register("r0", 11)
+        emu.write_register("r1", 22)
+        cs_insn = _disasm_one(
+            bytes.fromhex("010050e1"),
+            0x1000,
+            capstone.CS_ARCH_ARM,
+            capstone.CS_MODE_ARM,
+        )  # cmp r0, r1
+        entries = trace_execution.get_cmp_info(arm, emu, cs_insn)
+        self.assertEqual(
+            sorted((e.source.name, e.value) for e in entries),
+            [("r0", 11), ("r1", 22)],
+        )
+
+    def test_address_register_that_is_also_compared_is_dropped(self):
+        """KNOWN IMPRECISION, documented not fixed: the address-forming
+        filter assumes the pointer and compared roles are disjoint.
+        `cmp rax, [rax]` violates that -- rax is both -- and is reported
+        as the memory cell alone. Telling the roles apart needs
+        per-operand provenance a read set does not carry. If this test
+        fails because rax appears, the imprecision was fixed: update the
+        docs in get_cmp_info, not just this test."""
+        cs_insn = self._decode(b"\x48\x3b\x00")  # cmp rax, [rax]
+        self.emu.write_register("rax", 0x2000)
+        self.emu.map_memory(0x2000, 0x1000)
+        entries = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
+        self.assertEqual(len(entries), 1)
+        self.assertIsInstance(entries[0].source, BSIDMemoryReferenceOperand)
+
     def test_non_compare_returns_empty(self):
         # mov rax, 5
         cs_insn = self._decode(b"\x48\xc7\xc0\x05\x00\x00\x00")

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -66,7 +66,7 @@ from smallworld.analyses.crash_triage.printer import CrashTriagePrinter
 from smallworld.analyses.field_detection import field_analysis
 from smallworld.analyses.field_detection.hints import UnknownFieldHint
 from smallworld.analyses.field_detection.malloc import MallocModel
-from smallworld.analyses.trace_execution_types import TraceElement, TraceRes
+from smallworld.analyses.trace_execution_types import CmpEntry, TraceElement, TraceRes
 from smallworld.analyses.unstable.pointer_finder import PointerFinder
 from smallworld.arch import amd64_arch
 from smallworld.emulators.angr.exceptions import PathTerminationSignal
@@ -6725,8 +6725,8 @@ class FieldDetectionMemReadHintTests(unittest.TestCase):
 
 
 class GetCmpInfoTests(unittest.TestCase):
-    """get_cmp_info returns (cmp_info, cmp_values, immediates) with concrete
-    operand values read from the live emulator, index-aligned with cmp_info."""
+    """get_cmp_info returns a list of self-contained CmpEntry: each compared
+    thing with the concrete value read from the live emulator."""
 
     def setUp(self):
         self.platform = _analyses_amd64_platform()
@@ -6741,15 +6741,13 @@ class GetCmpInfoTests(unittest.TestCase):
         self.assertEqual(cs_insn.mnemonic, "cmp")
         self.emu.write_register("rax", 0x1234)
 
-        cmp_info, cmp_values, immediates = trace_execution.get_cmp_info(
-            self.platform, self.emu, cs_insn
-        )
-        self.assertEqual(len(cmp_info), 2)
-        self.assertIsInstance(cmp_info[0], RegisterOperand)
-        self.assertEqual(cmp_info[0].name, "rax")
-        self.assertEqual(cmp_info[1], 5)
-        self.assertEqual(cmp_values, [0x1234, 5])
-        self.assertEqual(immediates, [5])
+        entries = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
+        self.assertEqual(len(entries), 2)
+        self.assertIsInstance(entries[0].source, RegisterOperand)
+        self.assertEqual(entries[0].source.name, "rax")
+        self.assertEqual(entries[0].value, 0x1234)
+        # An immediate is its own source AND value.
+        self.assertEqual(entries[1], CmpEntry(source=5, value=5))
 
     def test_memory_operand_compare_reads_mapped_value(self):
         # cmp qword ptr [0x2000], rax
@@ -6761,14 +6759,12 @@ class GetCmpInfoTests(unittest.TestCase):
         )
         self.emu.write_register("rax", 99)
 
-        cmp_info, cmp_values, immediates = trace_execution.get_cmp_info(
-            self.platform, self.emu, cs_insn
-        )
-        self.assertEqual(len(cmp_info), 2)
-        self.assertIsInstance(cmp_info[0], BSIDMemoryReferenceOperand)
-        self.assertIsInstance(cmp_info[1], RegisterOperand)
-        self.assertEqual(cmp_values, [0x1122334455667788, 99])
-        self.assertEqual(immediates, [])
+        entries = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
+        self.assertEqual(len(entries), 2)
+        self.assertIsInstance(entries[0].source, BSIDMemoryReferenceOperand)
+        self.assertEqual(entries[0].value, 0x1122334455667788)
+        self.assertIsInstance(entries[1].source, RegisterOperand)
+        self.assertEqual(entries[1].value, 99)
 
     def test_memory_operand_compare_unmapped_yields_none(self):
         # cmp qword ptr [0x6000], rax -- 0x6000 is not mapped
@@ -6776,19 +6772,18 @@ class GetCmpInfoTests(unittest.TestCase):
         self.assertEqual(cs_insn.mnemonic, "cmp")
         self.emu.write_register("rax", 7)
 
-        cmp_info, cmp_values, immediates = trace_execution.get_cmp_info(
-            self.platform, self.emu, cs_insn
-        )
-        self.assertEqual(len(cmp_info), 2)
-        self.assertIsNone(cmp_values[0])
-        self.assertEqual(cmp_values[1], 7)
+        entries = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
+        self.assertEqual(len(entries), 2)
+        self.assertIsNone(entries[0].value)
+        self.assertEqual(entries[1].value, 7)
 
-    def test_non_compare_returns_three_empty_lists(self):
+    def test_non_compare_returns_empty(self):
         # mov rax, 5
         cs_insn = self._decode(b"\x48\xc7\xc0\x05\x00\x00\x00")
         self.assertEqual(cs_insn.mnemonic, "mov")
-        result = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
-        self.assertEqual(result, ([], [], []))
+        self.assertEqual(
+            trace_execution.get_cmp_info(self.platform, self.emu, cs_insn), []
+        )
 
 
 class TraceElementCmpValuesTests(unittest.TestCase):


### PR DESCRIPTION
  get_cmp_info filtered address-forming registers out of compared locations by guessing from the read set, which is provably insufficient: `cmp rax, [rax]` (rax IS compared) and `cmp qword ptr [rax], 5` (rax is only the address) present the identical set {rax, [rax]}, and the first was mis-reported as the memory cell alone. The p-code walk now tracks each register's role from resolved expressions -- address-role when it appears in a LOAD/STORE address, data-role when it reaches an architectural sink -- and exports `InstructionUseDef.address_only_uses`, surfaced as `Instruction.address_only_reads()` (Capstone fallback keeps the old approximation, documented). The corpora gain an optional `address_only_uses` assertion, with 26 role claims across all nine ISAs stated from the architecture and confirmed by the engine -- the negatives (writeback bases, `lwzx`, `jr $t9`, `push`) carry the interesting semantics -- plus the discriminating cmp pair as permanent ground truth; 796/796, strict count unchanged. Also carries the CmpEntry/TraceElement split commit that the #439 merge missed (magrathea's feat.cmp_entries branch depends on it).
