### PR TITLE
fix: map ghidras fs offset gs offset to AMD64 segment bases 

### DIFF
--- a/smallworld/platforms/defs/amd64.py
+++ b/smallworld/platforms/defs/amd64.py
@@ -11,6 +11,18 @@ class AMD64BasePlatformDef(PlatformDef):
     # The new bases are incompatible, so we need two separate classes.
     byteorder = Byteorder.LITTLE
 
+    # Ghidra names the segment bases fs_offset/gs_offset in p-code; the same
+    # state is modeled here as the fsbase/gsbase registers below. Without this
+    # mapping the p-code naming layer cannot resolve the base of
+    # `mov rax, qword ptr fs:[0x28]` -- the stack-protector read at the top of
+    # most compiled functions -- so it drops the whole memory reference and the
+    # instruction reports reading nothing at all.
+    #
+    # i386 has no equivalent: it models only the 2-byte fs/gs selectors, with
+    # no register holding the segment base, so 32-bit segment-relative accesses
+    # stay unresolvable until it grows one.
+    ghidra_register_aliases = {"fs_offset": "fsbase", "gs_offset": "gsbase"}
+
     address_size = 8
 
     capstone_arch = capstone.CS_ARCH_X86

--- a/tests/pcode_use_def/test.py
+++ b/tests/pcode_use_def/test.py
@@ -220,10 +220,18 @@ class PcodeNamingTests(unittest.TestCase):
         from smallworld.instructions.pcode_naming import canonicalize_operand
 
         amd64 = self._platdef("X86_64", "LITTLE")
-        # x86-64 segment addressing reads a real FS_OFFSET register that no
-        # platform definition models: the whole reference has to go, since
+        # x86-64 segment addressing reads Ghidra's FS_OFFSET, which AMD64
+        # aliases to the fsbase register it models. The reference must survive
+        # with its base rewritten: dropping it reported the stack-protector
+        # read at the top of most functions as reading nothing.
+        segment = BSIDMemoryReferenceOperand(base="fs_offset", offset=0x28, size=8)
+        mapped = canonicalize_operand(segment, amd64)
+        self.assertIsNotNone(mapped)
+        self.assertEqual((mapped.base, mapped.offset, mapped.size), ("fsbase", 0x28, 8))
+
+        # A base the platform genuinely does not model still goes, since
         # without a base there is no address to compute.
-        unresolvable = BSIDMemoryReferenceOperand(base="fs_offset", offset=0x28, size=8)
+        unresolvable = BSIDMemoryReferenceOperand(base="not_a_register", offset=0, size=8)
         self.assertIsNone(canonicalize_operand(unresolvable, amd64))
 
         # A resolvable one is preserved exactly.

--- a/tests/pcode_use_def/test.py
+++ b/tests/pcode_use_def/test.py
@@ -231,7 +231,9 @@ class PcodeNamingTests(unittest.TestCase):
 
         # A base the platform genuinely does not model still goes, since
         # without a base there is no address to compute.
-        unresolvable = BSIDMemoryReferenceOperand(base="not_a_register", offset=0, size=8)
+        unresolvable = BSIDMemoryReferenceOperand(
+            base="not_a_register", offset=0, size=8
+        )
         self.assertIsNone(canonicalize_operand(unresolvable, amd64))
 
         # A resolvable one is preserved exactly.


### PR DESCRIPTION
mov rax, qword ptr fs:[0x28] — the stack-protector read at the top of most compiled functions — reported no reads at all: Ghidra names the x86 segment bases fs_offset/gs_offset in p-code, while AMD64 models the same state as the fsbase/gsbase registers it already defines (and which the Unicorn machdef reads as MSRs), with no mapping declared between the two spellings, so the naming layer couldn't resolve the base and dropped the whole memory reference. Consumers are then stuck: an unmapped-read fault at that instruction arrives with no operands, so it can't be attributed to a location and no repair can act on it.  ghidra_register_aliases is the mechanism already in place for exactly this (MIPS64's O32-vs-N64 register names, ARM's condition-flag bits) and AMD64 simply had none; declared on the base class so AMD64 and AMD64AVX512 both get it. i386 is untouched and still affected — it models only the 2-byte fs/gs selectors, with no segment-base register to alias to, so that needs a separate change.                              
