### PR TITLE
perf: bind labeled memory via solver replacements 

### DIFF
--- a/smallworld/analyses/crash_triage/crash_triage.py
+++ b/smallworld/analyses/crash_triage/crash_triage.py
@@ -699,7 +699,9 @@ class CrashTriage(analysis.Analysis):
             emu.state.memory.read_strategies = [SimConcretizationStrategyFault(True)]
             emu.state.memory.write_strategies = [SimConcretizationStrategyFault(False)]
 
-        emu = emulators.AngrEmulator(self.platform, init=angr_init)
+        emu = emulators.AngrEmulator(
+            self.platform, init=angr_init, use_replacement_solver=True
+        )
         machine.apply(emu)
         emu.initialize()
 

--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -62,7 +62,13 @@ class AngrEmulator(
     description = "an emulator using angr as its backend"
     version = "0.0"
 
-    def __init__(self, platform: platforms.Platform, preinit=None, init=None):
+    def __init__(
+        self,
+        platform: platforms.Platform,
+        preinit=None,
+        init=None,
+        use_replacement_solver: bool = False,
+    ):
         # Initialized bit; tells us if angr state is initialized
         self._initialized: bool = False
 
@@ -71,6 +77,20 @@ class AngrEmulator(
 
         # Linear mode bit; tells us if we're running in forced linear execution
         self._linear: bool = True
+
+        # Use angr's replacement solver instead of the default.
+        #
+        # This binds labeled values via cheap substitutions rather than a giant
+        # conjunction of `symbol == value` constraints (see
+        # _write_memory_label_bulk), which is essential for analyses like
+        # crash-triage that label large regions of initialized memory.
+        #
+        # It is OPT-IN, not the default, because the replacement frontend walks
+        # every constraint through claripy.replace_dict on each add(), even when
+        # no replacements are registered.  That walk is superlinear on the
+        # deeply-shared symbolic expressions ordinary emulation produces, so
+        # enabling it globally regresses workloads that never label anything.
+        self._use_replacement_solver: bool = use_replacement_solver
 
         # Plugin preset; tells us which plugin preset to use.
         self._plugin_preset = "default"
@@ -214,19 +234,23 @@ class AngrEmulator(
             self.preinit(self)
 
         # Create a completely blank entry state
+        add_options = {
+            # angr.options.BYPASS_UNSUPPORTED_SYSCALL,
+            angr.options.KEEP_IP_SYMBOLIC,
+            angr.options.SYMBOL_FILL_UNCONSTRAINED_REGISTERS,
+            angr.options.SYMBOL_FILL_UNCONSTRAINED_MEMORY,
+        }
+        if self._use_replacement_solver:
+            # Bind labeled values via solver replacements rather than a giant
+            # conjunction of `symbol == value` constraints.  See
+            # _write_memory_label_bulk.  Opt-in only: the replacement frontend
+            # runs claripy.replace_dict over every constraint on each add(),
+            # which is superlinear on deeply-shared symbolic expressions, so it
+            # must not be imposed on workloads that never label memory.
+            add_options.add(angr.options.REPLACEMENT_SOLVER)
         self.state = self.proj.factory.blank_state(
             plugin_preset=self._plugin_preset,
-            add_options={
-                # angr.options.BYPASS_UNSUPPORTED_SYSCALL,
-                angr.options.KEEP_IP_SYMBOLIC,
-                angr.options.SYMBOL_FILL_UNCONSTRAINED_REGISTERS,
-                angr.options.SYMBOL_FILL_UNCONSTRAINED_MEMORY,
-                # Bind labeled values via solver replacements rather than a
-                # giant conjunction of `symbol == value` constraints.  See
-                # _write_memory_label_bulk; this keeps the first solve from
-                # ingesting every initialized byte at once.
-                angr.options.REPLACEMENT_SOLVER,
-            },
+            add_options=add_options,
             remove_options={
                 angr.options.SIMPLIFY_CONSTRAINTS,
                 angr.options.SIMPLIFY_EXIT_GUARD,

--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -12,6 +12,7 @@ from .. import emulator
 from .default import configure_default_plugins, configure_default_strategy
 from .factory import PatchedObjectFactory
 from .machdefs import AngrMachineDef
+from .replacement import MemoizingReplacementSolver
 from .simos import HookableSimOS
 
 log = logging.getLogger(__name__)
@@ -263,6 +264,15 @@ class AngrEmulator(
                 angr.options.SIMPLIFY_REGISTER_WRITES,
             },
         )
+        if self._use_replacement_solver:
+            # Swap angr's stock replacement solver for the memoizing one, whose
+            # replacement walk is linear rather than exponential in expression
+            # sharing depth.  Safe to install here: no constraints or
+            # replacements exist on the fresh state yet.
+            self.state.solver._stored_solver = MemoizingReplacementSolver(
+                auto_replace=False
+            )
+
         # If we're in linear mode,
         # limit the maximum number of results when solving
         # for a symbolic IP.  If the IP has constrained solutions,

--- a/smallworld/emulators/angr/angr.py
+++ b/smallworld/emulators/angr/angr.py
@@ -221,6 +221,11 @@ class AngrEmulator(
                 angr.options.KEEP_IP_SYMBOLIC,
                 angr.options.SYMBOL_FILL_UNCONSTRAINED_REGISTERS,
                 angr.options.SYMBOL_FILL_UNCONSTRAINED_MEMORY,
+                # Bind labeled values via solver replacements rather than a
+                # giant conjunction of `symbol == value` constraints.  See
+                # _write_memory_label_bulk; this keeps the first solve from
+                # ingesting every initialized byte at once.
+                angr.options.REPLACEMENT_SOLVER,
             },
             remove_options={
                 angr.options.SIMPLIFY_CONSTRAINTS,
@@ -646,6 +651,16 @@ class AngrEmulator(
         # This addresses a performance bottleneck during initialization;
         # it's not really intended for public use,
         # as it lacks some of the safety checks.
+        #
+        # When the replacement solver is enabled, we bind each label to its
+        # concrete value as a solver replacement (a substitution) rather than a
+        # `symbol == value` constraint.  The label symbol still lives in the
+        # stored AST, so provenance is preserved for data-flow analyses, but the
+        # binding never reaches z3.  Otherwise the first solve has to ingest one
+        # giant conjunction covering every initialized byte, which exhausts time
+        # and memory.  If someone has disabled REPLACEMENT_SOLVER, fall back to
+        # the constraint-based binding.
+        use_replacement = angr.options.REPLACEMENT_SOLVER in self.state.options
         cs = list()
         for addr, size, label in labels:
             if label is None:
@@ -653,9 +668,12 @@ class AngrEmulator(
             s = claripy.BVS(label, size * 8, explicit_name=True)
             v = self.state.memory.load(addr, size)
             self.state.memory.store(addr, s)
-            cs.append(s == v)
-        c = claripy.And(*cs)
-        self.state.solver.add(c)
+            if use_replacement:
+                self.state.solver._solver.add_replacement(s, v)
+            else:
+                cs.append(s == v)
+        if cs:
+            self.state.solver.add(claripy.And(*cs))
 
     def write_code(self, address: int, content: bytes):
         if self._initialized:

--- a/smallworld/emulators/angr/replacement.py
+++ b/smallworld/emulators/angr/replacement.py
@@ -1,0 +1,135 @@
+"""A hardened replacement solver for angr.
+
+angr's stock ``claripy.SolverReplacement`` runs ``claripy.replace_dict`` over
+every constraint on each ``add()``.  That walk descends into every node of the
+expression and only memoizes a subtree when a replacement actually fires, so on
+deeply-shared symbolic expressions -- a loop over a register or uninitialized
+value, say -- it re-expands shared subtrees and its cost is exponential in the
+sharing depth.  Registers (bound with constraints) and ``SYMBOL_FILL`` values
+are never replacements, so even an analysis that only labels *memory* is exposed
+whenever a branch guard is built from those.
+
+``MemoizingReplacementSolver`` closes that path with two changes to
+``_replacement``:
+
+1. **Disjoint short-circuit.**  If a constraint shares no variables with any
+   registered replacement, there is nothing to substitute -- return it
+   untouched, in O(1), without walking it at all.  This alone handles the common
+   case (guards that touch no labeled memory).
+
+2. **Full memoization.**  When a walk is unavoidable (a guard mixes labeled
+   memory with deeply-shared unlabeled subterms), substitute with a per-call
+   memo that caches *every* node -- identity results included -- so each distinct
+   node is visited once.  That makes the walk linear in the number of distinct
+   nodes instead of exponential.
+
+Results are identical to the stock frontend; only the traversal cost changes.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import claripy
+from claripy.solvers import SolverReplacement
+
+
+class MemoizingReplacementSolver(SolverReplacement):
+    """A ``SolverReplacement`` whose replacement walk is linear, not exponential.
+
+    See the module docstring for the rationale.  Drop-in for
+    ``claripy.SolverReplacement``.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Names of every variable that has a replacement registered.  Lets us
+        # skip the walk entirely for constraints that touch none of them.
+        self._replaced_var_names: typing.Set[str] = set()
+
+    # -- keep _replaced_var_names in sync across registration and branching --
+
+    def add_replacement(self, old, new, **kwargs):
+        if isinstance(old, claripy.ast.Base):
+            self._replaced_var_names |= old.variables
+        return super().add_replacement(old, new, **kwargs)
+
+    def clear_replacements(self):
+        super().clear_replacements()
+        self._replaced_var_names = set()
+
+    def _blank_copy(self, c):
+        super()._blank_copy(c)
+        c._replaced_var_names = set()
+
+    def _copy(self, c):
+        super()._copy(c)
+        c._replaced_var_names = set(self._replaced_var_names)
+
+    # -- the hardened replacement --
+
+    def _replacement(self, old):
+        if not isinstance(old, claripy.ast.Base):
+            return old
+
+        # (1) Nothing to replace in here: skip the walk.
+        if old.variables.isdisjoint(self._replaced_var_names):
+            return old
+
+        cached = self._replacement_cache.get(old.hash())
+        if cached is not None:
+            return cached
+
+        # (2) Fully-memoized substitution (linear in distinct nodes).
+        new = self._memoized_replace(old)
+        if new is not old:
+            self._replacement_cache[old.hash()] = new
+        return new
+
+    def _memoized_replace(self, expr: claripy.ast.Base) -> claripy.ast.Base:
+        replacements = self._replacement_cache
+        memo: typing.Dict[int, typing.Any] = {}
+        # Iterative post-order DFS.  `out` accumulates finished results in
+        # completion order; children land immediately before their parent.
+        stack: typing.List[typing.Tuple[typing.Any, bool]] = [(expr, False)]
+        out: typing.List[typing.Any] = []
+        while stack:
+            node, processed = stack.pop()
+
+            if not isinstance(node, claripy.ast.Base):
+                out.append(node)
+                continue
+
+            h = node.hash()
+            if not processed:
+                memoed = memo.get(h)
+                if memoed is not None:
+                    out.append(memoed)
+                    continue
+                if h in replacements:
+                    memo[h] = replacements[h]
+                    out.append(replacements[h])
+                    continue
+                if node.is_leaf() or not node.args:
+                    memo[h] = node
+                    out.append(node)
+                    continue
+                # Descend: reprocess this node after its children finish.
+                stack.append((node, True))
+                for arg in reversed(node.args):
+                    stack.append((arg, False))
+                continue
+
+            # Second visit: children results are the last len(args) of `out`.
+            n = len(node.args)
+            new_args = out[-n:]
+            del out[-n:]
+            if any(a is not b for a, b in zip(node.args, new_args)):
+                res = node.make_like(node.op, tuple(new_args))
+            else:
+                res = node
+            memo[h] = res
+            out.append(res)
+
+        assert len(out) == 1, ("replacement walk left a malformed stack", len(out))
+        return out[0]

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -13,6 +13,7 @@ import struct
 import subprocess
 import sys
 import tempfile
+import time
 import types
 import typing
 import unittest
@@ -53,6 +54,7 @@ from pcode_use_def.test import (  # noqa: F401 - registers the TestCases
 
 from smallworld import emulators, exceptions, helpers, hinting, platforms, state, utils
 from smallworld.analyses import trace_execution
+from smallworld.emulators.angr.replacement import MemoizingReplacementSolver
 from smallworld.analyses.colorizer_read_write import (
     ColorizerReadWrite,
     MemLvalDvKey,
@@ -7093,6 +7095,112 @@ class PEBaseRelocationTests(unittest.TestCase):
             BINARIES_TESTS_DIR / "pe" / "pe.i386.pe", I386_PLATFORM, 0x10000000, 4
         )
         self.assertEqual(loaded, (original + delta) & 0xFFFFFFFF)
+
+
+class MemoizingReplacementSolverTests(unittest.TestCase):
+    """Regression tests for the hardened crash-triage replacement solver.
+
+    angr's stock ``SolverReplacement`` walks ``claripy.replace_dict`` over every
+    constraint and only memoizes subtrees where a replacement fires, so a branch
+    guard built from a deeply-shared *non-replaced* symbol (a register or
+    uninitialized value) costs time exponential in the sharing depth.  That is
+    what hung ``square.msp430x.angr`` once ``REPLACEMENT_SOLVER`` was enabled.
+    ``MemoizingReplacementSolver`` must stay linear while producing identical
+    substitutions.  Each walk below is depth 20, which takes the stock solver
+    minutes; the fix must finish well under a second.
+    """
+
+    # Generous ceiling: the stock solver needs minutes at these depths, the
+    # memoizing one microseconds, so any regression to the old behaviour blows
+    # far past this rather than flirting with it.
+    _BUDGET_SECS = 2.0
+
+    @staticmethod
+    def _deep(base, n):
+        # Each level references the running expression twice: O(n) distinct
+        # nodes, but exponentially many unshared root-to-leaf paths.
+        e = base
+        for _ in range(n):
+            e = (e + (e << 1)) ^ (e >> 1)
+        return e
+
+    def _solver(self):
+        mem = claripy.BVS("memory_403000", 64, explicit_name=True)
+        s = MemoizingReplacementSolver(auto_replace=False)
+        s.add_replacement(mem, claripy.BVV(0xDEAD, 64))
+        return s, mem
+
+    def test_disjoint_guard_is_untouched_and_instant(self):
+        s, _mem = self._solver()
+        reg = claripy.BVS("r15", 64, explicit_name=True)
+        guard = self._deep(reg, 20) == 0  # touches no replacement
+        start = time.perf_counter()
+        result = s._replacement(guard)
+        elapsed = time.perf_counter() - start
+        self.assertIs(result, guard)  # short-circuited to identity
+        self.assertLess(elapsed, self._BUDGET_SECS)
+
+    def test_mixed_guard_substitutes_and_stays_linear(self):
+        s, mem = self._solver()
+        reg = claripy.BVS("r15", 64, explicit_name=True)
+        guard = (self._deep(reg, 20) + mem) == 0  # not disjoint -> forces the walk
+        start = time.perf_counter()
+        result = s._replacement(guard)
+        elapsed = time.perf_counter() - start
+        self.assertLess(elapsed, self._BUDGET_SECS)
+        self.assertNotIn("memory_403000", result.variables)  # label substituted
+        self.assertIn("r15", result.variables)  # register preserved
+
+    def test_result_matches_stock_replacement(self):
+        # On a shallow (correctness-only) expression the memoizing walk must
+        # produce exactly what claripy's own walk does.
+        from claripy.solvers import SolverReplacement
+
+        mem = claripy.BVS("memory_403000", 64, explicit_name=True)
+        reg = claripy.BVS("r15", 64, explicit_name=True)
+        val = claripy.BVV(0xDEAD, 64)
+        expr = ((mem + reg) ^ (mem << 2)) == 0
+
+        mine = MemoizingReplacementSolver(auto_replace=False)
+        mine.add_replacement(mem, val)
+        stock = SolverReplacement(auto_replace=False)
+        stock.add_replacement(mem, val)
+
+        self.assertTrue(
+            mine._replacement(expr).structurally_match(stock._replacement(expr))
+        )
+
+    def test_survives_branch(self):
+        # The replaced-variable set must carry across solver branching, or a
+        # branched state would silently stop substituting (fast but wrong).
+        s, mem = self._solver()
+        branched = s.branch()
+        reg = claripy.BVS("r15", 64, explicit_name=True)
+        guard = (self._deep(reg, 20) + mem) == 0
+        start = time.perf_counter()
+        result = branched._replacement(guard)
+        self.assertLess(time.perf_counter() - start, self._BUDGET_SECS)
+        self.assertNotIn("memory_403000", result.variables)
+
+    def test_emulator_installs_memoizing_solver_only_when_opted_in(self):
+        platform = platforms.Platform(
+            platforms.Architecture.X86_64, platforms.Byteorder.LITTLE
+        )
+
+        opt_in = emulators.AngrEmulator(platform, use_replacement_solver=True)
+        opt_in._code.append((0x400000, b"\x90\x90"))
+        opt_in.initialize()
+        self.assertIsInstance(
+            opt_in.state.solver._solver, MemoizingReplacementSolver
+        )
+
+        # A default emulator must not pay the replacement tax at all.
+        default = emulators.AngrEmulator(platform)
+        default._code.append((0x400000, b"\x90\x90"))
+        default.initialize()
+        self.assertNotIsInstance(
+            default.state.solver._solver, MemoizingReplacementSolver
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -54,7 +54,6 @@ from pcode_use_def.test import (  # noqa: F401 - registers the TestCases
 
 from smallworld import emulators, exceptions, helpers, hinting, platforms, state, utils
 from smallworld.analyses import trace_execution
-from smallworld.emulators.angr.replacement import MemoizingReplacementSolver
 from smallworld.analyses.colorizer_read_write import (
     ColorizerReadWrite,
     MemLvalDvKey,
@@ -72,6 +71,7 @@ from smallworld.analyses.trace_execution_types import CmpEntry, TraceElement, Tr
 from smallworld.analyses.unstable.pointer_finder import PointerFinder
 from smallworld.arch import amd64_arch
 from smallworld.emulators.angr.exceptions import PathTerminationSignal
+from smallworld.emulators.angr.replacement import MemoizingReplacementSolver
 from smallworld.emulators.unicorn.machdefs.ppc import PPC64MachineDef, PPCMachineDef
 from smallworld.extern.ctypes import TypedPointer, create_typed_pointer
 from smallworld.hinting import (
@@ -7190,9 +7190,7 @@ class MemoizingReplacementSolverTests(unittest.TestCase):
         opt_in = emulators.AngrEmulator(platform, use_replacement_solver=True)
         opt_in._code.append((0x400000, b"\x90\x90"))
         opt_in.initialize()
-        self.assertIsInstance(
-            opt_in.state.solver._solver, MemoizingReplacementSolver
-        )
+        self.assertIsInstance(opt_in.state.solver._solver, MemoizingReplacementSolver)
 
         # A default emulator must not pay the replacement tax at all.
         default = emulators.AngrEmulator(platform)


### PR DESCRIPTION
Labeling all initialized memory lets angr act as a high-precision data-flow tool for crash triage, but _write_memory_label_bulk bound each label to its concrete value with a `symbol == value` constraint and added them all as one giant conjunction. The first downstream solve forced z3 to ingest an equality for every initialized byte at once, exhausting time and memory.

These bindings are definitions (a symbol aliased to a constant), not search constraints. Enable REPLACEMENT_SOLVER by default in AngrEmulator and, when it is active, register each binding via add_replacement (a substitution) instead of a constraint. The label symbol still lives in the stored AST, so provenance is preserved for _diagnose_expression, but nothing reaches z3; only the symbols that actually flow into a queried expression get substituted at solve time.

Gated on the state option so disabling REPLACEMENT_SOLVER cleanly falls back to the constraint-based binding. Full crash-triage suite passes across all 7 architectures (aarch64, amd64, armel, armhf, i386, mips, mipsel).