### PR TITLE
feat: report dual-role compare operands via address role tracking

### DIFF
--- a/smallworld/analyses/trace_execution.py
+++ b/smallworld/analyses/trace_execution.py
@@ -75,20 +75,15 @@ def get_cmp_info(
             bytes(cs_insn.bytes), cs_insn.address, platform
         )
         reads = sw_insn.reads
+        address_regs = sw_insn.address_only_reads()
     except ValueError as exc:
         logger.info(f"get_cmp_info: no Instruction for {cs_insn.mnemonic}: {exc}")
         return []
-    address_regs = set()
-    for op in reads:
-        if isinstance(op, BSIDMemoryReferenceOperand):
-            for name in (op.base, op.index):
-                if name is not None:
-                    address_regs.add(name)
-    # Compared locations: reads, minus non-value roles -- address-forming
-    # registers (rbp in `cmp [rbp-0x1c], 47`) and the status register (a
-    # plain ARM cmp reads the carry via the barrel shifter). KNOWN
-    # IMPRECISION: `cmp rax, [rax]` reports only [rax] -- rax is both
-    # pointer and compared value, and a read SET cannot say which.
+    # Compared locations: reads, minus non-value roles -- registers the
+    # analysis says were read ONLY to form an address (rbp in
+    # `cmp [rbp-0x1c], 47`; dual-role rax in `cmp rax, [rax]` is kept)
+    # and the status register (a plain ARM cmp reads the carry via the
+    # barrel shifter).
     locations = sorted(
         (
             op

--- a/smallworld/instructions/instructions.py
+++ b/smallworld/instructions/instructions.py
@@ -548,6 +548,40 @@ class Instruction(metaclass=abc.ABCMeta):
             and (not hasattr(operand, "access") or operand.access & capstone.CS_AC_READ)
         }
 
+    def address_only_reads(self) -> typing.Set[str]:
+        """Names of registers in `reads` whose every read served address
+        formation (rbp in `cmp [rbp-0x1c], 47`) -- a subset claim about
+        `reads`, never new operands. A register read both as an address
+        and as a value (`cmp rax, [rax]`) is not listed.
+
+        The p-code backend reports this from the analysis's role tracking.
+        The Capstone fallback cannot know, so it approximates the way
+        get_cmp_info always did: every base/index of a memory read is
+        presumed address-only -- which mislabels the dual-role case.
+        """
+        platdef = self._pcode_platdef()
+        if platdef is not None:
+            from .pcode_naming import canonicalize_register
+
+            result = self._pcode_result("address-only", platdef)
+            if result is None:
+                return set()
+            return {
+                name
+                for name in (
+                    canonicalize_register(r, platdef) for r in result.address_only_uses
+                )
+                if name is not None
+            }
+        names: typing.Set[str] = set()
+        for op in self.reads:
+            if isinstance(op, MemoryReferenceOperand):
+                for attr in ("base", "index"):
+                    reg = getattr(op, attr, None)
+                    if reg is not None:
+                        names.add(reg)
+        return names
+
     # def to_json(self) -> dict:
     #     return {
     #         "instruction": base64.b64encode(self.instruction).decode(),

--- a/smallworld/instructions/pcode_use_def.py
+++ b/smallworld/instructions/pcode_use_def.py
@@ -469,6 +469,11 @@ class InstructionUseDef(typing.NamedTuple):
     size: int
     uses: typing.Tuple[Operand, ...]
     defs: typing.Tuple[Operand, ...]
+    #: Registers in `uses` whose every read served address formation (rbp
+    #: in `cmp [rbp-0x1c], 47`) -- a subset claim about `uses`, never new
+    #: operands. A register read both ways (`cmp rax, [rax]`) is absent.
+    address_only_uses: typing.Tuple[str, ...] = ()
+
     #: Registers whose *value* is the destination of an indirect transfer
     #: (BRANCHIND/CALLIND/RETURN) -- MIPS `jr $t9`, x86 `jmp rax`. Reported
     #: separately because "this register holds a code pointer" is structure
@@ -534,9 +539,10 @@ def _resolve_input(inp, sstate):
 
 
 def _update_symstate(op, sstate):
-    # resolve all inputs (args) to this op in terms of
-    # inputs-to-the-instruction, and then record
-    # mapping from out to that resolution
+    """Record op's output in sstate as an expression over instruction
+    inputs; returns the resolved inputs so the walk can reuse them.
+    (Inputs are resolved BEFORE the output is recorded, so an op that
+    overwrites its own input register resolves against the old value.)"""
     ris = [_resolve_input(inp, sstate) for inp in op.inputs]
     # special case! There's no need for an s-expr. This is basically
     # just an assignment
@@ -549,13 +555,14 @@ def _update_symstate(op, sstate):
     outp = op.output
     if outp is None:
         # no output to track (e.g. STORE, branches)
-        return
+        return ris
     if _is_unique(outp):
         sstate[_unique_key(outp)] = val
     elif _is_register(outp):
         sstate[_reg_slot(outp)] = val
     # else: output is a ram address (absolute store via COPY); nothing
     # downstream reads it back through sstate, so don't track it
+    return ris
 
 
 def _const_value(vn):
@@ -842,14 +849,30 @@ def _instruction_use_def(ctx, ops, disassembly, address):
 
     indirect_targets: typing.List[str] = []
     saw_callother = False
+    # Role tracking for address_only_uses: which registers were read to
+    # FORM an address, and which fed a value an architectural sink
+    # consumes. Derived from resolved expressions, not raw op inputs -- at
+    # read time the role is sometimes unknowable (rbp feeding the INT_ADD
+    # of `cmp [rbp-0x1c], 47` looks like data until the LOAD consumes it).
+    addr_role: typing.Set[str] = set()
+    data_role: typing.Set[str] = set()
+
+    def _flag_data(resolved) -> None:
+        # _expr_registers stops at LOAD nodes, so a value that came OUT of
+        # memory does not data-flag the registers that addressed it.
+        for name in _expr_registers(resolved, ctx, []):
+            data_role.add(name)
+
     for op in ops:
 
-        _update_symstate(op, sstate)
+        ris = _update_symstate(op, sstate)
 
         mnemonic = _mnemonic_of(op)
 
         if mnemonic is _PCODE_OP.CALLOTHER:
             saw_callother = True
+            for resolved in ris:
+                _flag_data(resolved)
 
         if mnemonic in (_PCODE_OP.UNIMPLEMENTED, _PCODE_OP.INVALID_OP):
             # Ghidra is telling us it has no semantics for this
@@ -889,6 +912,8 @@ def _instruction_use_def(ctx, ops, disassembly, address):
             if mnemonic in (_PCODE_OP.BRANCH, _PCODE_OP.CBRANCH, _PCODE_OP.CALL)
             else None
         )
+        if mnemonic is _PCODE_OP.CBRANCH and len(ris) > 1:
+            _flag_data(ris[1])  # the condition; input 0 is the target
         if mnemonic in (
             _PCODE_OP.BRANCHIND,
             _PCODE_OP.CALLIND,
@@ -901,7 +926,8 @@ def _instruction_use_def(ctx, ops, disassembly, address):
             # resolving through the symbolic state, then collecting
             # registers -- the mask is computed, not a literal, so the
             # address walker rejects it.
-            target = _resolve_input(op.inputs[0], sstate)
+            target = ris[0]
+            _flag_data(target)
             regs = [
                 name
                 for name in _expr_registers(target, ctx, [])
@@ -956,6 +982,8 @@ def _instruction_use_def(ctx, ops, disassembly, address):
             assert len(inputs) == 3
             mem = _load_store_mem(op, ctx, sstate, int(inputs[2].size))
             defs.add(mem)
+            addr_role.update(_expr_registers(ris[1], ctx, []))
+            _flag_data(ris[2])
             continue  # STORE has no output varnode
 
         # ---- LOAD: emit a symbolic memory use, propagate value ------- #
@@ -965,6 +993,7 @@ def _instruction_use_def(ctx, ops, disassembly, address):
             out = op.output
             assert not (out is None)
             mem = _load_store_mem(op, ctx, sstate, int(out.size))
+            addr_role.update(_expr_registers(ris[1], ctx, []))
 
             # skip the use if this instruction already stored to the
             # same location (the load reads its own store)
@@ -991,6 +1020,8 @@ def _instruction_use_def(ctx, ops, disassembly, address):
             # (no STORE op is emitted for these).
             mem = _varnode_operand(ctx, out)
             defs.add(mem)
+            for resolved in ris:
+                _flag_data(resolved)
             continue
         if not _is_register(out):
             raise UseDefError(f"unsupported output varnode {out} for op {op}")
@@ -999,6 +1030,8 @@ def _instruction_use_def(ctx, ops, disassembly, address):
             continue
         defs.add(reg)
         written_so_far.add(out)
+        for resolved in ris:
+            _flag_data(resolved)
 
     if saw_callother and not uses and not defs:
         # The instruction's entire data effect is hidden inside a CALLOTHER
@@ -1013,7 +1046,9 @@ def _instruction_use_def(ctx, ops, disassembly, address):
             f"semantics of {disassembly or '<unknown>'} at {address:#x} "
             f"are entirely inside a CALLOTHER (opaque user-op); use/def unknown"
         )
-    return uses, defs, tuple(indirect_targets)
+    use_names = {o.name for o in uses if isinstance(o, RegisterOperand)}
+    address_only = tuple(sorted((addr_role - data_role) & use_names))
+    return uses, defs, tuple(indirect_targets), address_only
 
 
 # --------------------------------------------------------------------------- #
@@ -1094,13 +1129,16 @@ def _analyze_locked(byte_data, arch, base_address):
     except Exception:
         text = ""  # presentation only; never fail an analysis over it
 
-    uses, defs, indirect_targets = _instruction_use_def(ctx, ops, text, base)
+    uses, defs, indirect_targets, address_only = _instruction_use_def(
+        ctx, ops, text, base
+    )
     return InstructionUseDef(
         disassembly=text,
         size=size,
         uses=tuple(uses),
         defs=tuple(defs),
         indirect_targets=indirect_targets,
+        address_only_uses=address_only,
     )
 
 

--- a/tests/pcode_use_def/CORPUS.md
+++ b/tests/pcode_use_def/CORPUS.md
@@ -6,7 +6,7 @@ Operand notation: registers by name; memory as `[base+scale*index±0xoffset]:siz
 
 ## Contents
 
-- [x86-64](#x86-64) - 94 instructions, `x86:LE:64:default`
+- [x86-64](#x86-64) - 96 instructions, `x86:LE:64:default`
 - [i386 (x86-32)](#i386-x86-32) - 83 instructions, `x86:LE:32:default`
 - [AArch64](#aarch64) - 112 instructions, `AARCH64:LE:64:v8A`
 - [ARM (ARMv7-A, ARM mode)](#arm-armv7-a-arm-mode) - 74 instructions, `ARM:LE:32:v7`
@@ -18,9 +18,9 @@ Operand notation: registers by name; memory as `[base+scale*index±0xoffset]:siz
 
 ## x86-64
 
-94 instructions - Ghidra language `x86:LE:64:default` - base address `0x1000`
+96 instructions - Ghidra language `x86:LE:64:default` - base address `0x1000`
 
-Category breakdown: arith 13, mov 9, load 9, branch 8, ext 7, store 6, shift 6, muldiv 6, logic 5, misc 5, fp 5, stack 4, call 4, cmp 3, string 3, ret 1
+Category breakdown: arith 13, mov 9, load 9, branch 8, ext 7, store 6, shift 6, muldiv 6, logic 5, cmp 5, misc 5, fp 5, stack 4, call 4, string 3, ret 1
 
 | # | asm | bytes | uses | defs | notes |
 |--:|-----|-------|------|------|-------|
@@ -118,6 +118,8 @@ Category breakdown: arith 13, mov 9, load 9, branch 8, ext 7, store 6, shift 6, 
 | 92 | `movaps xmm3, xmmword ptr [rax]` | `0f2818` | rax, [rax]:16 | xmm3 |  |
 | 93 | `jmp qword ptr [0x1234]` | `ff242534120000` | [0x1234]:8 | — | Ghidra emits a bare BRANCHIND on a ram varnode; the pointer load is a real read. |
 | 94 | `call qword ptr [0x1234]` | `ff142534120000` | rsp, [0x1234]:8 | rsp, [rsp-0x8]:8 | Absolute memory-indirect NEAR call (ff /2): reads the target pointer and pushes a return address. |
+| 95 | `cmp rax, qword ptr [rax]` | `483b00` | rax, [rax]:8 | cf, pf, af, zf, sf, of | Dual-role: rax is the address AND one compared value, so it is deliberately absent from address_only_uses. The discriminating sibling of the next entry -- identical use/def sets, different roles. |
+| 96 | `cmp qword ptr [rax], 5` | `48833805` | rax, [rax]:8 | cf, pf, af, zf, sf, of | rax is read only to form the address; the compared values are the memory cell and the immediate. |
 
 ## i386 (x86-32)
 

--- a/tests/pcode_use_def/README.md
+++ b/tests/pcode_use_def/README.md
@@ -52,6 +52,7 @@ truth.
       "defs": [{"reg": "rax"}],
       "uses_optional": [],
       "defs_optional": [],
+      "address_only_uses": ["rdx"],
       "notes": ""
     }
   ]
@@ -60,6 +61,15 @@ truth.
 
 Every entry is a single machine instruction, assembled at `base_address`
 (each entry is analyzed independently — entries are NOT concatenated).
+
+`address_only_uses` is OPTIONAL and asserts, exactly, which registers in
+`uses` were read only to form a memory address (the base of a plain
+load), checked strictly when present and ignored when absent. State it
+from the architecture, not from the analysis's output; the interesting
+cases are the negatives — a writeback base (PPC `stwu`, AArch64
+pre/post-index, ARM `push`) and an indirect branch target (`jr $t9`)
+consume the register's value and must NOT be listed, and a dual-role
+read (`cmp rax, [rax]`) must not be either.
 `bytes` is the hex encoding as produced by `llvm-mc --show-encoding` for
 `llvm_triple` and verified by round-tripping through Capstone.
 

--- a/tests/pcode_use_def/corpus_aarch64.json
+++ b/tests/pcode_use_def/corpus_aarch64.json
@@ -1368,6 +1368,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["x1"],
    "notes": ""
   },
   {
@@ -1616,6 +1617,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["x1", "x2"],
    "notes": ""
   },
   {
@@ -1683,6 +1685,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": [],
    "notes": "pre-index writeback defs base"
   },
   {
@@ -1716,6 +1719,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": [],
    "notes": "post-index writeback defs base; access at old base"
   },
   {

--- a/tests/pcode_use_def/corpus_arm32.json
+++ b/tests/pcode_use_def/corpus_arm32.json
@@ -1157,6 +1157,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["r1"],
    "notes": ""
   },
   {
@@ -1628,6 +1629,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": [],
    "notes": "stmdb sp!; lowest reg at lowest address"
   },
   {

--- a/tests/pcode_use_def/corpus_i386.json
+++ b/tests/pcode_use_def/corpus_i386.json
@@ -317,6 +317,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["esp"],
    "notes": ""
   },
   {
@@ -805,6 +806,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["ebx"],
    "notes": ""
   },
   {
@@ -1652,6 +1654,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["esi"],
    "notes": ""
   },
   {

--- a/tests/pcode_use_def/corpus_mips32.json
+++ b/tests/pcode_use_def/corpus_mips32.json
@@ -918,6 +918,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["sp"],
    "notes": ""
   },
   {
@@ -1200,6 +1201,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["sp"],
    "notes": ""
   },
   {
@@ -1434,6 +1436,7 @@
    "defs": [],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": [],
    "notes": ""
   },
   {

--- a/tests/pcode_use_def/corpus_mips64.json
+++ b/tests/pcode_use_def/corpus_mips64.json
@@ -2080,6 +2080,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["sp"],
    "notes": ""
   },
   {
@@ -2111,6 +2112,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["sp"],
    "notes": ""
   },
   {

--- a/tests/pcode_use_def/corpus_mips64el.json
+++ b/tests/pcode_use_def/corpus_mips64el.json
@@ -2080,6 +2080,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["sp"],
    "notes": ""
   },
   {
@@ -2111,6 +2112,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["sp"],
    "notes": ""
   },
   {

--- a/tests/pcode_use_def/corpus_mipsel.json
+++ b/tests/pcode_use_def/corpus_mipsel.json
@@ -918,6 +918,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["sp"],
    "notes": ""
   },
   {
@@ -1200,6 +1201,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["sp"],
    "notes": ""
   },
   {
@@ -1434,6 +1436,7 @@
    "defs": [],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": [],
    "notes": ""
   },
   {

--- a/tests/pcode_use_def/corpus_ppc32.json
+++ b/tests/pcode_use_def/corpus_ppc32.json
@@ -1057,6 +1057,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["r4"],
    "notes": ""
   },
   {
@@ -1211,6 +1212,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["r4", "r5"],
    "notes": ""
   },
   {
@@ -1523,6 +1525,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": [],
    "notes": "frame push: stores r1 at r1-48 then r1 -= 48; offset relative to pre-instruction r1"
   },
   {

--- a/tests/pcode_use_def/corpus_x86_64.json
+++ b/tests/pcode_use_def/corpus_x86_64.json
@@ -275,6 +275,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": ["rbx", "rcx"],
    "notes": ""
   },
   {
@@ -365,6 +366,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": [],
    "notes": "absolute (SIB, no base/index) addressing"
   },
   {
@@ -821,6 +823,7 @@
    ],
    "uses_optional": [],
    "defs_optional": [],
+   "address_only_uses": [],
    "notes": ""
   },
   {
@@ -3123,6 +3126,103 @@
    "uses_optional": [],
    "defs_optional": [],
    "notes": "Absolute memory-indirect NEAR call (ff /2): reads the target pointer and pushes a return address."
+  },
+  {
+   "asm": "cmp rax, qword ptr [rax]",
+   "bytes": "483b00",
+   "categories": [
+    "cmp",
+    "reg-mem",
+    "dual-role",
+    "qword"
+   ],
+   "uses": [
+    {
+     "reg": "rax"
+    },
+    {
+     "mem": {
+      "base": "rax",
+      "index": null,
+      "scale": 1,
+      "offset": 0,
+      "size": 8
+     }
+    }
+   ],
+   "defs": [
+    {
+     "reg": "cf"
+    },
+    {
+     "reg": "pf"
+    },
+    {
+     "reg": "af"
+    },
+    {
+     "reg": "zf"
+    },
+    {
+     "reg": "sf"
+    },
+    {
+     "reg": "of"
+    }
+   ],
+   "uses_optional": [],
+   "defs_optional": [],
+   "address_only_uses": [],
+   "notes": "Dual-role: rax is the address AND one compared value, so it is deliberately absent from address_only_uses. The discriminating sibling of the next entry -- identical use/def sets, different roles."
+  },
+  {
+   "asm": "cmp qword ptr [rax], 5",
+   "bytes": "48833805",
+   "categories": [
+    "cmp",
+    "mem-imm",
+    "qword"
+   ],
+   "uses": [
+    {
+     "reg": "rax"
+    },
+    {
+     "mem": {
+      "base": "rax",
+      "index": null,
+      "scale": 1,
+      "offset": 0,
+      "size": 8
+     }
+    }
+   ],
+   "defs": [
+    {
+     "reg": "cf"
+    },
+    {
+     "reg": "pf"
+    },
+    {
+     "reg": "af"
+    },
+    {
+     "reg": "zf"
+    },
+    {
+     "reg": "sf"
+    },
+    {
+     "reg": "of"
+    }
+   ],
+   "uses_optional": [],
+   "defs_optional": [],
+   "address_only_uses": [
+    "rax"
+   ],
+   "notes": "rax is read only to form the address; the compared values are the memory cell and the immediate."
   }
  ]
 }

--- a/tests/pcode_use_def/harness.py
+++ b/tests/pcode_use_def/harness.py
@@ -471,6 +471,25 @@ def check_entry(
     result["actual_use"] = sorted(fmt_item(i) for i in act["use"])
     result["actual_def"] = sorted(fmt_item(i) for i in act["def"])
 
+    # Optional role check: entries carrying "address_only_uses" assert
+    # exactly which registers were read only to form an address (Ghidra
+    # namespace, like everything else here). Exact-set, strict-only --
+    # register names, nothing to normalize -- and only checked where the
+    # entry states it, so unannotated entries are unaffected.
+    if "address_only_uses" in entry:
+        exp_roles = {str(n).lower() for n in entry["address_only_uses"]}
+        act_roles = {n.lower() for n in analyzed.address_only_uses}
+        if exp_roles != act_roles:
+            strict_ok = False
+            norm_ok = False
+            result["address_only_expected"] = sorted(exp_roles)
+            result["address_only_actual"] = sorted(act_roles)
+            result.setdefault("error", "")
+            result["error"] = (
+                result["error"] + f" address_only_uses: expected {sorted(exp_roles)}, "
+                f"got {sorted(act_roles)}"
+            ).strip()
+
     if strict_ok:
         result["status"] = "pass"
     elif norm_ok:

--- a/tests/pcode_use_def/test.py
+++ b/tests/pcode_use_def/test.py
@@ -840,6 +840,65 @@ class InstructionFetchesTests(unittest.TestCase):
 
 
 @unittest.skipUnless(HAVE_PYPCODE, "pypcode is not installed")
+class AddressRoleTests(unittest.TestCase):
+    """InstructionUseDef.address_only_uses: registers whose every read
+    served address formation. Roles come from resolved expressions -- a
+    register's read can look like data (rbp feeding INT_ADD) until the
+    LOAD consumes the result -- and _expr_registers' stop-at-LOAD rule
+    keeps memory-sourced values from data-flagging their address."""
+
+    CASES = [
+        ("x86:LE:64:default", "483b00", "cmp rax, [rax]", ()),  # dual role
+        ("x86:LE:64:default", "48833805", "cmp [rax], 5", ("rax",)),
+        ("x86:LE:64:default", "837de42f", "cmp [rbp-0x1c], 47", ("rbp",)),
+        ("x86:LE:64:default", "488b448a10", "mov rax, [rdx+rcx*4+16]", ("rcx", "rdx")),
+        # push writes [rsp-8] AND consumes rsp's value for the decrement.
+        ("x86:LE:64:default", "50", "push rax", ()),
+        ("MIPS:BE:32:default", "8fa80004", "lw t0, 4(sp)", ("sp",)),
+        # jr's t9 is the transfer target's VALUE, not an address read.
+        ("MIPS:BE:32:default", "03200008", "jr $t9", ()),
+    ]
+
+    def test_address_only_uses(self):
+        from smallworld.instructions.pcode_use_def import analyze
+
+        for lang, hexbytes, desc, expected in self.CASES:
+            with self.subTest(instruction=desc):
+                result = analyze(bytes.fromhex(hexbytes), lang, 0)
+                self.assertEqual(result.address_only_uses, expected)
+
+    def test_instruction_address_only_reads_canonicalizes(self):
+        from smallworld.instructions import Instruction
+        from smallworld.platforms import Architecture, Byteorder, Platform
+
+        insn = Instruction.from_bytes(
+            bytes.fromhex("837de42f"),  # cmp [rbp-0x1c], 47
+            0x1000,
+            Platform(Architecture.X86_64, Byteorder.LITTLE),
+            use_def_backend="pcode",
+        )
+        self.assertEqual(insn.address_only_reads(), {"rbp"})
+
+
+class AddressOnlyReadsCapstoneFallbackTests(unittest.TestCase):
+    """Without pcode the role facts don't exist; the fallback keeps the old
+    approximation -- every base/index of a memory read -- which mislabels
+    the dual-role case, documented on the method."""
+
+    def test_fallback_presumes_bases_address_only(self):
+        from smallworld.instructions import Instruction
+        from smallworld.platforms import Architecture, Byteorder, Platform
+
+        insn = Instruction.from_bytes(
+            bytes.fromhex("8fa80004"),  # lw t0, 4(sp)
+            0x1000,
+            Platform(Architecture.MIPS32, Byteorder.BIG),
+            use_def_backend="capstone",
+        )
+        self.assertEqual(insn.address_only_reads(), {"sp"})
+
+
+@unittest.skipUnless(HAVE_PYPCODE, "pypcode is not installed")
 class UseDefCorpusTests(unittest.TestCase):
     """Every corpus entry must agree with ground truth (normalized)."""
 

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -38,6 +38,8 @@ from harness.scenarios import fuzz as fuzz_scenario
 from harness.scenarios import static_buf as static_buf_scenario
 from pcode_use_def.test import (  # noqa: F401 - registers the TestCases
     AddressMaskingTests,
+    AddressOnlyReadsCapstoneFallbackTests,
+    AddressRoleTests,
     GetCmpInfoDegradationTests,
     GhidraMachdefRegisterAliasTests,
     InstructionFetchesTests,
@@ -6803,20 +6805,21 @@ class GetCmpInfoTests(unittest.TestCase):
             [("r0", 11), ("r1", 22)],
         )
 
-    def test_address_register_that_is_also_compared_is_dropped(self):
-        """KNOWN IMPRECISION, documented not fixed: the address-forming
-        filter assumes the pointer and compared roles are disjoint.
-        `cmp rax, [rax]` violates that -- rax is both -- and is reported
-        as the memory cell alone. Telling the roles apart needs
-        per-operand provenance a read set does not carry. If this test
-        fails because rax appears, the imprecision was fixed: update the
-        docs in get_cmp_info, not just this test."""
+    def test_dual_role_register_is_reported_as_compared(self):
+        """`cmp rax, [rax]`: rax is both the address and one compared
+        value. The analysis's role tracking (address_only_uses) tells the
+        two apart, so rax is reported alongside the memory cell -- the
+        imprecision the old read-set filter had to accept."""
         cs_insn = self._decode(b"\x48\x3b\x00")  # cmp rax, [rax]
         self.emu.write_register("rax", 0x2000)
         self.emu.map_memory(0x2000, 0x1000)
         entries = trace_execution.get_cmp_info(self.platform, self.emu, cs_insn)
-        self.assertEqual(len(entries), 1)
-        self.assertIsInstance(entries[0].source, BSIDMemoryReferenceOperand)
+        self.assertEqual(len(entries), 2)
+        kinds = {type(e.source) for e in entries}
+        self.assertEqual(kinds, {RegisterOperand, BSIDMemoryReferenceOperand})
+        reg = next(e for e in entries if isinstance(e.source, RegisterOperand))
+        self.assertEqual(reg.source.name, "rax")
+        self.assertEqual(reg.value, 0x2000)
 
     def test_non_compare_returns_empty(self):
         # mov rax, 5


### PR DESCRIPTION
`get_cmp_info` filtered address-forming registers out of the compared operands
  by guessing from the use set, which can't work: `cmp rax, [rax]` (rax is
  compared) and `cmp qword ptr [rax], 5` (rax is only the address) produce the
  identical use set {rax, [rax]}, so the first dropped rax as a compared value.
  The p-code walk now tracks each register's role from resolved expressions --
  address-role in a LOAD/STORE address, data-role reaching an architectural
  sink -- and exports `InstructionUseDef.address_only_uses`, surfaced as
  `Instruction.address_only_reads()`; `get_cmp_info` subtracts it instead of
  guessing, so `cmp rax, [rax]` now reports both sides while `cmp [rbp-0x1c], 47`
  still drops rbp. The corpora gain an optional `address_only_uses` assertion
  with 26 role claims across all nine ISAs, stated from the architecture and
  confirmed by the engine (the negatives -- writeback bases, `lwzx`, `jr $t9`,
  `push` -- carry the semantics); 796/796, strict count unchanged.
