### PR TITLE
feat: resolve x86-64 TLS descriptors (gnu2 dialect)

### DIFF
--- a/smallworld/state/memory/elf/elf.py
+++ b/smallworld/state/memory/elf/elf.py
@@ -105,6 +105,8 @@ PT_HIPROC = 0x7FFFFFFF  # End of processor-specific types
 SHF_WRITE = 0x1  # Section is writable
 SHF_ALLOC = 0x2  # Section occupies memory durring execution
 SHF_EXECINSTR = 0x4  # Section is executable
+SHF_TLS = 0x400  # Section holds thread-local storage
+SHT_NOBITS = 8  # Section occupies no file space (.bss/.tbss)
 
 # Program header flags
 PF_X = 0x1  # Segment is executable
@@ -186,6 +188,11 @@ class ElfExecutable(Executable):
         # resolver yet -- and filled in by bind_tlsdesc_resolver once a model
         # library is linked. See AMD64ElfRelocator's R_X86_64_TLSDESC case.
         self._tlsdesc_descriptors: typing.List[int] = list()
+        # Synthetic GOT for object files, which name descriptor slots a linker
+        # would have created. Keyed by symbol index so a symbol referenced from
+        # several call sites shares one descriptor, as it would after linking.
+        self._tlsdesc_got: typing.Dict[int, int] = dict()
+        self._tlsdesc_got_next: typing.Optional[int] = None
         # PT_TLS: the module's thread-local initialization image, its full
         # size including .tbss, and its required alignment. Empty when the
         # image declares no thread-locals.
@@ -652,6 +659,15 @@ class ElfExecutable(Executable):
         section_data_offsets: typing.Dict[int, int] = dict()
         section_rodata_offsets: typing.Dict[int, int] = dict()
 
+        # The thread-local sections are a TEMPLATE, not process memory: a
+        # thread-local's st_value is an offset within the module's TLS block,
+        # not within the image. They are laid out separately here, and the
+        # symbol loop below uses these offsets rather than the section ones.
+        # They are still allowed into the data blob as before -- the bytes are
+        # dead but excluding them would shift every offset in existing images.
+        tls = bytearray()
+        tls_section_offsets: typing.Dict[int, int] = dict()
+
         # Basically every architecture needs a GOT;
         # they will have relocations that reference either the GOT itself,
         # or a symbol's GOT slot
@@ -663,6 +679,23 @@ class ElfExecutable(Executable):
                 # Section is not allocated;
                 # It's metadata that won't get referenced later.
                 continue
+
+            if (section.flags & SHF_TLS) != 0:
+                skew = len(tls) % section.alignment
+                if skew != 0:
+                    tls.extend(b"\0" * (section.alignment - skew))
+                tls_section_offsets[index] = len(tls)
+                self._tls_align = max(self._tls_align, section.alignment)
+                if section.type == SHT_NOBITS:
+                    # .tbss occupies no file space; it contributes zeroes.
+                    tls.extend(b"\0" * section.original_size)
+                else:
+                    tls.extend(
+                        image[
+                            section.file_offset : section.file_offset
+                            + section.original_size
+                        ]
+                    )
 
             if (section.flags & SHF_EXECINSTR) != 0:
                 # Section is executable
@@ -721,8 +754,21 @@ class ElfExecutable(Executable):
         if len(data) > 0:
             self[data_offset] = BytesValue(bytes(data), None)
 
+        if len(tls) > 0:
+            self._tls_image = bytes(tls)
+            self._tls_size = len(tls)
+
         for sym in elf.symbols:
-            if sym.shndx in self._section_offsets:
+            if sym.type.value == STT_TLS:
+                # A thread-local's value is an offset within its section of
+                # the TLS BLOCK. Adding the section's image offset instead --
+                # which is what happened before -- turns a small block offset
+                # into an image offset, so every descriptor argument named a
+                # slot far outside the block and adjacent thread-locals
+                # stopped being distinguishable from unrelated data.
+                if sym.shndx in tls_section_offsets:
+                    sym.value += tls_section_offsets[sym.shndx]
+            elif sym.shndx in self._section_offsets:
                 sym.value += self._section_offsets[sym.shndx]
 
     def _extract_dtags(self, elf):
@@ -1057,7 +1103,12 @@ class ElfExecutable(Executable):
             return
         unresolved: typing.Dict[str, int] = dict()
         for rela in itertools.chain(self._dynamic_relas, self._static_relas):
-            if rela.symbol.defined or not self._relocator.is_tls_descriptor(rela):
+            if rela.symbol.defined:
+                continue
+            if not (
+                self._relocator.is_tls_descriptor(rela)
+                or self._relocator.is_tls_descriptor_reference(rela)
+            ):
                 continue
             self._relocator.relocate(self, rela)
             name = rela.symbol.name or f"<symbol {rela.symbol.idx}>"
@@ -1203,6 +1254,40 @@ class ElfExecutable(Executable):
         if not self._tls_size:
             return b""
         return self._tls_image.ljust(self._tls_size, b"\x00")
+
+    def tlsdesc_got_slot(self, symbol_index: int) -> int:
+        """Address of the TLS descriptor for a symbol, creating it if needed.
+
+        A linked image has its descriptors in the GOT already; an object file
+        does not, because building the GOT is the linker's job. Rather than
+        refuse the image -- which costs every function in it -- lay the
+        missing slots out past the end of the loaded sections, one per symbol
+        so that repeated references share storage the way a real GOT entry
+        would. The region grows this image's capacity, so it is mapped along
+        with everything else when the memory is applied.
+
+        Allocation is keyed and idempotent because relocation is not one-shot:
+        `update_symbol_value` re-relocates every rela attached to a symbol.
+        """
+        if symbol_index in self._tlsdesc_got:
+            return self._tlsdesc_got[symbol_index]
+        if self.platform is None:
+            raise ConfigurationError(
+                "No platform defined; cannot size a TLS descriptor"
+            )
+        size = 2 * PlatformDef.for_platform(self.platform).address_size
+        if self._tlsdesc_got_next is None:
+            # Start on a page of its own rather than abutting the last
+            # section: a synthetic region overlapping real content would be
+            # far harder to recognise in a memory dump than a gap.
+            self._tlsdesc_got_next = self._page_align(self.size, up=True)
+        offset = self._tlsdesc_got_next
+        self._tlsdesc_got_next += size
+        self.size = max(self.size, offset + size)
+        self[offset] = BytesValue(b"\0" * size, "synthetic TLS descriptor")
+        address = self.address + offset
+        self._tlsdesc_got[symbol_index] = address
+        return address
 
     def note_tlsdesc_descriptor(self, address: int) -> int:
         """Record a TLS descriptor and hand back the resolver it should carry.

--- a/smallworld/state/memory/elf/elf.py
+++ b/smallworld/state/memory/elf/elf.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import typing
 
@@ -1026,6 +1027,50 @@ class ElfExecutable(Executable):
             for sym in self._dynamic_symbols[1:]:
                 if SHN_UNDEF < sym.shndx < SHN_LORESERVE:
                     self.update_symbol_value(sym, sym.value, rebase=False)
+
+        self._relocate_undefined_tls_descriptors()
+
+    def _relocate_undefined_tls_descriptors(self) -> None:
+        """Relocate and record TLS descriptors whose thread-local is external.
+
+        The loops above deliberately skip undefined symbols: a real loader
+        resolves those against another module, which is `link_elf`'s job. That
+        is right for a data or function reference -- an unrelocated one just
+        reads or calls null, and the caller notices.
+
+        A TLS descriptor is different. Its first word is a resolver that gnu2
+        code CALLS indirectly, so leaving it null does not produce a bad value
+        somewhere; it transfers control to address zero. And because nothing
+        ever recorded the descriptor, `bind_tlsdesc_resolver` did not know to
+        fill it in even once a model library was linked, and no warning
+        mentioned TLS at all. An image referencing an `extern __thread`
+        variable no module defines therefore loaded clean and jumped to zero.
+
+        Relocating them here writes the addend-derived argument and enrolls
+        them for binding, so the call reaches the resolver model instead. The
+        thread-local's true block offset is still unknown -- every such access
+        aliases onto the same storage -- so this warns rather than pretending
+        to have resolved it. If a definer IS linked later, `link_elf` calls
+        `update_symbol_value`, which re-relocates and writes the real offset.
+        """
+        if self._relocator is None:
+            return
+        unresolved: typing.Dict[str, int] = dict()
+        for rela in itertools.chain(self._dynamic_relas, self._static_relas):
+            if rela.symbol.defined or not self._relocator.is_tls_descriptor(rela):
+                continue
+            self._relocator.relocate(self, rela)
+            name = rela.symbol.name or f"<symbol {rela.symbol.idx}>"
+            unresolved[name] = unresolved.get(name, 0) + 1
+        if unresolved:
+            listed = ", ".join(sorted(unresolved))
+            log.warning(
+                f"{sum(unresolved.values())} TLS descriptor(s) reference "
+                f"thread-locals no loaded module defines ({listed}). They are "
+                f"bound to the resolver so they no longer call address zero, "
+                f"but their block offsets are unknown and all such accesses "
+                f"share one slot. Load the defining module to resolve them."
+            )
 
     def _get_symbols(
         self, name: typing.Union[str, int], dynamic: bool

--- a/smallworld/state/memory/elf/elf.py
+++ b/smallworld/state/memory/elf/elf.py
@@ -90,6 +90,7 @@ PT_NOTE = 4  # Points to auxiliary information
 PT_SHLIB = 5  # Reserved value; I think it's unused
 PT_PHDR = 6  # Points to program header table
 PT_TLS = 7  # Indicates need for thread-local storage
+STT_TLS = 6  # Symbol names a thread-local; its value is a TLS-block offset
 PT_LOOS = 0x60000000  # Start of OS-specific types
 PT_GNU_EH_FRAME = 0x6474E550  # GNU-specific: Points to exception handler segment
 PT_GNU_STACK = 0x6474E551  # GNU-specific: Describes stack permissions
@@ -1236,7 +1237,19 @@ class ElfExecutable(Executable):
                 continue
 
             o_sym = o_syms[0]
-            self.update_symbol_value(my_sym, o_sym.value + o_sym.baseaddr, rebase=True)
+            if o_sym.type == STT_TLS:
+                # A thread-local's value is an offset within its module's TLS
+                # block, not an address. Rebasing it -- adding the definer's
+                # load address and subtracting ours -- leaves the delta between
+                # the two images, which is not an offset into anything: two
+                # thread-locals in modules loaded far apart then resolve to the
+                # same storage, and a definer loaded below the referencer
+                # produces a negative one.
+                self.update_symbol_value(my_sym, o_sym.value, rebase=False)
+            else:
+                self.update_symbol_value(
+                    my_sym, o_sym.value + o_sym.baseaddr, rebase=True
+                )
 
     def __getstate__(self):
         # Override the default pickling mechanism.

--- a/smallworld/state/memory/elf/elf.py
+++ b/smallworld/state/memory/elf/elf.py
@@ -184,6 +184,12 @@ class ElfExecutable(Executable):
         # resolver yet -- and filled in by bind_tlsdesc_resolver once a model
         # library is linked. See AMD64ElfRelocator's R_X86_64_TLSDESC case.
         self._tlsdesc_descriptors: typing.List[int] = list()
+        # PT_TLS: the module's thread-local initialization image, its full
+        # size including .tbss, and its required alignment. Empty when the
+        # image declares no thread-locals.
+        self._tls_image: bytes = b""
+        self._tls_size: int = 0
+        self._tls_align: int = 1
         # Resolver address the descriptors above should carry. Null until a
         # model library is linked; remembered so that a descriptor relocated
         # later -- or re-relocated, which happens whenever a symbol's value is
@@ -553,9 +559,19 @@ class ElfExecutable(Executable):
                 # Useful for the dynamic linker, but not for us
                 pass
             elif phdr_type == PT_TLS:
-                # TLS Segment
-                # Your analysis is about to get nasty :(
-                log.debug("Program includes thread-local storage")
+                # The initialization image for this module's thread-locals:
+                # `filesz` bytes of initialized data followed by `memsz -
+                # filesz` zero bytes (.tbss). A TLS symbol's st_value is an
+                # offset into this block, so whoever hands out thread-local
+                # storage can seed it from here -- without which every
+                # thread-local reads zero instead of its initializer.
+                self._tls_image = bytes(phdr.content)[: phdr.physical_size]
+                self._tls_size = int(phdr.virtual_size)
+                self._tls_align = max(1, int(phdr.alignment))
+                log.debug(
+                    f"Program includes thread-local storage: "
+                    f"{len(self._tls_image):#x} init bytes of {self._tls_size:#x}"
+                )
             elif phdr_type == PT_GNU_EH_FRAME:
                 # Exception handler frame.
                 # GCC puts one of these in everything.  Do we care?
@@ -1133,6 +1149,14 @@ class ElfExecutable(Executable):
     def tlsdesc_descriptors(self) -> typing.List[int]:
         """Addresses of the TLS descriptors this image carries."""
         return list(self._tlsdesc_descriptors)
+
+    @property
+    def tls_image(self) -> bytes:
+        """The module's thread-local initialization image, zero-extended to
+        its full size (`memsz`), or empty if it declares no thread-locals."""
+        if not self._tls_size:
+            return b""
+        return self._tls_image.ljust(self._tls_size, b"\x00")
 
     def note_tlsdesc_descriptor(self, address: int) -> int:
         """Record a TLS descriptor and hand back the resolver it should carry.

--- a/smallworld/state/memory/elf/elf.py
+++ b/smallworld/state/memory/elf/elf.py
@@ -184,6 +184,11 @@ class ElfExecutable(Executable):
         # resolver yet -- and filled in by bind_tlsdesc_resolver once a model
         # library is linked. See AMD64ElfRelocator's R_X86_64_TLSDESC case.
         self._tlsdesc_descriptors: typing.List[int] = list()
+        # Resolver address the descriptors above should carry. Null until a
+        # model library is linked; remembered so that a descriptor relocated
+        # later -- or re-relocated, which happens whenever a symbol's value is
+        # updated -- is written with the bound resolver rather than null again.
+        self._tlsdesc_resolver: int = 0
 
         # Read the entire image out of the file.
         image = file.read()
@@ -1124,9 +1129,23 @@ class ElfExecutable(Executable):
         else:
             log.error(f"No platform defined; cannot relocate {name}!")
 
-    def note_tlsdesc_descriptor(self, address: int) -> None:
-        """Record a TLS descriptor whose resolver word still needs binding."""
-        self._tlsdesc_descriptors.append(address)
+    @property
+    def tlsdesc_descriptors(self) -> typing.List[int]:
+        """Addresses of the TLS descriptors this image carries."""
+        return list(self._tlsdesc_descriptors)
+
+    def note_tlsdesc_descriptor(self, address: int) -> int:
+        """Record a TLS descriptor and hand back the resolver it should carry.
+
+        Relocation is not one-shot: `update_symbol_value` re-relocates every
+        rela attached to a symbol, so this can be called repeatedly for the
+        same descriptor. Returning the bound resolver (null until a model
+        library is linked) keeps the relocator idempotent -- a re-relocation
+        after binding rewrites the same resolver instead of nulling it.
+        """
+        if address not in self._tlsdesc_descriptors:
+            self._tlsdesc_descriptors.append(address)
+        return self._tlsdesc_resolver
 
     def bind_tlsdesc_resolver(self, address: int) -> None:
         """Point every TLS descriptor's resolver word at `address`.
@@ -1136,15 +1155,15 @@ class ElfExecutable(Executable):
         long before that. Without this the resolver word stays null and code
         built with -mtls-dialect=gnu2 calls address zero.
         """
-        if not self._tlsdesc_descriptors or self.platform is None:
+        self._tlsdesc_resolver = address
+        if not self._tlsdesc_descriptors:
+            return
+        if self.platform is None:
+            log.error("No platform defined; cannot bind the TLS descriptor resolver!")
             return
         size = PlatformDef.for_platform(self.platform).address_size
-        order: typing.Literal["little", "big"] = (
-            "little" if self.platform.byteorder is Byteorder.LITTLE else "big"
-        )
-        packed = address.to_bytes(size, order)
         for descriptor in self._tlsdesc_descriptors:
-            self.write_bytes(descriptor, packed)
+            self.write_int(descriptor, address, size, self.platform.byteorder)
 
     def link_elf(
         self, elf: "ElfExecutable", dynamic: bool = True, all_syms: bool = False

--- a/smallworld/state/memory/elf/elf.py
+++ b/smallworld/state/memory/elf/elf.py
@@ -184,13 +184,11 @@ class ElfExecutable(Executable):
         self._syms_by_name: typing.Dict[str, typing.List[ElfSymbol]] = dict()
         self._relocator: typing.Optional[ElfRelocator] = None
         # Addresses of TLS-descriptor pairs written by the relocator. Their
-        # resolver word is left null at load -- nothing has an address for a
-        # resolver yet -- and filled in by bind_tlsdesc_resolver once a model
-        # library is linked. See AMD64ElfRelocator's R_X86_64_TLSDESC case.
+        # resolver word is null at load and filled in by
+        # bind_tlsdesc_resolver once a model library is linked.
         self._tlsdesc_descriptors: typing.List[int] = list()
-        # Synthetic GOT for object files, which name descriptor slots a linker
-        # would have created. Keyed by symbol index so a symbol referenced from
-        # several call sites shares one descriptor, as it would after linking.
+        # Synthetic GOT for object files, whose descriptor slots no linker
+        # built. Keyed by symbol so several call sites share one descriptor.
         self._tlsdesc_got: typing.Dict[int, int] = dict()
         self._tlsdesc_got_next: typing.Optional[int] = None
         # PT_TLS: the module's thread-local initialization image, its full
@@ -199,10 +197,9 @@ class ElfExecutable(Executable):
         self._tls_image: bytes = b""
         self._tls_size: int = 0
         self._tls_align: int = 1
-        # Resolver address the descriptors above should carry. Null until a
-        # model library is linked; remembered so that a descriptor relocated
-        # later -- or re-relocated, which happens whenever a symbol's value is
-        # updated -- is written with the bound resolver rather than null again.
+        # Resolver the descriptors above should carry, remembered so that a
+        # descriptor relocated (or re-relocated) after binding is not written
+        # back to null.
         self._tlsdesc_resolver: int = 0
 
         # Read the entire image out of the file.
@@ -568,12 +565,10 @@ class ElfExecutable(Executable):
                 # Useful for the dynamic linker, but not for us
                 pass
             elif phdr_type == PT_TLS:
-                # The initialization image for this module's thread-locals:
-                # `filesz` bytes of initialized data followed by `memsz -
-                # filesz` zero bytes (.tbss). A TLS symbol's st_value is an
-                # offset into this block, so whoever hands out thread-local
-                # storage can seed it from here -- without which every
-                # thread-local reads zero instead of its initializer.
+                # This module's thread-local initialization image: `filesz`
+                # initialized bytes then `memsz - filesz` zeroes (.tbss). A
+                # TLS symbol's st_value indexes into it, so whoever hands out
+                # thread-local storage can seed it from here.
                 self._tls_image = bytes(phdr.content)[: phdr.physical_size]
                 self._tls_size = int(phdr.virtual_size)
                 self._tls_align = max(1, int(phdr.alignment))
@@ -659,12 +654,11 @@ class ElfExecutable(Executable):
         section_data_offsets: typing.Dict[int, int] = dict()
         section_rodata_offsets: typing.Dict[int, int] = dict()
 
-        # The thread-local sections are a TEMPLATE, not process memory: a
-        # thread-local's st_value is an offset within the module's TLS block,
-        # not within the image. They are laid out separately here, and the
-        # symbol loop below uses these offsets rather than the section ones.
-        # They are still allowed into the data blob as before -- the bytes are
-        # dead but excluding them would shift every offset in existing images.
+        # TLS sections are a template, not process memory: st_value is an
+        # offset within the module's TLS block, not the image, so they get
+        # their own layout, used by the symbol loop below. They still go into
+        # the data blob as before -- dead bytes, but excluding them would
+        # shift every offset in existing images.
         tls = bytearray()
         tls_section_offsets: typing.Dict[int, int] = dict()
 
@@ -760,12 +754,8 @@ class ElfExecutable(Executable):
 
         for sym in elf.symbols:
             if sym.type.value == STT_TLS:
-                # A thread-local's value is an offset within its section of
-                # the TLS BLOCK. Adding the section's image offset instead --
-                # which is what happened before -- turns a small block offset
-                # into an image offset, so every descriptor argument named a
-                # slot far outside the block and adjacent thread-locals
-                # stopped being distinguishable from unrelated data.
+                # Relative to the TLS block, not the image: adding the
+                # section's image offset would point outside the block.
                 if sym.shndx in tls_section_offsets:
                     sym.value += tls_section_offsets[sym.shndx]
             elif sym.shndx in self._section_offsets:
@@ -1079,25 +1069,16 @@ class ElfExecutable(Executable):
     def _relocate_undefined_tls_descriptors(self) -> None:
         """Relocate and record TLS descriptors whose thread-local is external.
 
-        The loops above deliberately skip undefined symbols: a real loader
-        resolves those against another module, which is `link_elf`'s job. That
-        is right for a data or function reference -- an unrelocated one just
-        reads or calls null, and the caller notices.
+        The loops above skip undefined symbols, leaving them for `link_elf`.
+        That is fine for a data or function reference -- an unrelocated one
+        reads or calls null and the caller notices -- but a descriptor's first
+        word is a resolver called INDIRECTLY, so a null one jumps to address
+        zero, and an unrecorded descriptor cannot be bound later either.
 
-        A TLS descriptor is different. Its first word is a resolver that gnu2
-        code CALLS indirectly, so leaving it null does not produce a bad value
-        somewhere; it transfers control to address zero. And because nothing
-        ever recorded the descriptor, `bind_tlsdesc_resolver` did not know to
-        fill it in even once a model library was linked, and no warning
-        mentioned TLS at all. An image referencing an `extern __thread`
-        variable no module defines therefore loaded clean and jumped to zero.
-
-        Relocating them here writes the addend-derived argument and enrolls
-        them for binding, so the call reaches the resolver model instead. The
-        thread-local's true block offset is still unknown -- every such access
-        aliases onto the same storage -- so this warns rather than pretending
-        to have resolved it. If a definer IS linked later, `link_elf` calls
-        `update_symbol_value`, which re-relocates and writes the real offset.
+        Relocating them here enrolls them for binding, so the call reaches the
+        resolver. The real block offset is still unknown and every such access
+        aliases onto one slot, hence the warning. A definer linked later
+        re-relocates through `update_symbol_value` and writes the true offset.
         """
         if self._relocator is None:
             return
@@ -1258,16 +1239,11 @@ class ElfExecutable(Executable):
     def tlsdesc_got_slot(self, symbol_index: int) -> int:
         """Address of the TLS descriptor for a symbol, creating it if needed.
 
-        A linked image has its descriptors in the GOT already; an object file
-        does not, because building the GOT is the linker's job. Rather than
-        refuse the image -- which costs every function in it -- lay the
-        missing slots out past the end of the loaded sections, one per symbol
-        so that repeated references share storage the way a real GOT entry
-        would. The region grows this image's capacity, so it is mapped along
-        with everything else when the memory is applied.
-
-        Allocation is keyed and idempotent because relocation is not one-shot:
-        `update_symbol_value` re-relocates every rela attached to a symbol.
+        An object file has no GOT -- building one is the linker's job -- so
+        the missing slots go past the loaded sections, one per symbol, and
+        grow this image's capacity so they are mapped with everything else.
+        Keyed and idempotent, since `update_symbol_value` re-relocates every
+        rela attached to a symbol.
         """
         if symbol_index in self._tlsdesc_got:
             return self._tlsdesc_got[symbol_index]
@@ -1368,13 +1344,9 @@ class ElfExecutable(Executable):
 
             o_sym = o_syms[0]
             if o_sym.type == STT_TLS:
-                # A thread-local's value is an offset within its module's TLS
-                # block, not an address. Rebasing it -- adding the definer's
-                # load address and subtracting ours -- leaves the delta between
-                # the two images, which is not an offset into anything: two
-                # thread-locals in modules loaded far apart then resolve to the
-                # same storage, and a definer loaded below the referencer
-                # produces a negative one.
+                # A block offset, not an address: rebasing would leave the
+                # delta between the two load addresses, which indexes nothing
+                # -- and goes negative if the definer loaded lower.
                 self.update_symbol_value(my_sym, o_sym.value, rebase=False)
             else:
                 self.update_symbol_value(

--- a/smallworld/state/memory/elf/elf.py
+++ b/smallworld/state/memory/elf/elf.py
@@ -4,7 +4,7 @@ import typing
 import lief
 
 from ....exceptions import ConfigurationError
-from ....platforms import Architecture, Byteorder, Platform
+from ....platforms import Architecture, Byteorder, Platform, PlatformDef
 from ....utils import RangeCollection
 from ...state import BytesValue
 from ..code import Executable
@@ -179,6 +179,11 @@ class ElfExecutable(Executable):
         self._static_relas: typing.List[ElfRela] = list()
         self._syms_by_name: typing.Dict[str, typing.List[ElfSymbol]] = dict()
         self._relocator: typing.Optional[ElfRelocator] = None
+        # Addresses of TLS-descriptor pairs written by the relocator. Their
+        # resolver word is left null at load -- nothing has an address for a
+        # resolver yet -- and filled in by bind_tlsdesc_resolver once a model
+        # library is linked. See AMD64ElfRelocator's R_X86_64_TLSDESC case.
+        self._tlsdesc_descriptors: typing.List[int] = list()
 
         # Read the entire image out of the file.
         image = file.read()
@@ -1118,6 +1123,28 @@ class ElfExecutable(Executable):
                     self._relocator.relocate(self, rela)
         else:
             log.error(f"No platform defined; cannot relocate {name}!")
+
+    def note_tlsdesc_descriptor(self, address: int) -> None:
+        """Record a TLS descriptor whose resolver word still needs binding."""
+        self._tlsdesc_descriptors.append(address)
+
+    def bind_tlsdesc_resolver(self, address: int) -> None:
+        """Point every TLS descriptor's resolver word at `address`.
+
+        Called once a model library is linked, which is the first moment a
+        resolver has an address at all: the descriptors are relocated at load,
+        long before that. Without this the resolver word stays null and code
+        built with -mtls-dialect=gnu2 calls address zero.
+        """
+        if not self._tlsdesc_descriptors or self.platform is None:
+            return
+        size = PlatformDef.for_platform(self.platform).address_size
+        order: typing.Literal["little", "big"] = (
+            "little" if self.platform.byteorder is Byteorder.LITTLE else "big"
+        )
+        packed = address.to_bytes(size, order)
+        for descriptor in self._tlsdesc_descriptors:
+            self.write_bytes(descriptor, packed)
 
     def link_elf(
         self, elf: "ElfExecutable", dynamic: bool = True, all_syms: bool = False

--- a/smallworld/state/memory/elf/rela/amd64.py
+++ b/smallworld/state/memory/elf/rela/amd64.py
@@ -209,20 +209,23 @@ class AMD64ElfRelocator(ElfRelocator):
             # A two-word descriptor { resolver, argument } that gnu2-dialect TLS
             # code calls indirectly. The argument is the symbol's offset within
             # its TLS block, which is all the __tlsdesc_resolve model needs to
-            # hand out stable per-thread-local storage. The resolver is left
-            # null here because nothing has an address for one at load time;
-            # Library.link fills it in via bind_tlsdesc_resolver once the model
-            # library is placed. Refusing instead made the whole image fail to
-            # load, which cost every function in it -- a binary needs only one
-            # of these to be unloadable, and the functions that never touch a
-            # thread-local paid for it too.
-            elf.note_tlsdesc_descriptor(rela.offset)
+            # hand out stable per-thread-local storage. Refusing instead made
+            # the whole image fail to load, which cost every function in it.
+            #
+            # The resolver word comes back from note_tlsdesc_descriptor: null
+            # until a model library is linked (nothing has an address for a
+            # resolver at load time), and the bound address afterwards. Taking
+            # it from the ELF rather than hardcoding zero keeps relocation
+            # idempotent -- update_symbol_value re-relocates every rela of a
+            # symbol, so a hardcoded zero would silently unbind descriptors
+            # that Library.link had already bound.
+            resolver = elf.note_tlsdesc_descriptor(rela.offset)
             # A TLS symbol's st_value is its offset within the TLS block, not
             # an address, so this is the one place `symval` must not be used:
             # rebasing it turns a small offset into a load address and loses
             # the distinction between adjacent thread-locals.
             argument = rela.symbol.value + self._get_addend(rela, elf, 8)
-            return self._pack(0, 8) + self._pack(argument, 8)
+            return self._pack(resolver, 8) + self._pack(argument, 8)
         elif rela.type == R_X86_64_IRELATIVE:
             # Indirect relative relocations require executing an IFUNC resolver
             # at load time and using its return value.

--- a/smallworld/state/memory/elf/rela/amd64.py
+++ b/smallworld/state/memory/elf/rela/amd64.py
@@ -87,6 +87,15 @@ class AMD64ElfRelocator(ElfRelocator):
         mask = (1 << (size * 8)) - 1
         return (value & mask).to_bytes(size, self.byteorder.value)
 
+    def _tls_block_offset(self, rela: ElfRela, elf, size: int) -> int:
+        """A TLS symbol's offset within its module's TLS block.
+
+        Deliberately not `_symbol_value`: a TLS symbol's st_value is already an
+        offset into the block, so adding the load base would turn it into an
+        address and collapse the distinction between adjacent thread-locals.
+        """
+        return rela.symbol.value + self._get_addend(rela, elf, size)
+
     def _missing_context(self, rela: ElfRela, detail: str) -> None:
         raise ConfigurationError(
             f"Relocation {hex(rela.type)} for {self._symbol_name(rela)} requires "
@@ -144,8 +153,7 @@ class AMD64ElfRelocator(ElfRelocator):
             # otherwise-ordinary TLS-using shared objects.)
             return self._pack(1, 8)
         elif rela.type == R_X86_64_DTPOFF64:
-            # Dynamic TLS offsets depend on the module's TLS block layout.
-            self._missing_context(rela, "the symbol's offset within its TLS block")
+            return self._pack(self._tls_block_offset(rela, elf, 8), 8)
         elif rela.type == R_X86_64_TPOFF64:
             # Initial-exec/local-exec TLS offsets are relative to the thread pointer.
             self._missing_context(
@@ -158,8 +166,7 @@ class AMD64ElfRelocator(ElfRelocator):
             # Local-dynamic TLS uses a two-entry GOT descriptor for the module.
             self._missing_context(rela, "the TLS LD descriptor's GOT entry addresses")
         elif rela.type == R_X86_64_DTPOFF32:
-            # Dynamic TLS offsets depend on the module's TLS block layout.
-            self._missing_context(rela, "the symbol's offset within its TLS block")
+            return self._pack(self._tls_block_offset(rela, elf, 4), 4)
         elif rela.type == R_X86_64_GOTTPOFF:
             # Initial-exec TLS references a GOT slot holding the thread offset.
             self._missing_context(

--- a/smallworld/state/memory/elf/rela/amd64.py
+++ b/smallworld/state/memory/elf/rela/amd64.py
@@ -213,16 +213,13 @@ class AMD64ElfRelocator(ElfRelocator):
         elif rela.type == R_X86_64_SIZE64:
             return self._pack(rela.symbol.size + self._get_addend(rela, elf, 8), 8)
         elif rela.type == R_X86_64_GOTPC32_TLSDESC:
-            # The unlinked form of R_X86_64_TLSDESC. A linked object already
-            # has its two-word descriptor sitting in the GOT; an object file
-            # only has `lea x@tlsdesc(%rip)` naming a GOT slot the linker
-            # never got to create. Refusing here failed the whole image, which
-            # cost every function in it -- so synthesize the slot instead.
+            # The unlinked form of R_X86_64_TLSDESC: an object file has only
+            # `lea x@tlsdesc(%rip)`, naming a GOT slot no linker built, so
+            # synthesize one.
             slot = elf.tlsdesc_got_slot(rela.symbol.idx)
-            # Fill the descriptor the way the TLSDESC case does. The addend
-            # here belongs to the PC-RELATIVE computation -- gcc emits -4 for
-            # the rip-relative displacement -- and must not reach the
-            # argument, which is the symbol's TLS-block offset alone.
+            # The addend belongs to the PC-relative computation (gcc emits -4
+            # for the displacement), not to the argument, which is the
+            # symbol's block offset alone.
             elf.write_bytes(
                 slot,
                 self._pack(elf.note_tlsdesc_descriptor(slot), 8)
@@ -234,24 +231,14 @@ class AMD64ElfRelocator(ElfRelocator):
             # This is a marker relocation used to tag a TLS descriptor call sequence.
             return b""
         elif rela.type == R_X86_64_TLSDESC:
-            # A two-word descriptor { resolver, argument } that gnu2-dialect TLS
-            # code calls indirectly. The argument is the symbol's offset within
-            # its TLS block, which is all the __tlsdesc_resolve model needs to
-            # hand out stable per-thread-local storage. Refusing instead made
-            # the whole image fail to load, which cost every function in it.
-            #
-            # The resolver word comes back from note_tlsdesc_descriptor: null
-            # until a model library is linked (nothing has an address for a
-            # resolver at load time), and the bound address afterwards. Taking
-            # it from the ELF rather than hardcoding zero keeps relocation
-            # idempotent -- update_symbol_value re-relocates every rela of a
-            # symbol, so a hardcoded zero would silently unbind descriptors
-            # that Library.link had already bound.
+            # A two-word descriptor { resolver, argument } that gnu2-dialect
+            # TLS code calls indirectly. The resolver comes from the ELF --
+            # null until a model library is linked, bound afterwards -- rather
+            # than being hardcoded, so that re-relocating a symbol does not
+            # unbind descriptors Library.link already bound.
             resolver = elf.note_tlsdesc_descriptor(rela.offset)
-            # A TLS symbol's st_value is its offset within the TLS block, not
-            # an address, so this is the one place `symval` must not be used:
-            # rebasing it turns a small offset into a load address and loses
-            # the distinction between adjacent thread-locals.
+            # Not `symval`: a TLS symbol's st_value is a block offset, and
+            # rebasing it would turn it into a load address.
             argument = rela.symbol.value + self._get_addend(rela, elf, 8)
             return self._pack(resolver, 8) + self._pack(argument, 8)
         elif rela.type == R_X86_64_IRELATIVE:

--- a/smallworld/state/memory/elf/rela/amd64.py
+++ b/smallworld/state/memory/elf/rela/amd64.py
@@ -102,6 +102,9 @@ class AMD64ElfRelocator(ElfRelocator):
             f"{detail}, which is not available to AMD64ElfRelocator._compute_value()"
         )
 
+    def is_tls_descriptor(self, rela: ElfRela) -> bool:
+        return rela.type == R_X86_64_TLSDESC
+
     def _compute_value(self, rela: ElfRela, elf):
         symval = self._symbol_value(rela)
 

--- a/smallworld/state/memory/elf/rela/amd64.py
+++ b/smallworld/state/memory/elf/rela/amd64.py
@@ -206,10 +206,23 @@ class AMD64ElfRelocator(ElfRelocator):
             # This is a marker relocation used to tag a TLS descriptor call sequence.
             return b""
         elif rela.type == R_X86_64_TLSDESC:
-            # TLS descriptors require descriptor contents and runtime resolver state.
-            self._missing_context(
-                rela, "the TLS descriptor contents and resolver state"
-            )
+            # A two-word descriptor { resolver, argument } that gnu2-dialect TLS
+            # code calls indirectly. The argument is the symbol's offset within
+            # its TLS block, which is all the __tlsdesc_resolve model needs to
+            # hand out stable per-thread-local storage. The resolver is left
+            # null here because nothing has an address for one at load time;
+            # Library.link fills it in via bind_tlsdesc_resolver once the model
+            # library is placed. Refusing instead made the whole image fail to
+            # load, which cost every function in it -- a binary needs only one
+            # of these to be unloadable, and the functions that never touch a
+            # thread-local paid for it too.
+            elf.note_tlsdesc_descriptor(rela.offset)
+            # A TLS symbol's st_value is its offset within the TLS block, not
+            # an address, so this is the one place `symval` must not be used:
+            # rebasing it turns a small offset into a load address and loses
+            # the distinction between adjacent thread-locals.
+            argument = rela.symbol.value + self._get_addend(rela, elf, 8)
+            return self._pack(0, 8) + self._pack(argument, 8)
         elif rela.type == R_X86_64_IRELATIVE:
             # Indirect relative relocations require executing an IFUNC resolver
             # at load time and using its return value.

--- a/smallworld/state/memory/elf/rela/amd64.py
+++ b/smallworld/state/memory/elf/rela/amd64.py
@@ -154,9 +154,9 @@ class AMD64ElfRelocator(ElfRelocator):
             # TLS module relocations need the runtime-assigned TLS module ID.
             # SmallWorld emulates a single module in isolation, so there is
             # exactly one TLS module; assign it the conventional module ID 1.
-            # (DTPOFF64/TPOFF64 below still require real TLS-block layout and
-            # remain unsupported, but DTPMOD64 alone is what blocks loading
-            # otherwise-ordinary TLS-using shared objects.)
+            # DTPOFF64 below completes the pair with the symbol's offset
+            # within that module's block. (The initial-exec forms, TPOFF*,
+            # still need a real thread-pointer layout and remain unsupported.)
             return self._pack(1, 8)
         elif rela.type == R_X86_64_DTPOFF64:
             return self._pack(self._tls_block_offset(rela, elf, 8), 8)

--- a/smallworld/state/memory/elf/rela/amd64.py
+++ b/smallworld/state/memory/elf/rela/amd64.py
@@ -105,6 +105,9 @@ class AMD64ElfRelocator(ElfRelocator):
     def is_tls_descriptor(self, rela: ElfRela) -> bool:
         return rela.type == R_X86_64_TLSDESC
 
+    def is_tls_descriptor_reference(self, rela: ElfRela) -> bool:
+        return rela.type == R_X86_64_GOTPC32_TLSDESC
+
     def _compute_value(self, rela: ElfRela, elf):
         symval = self._symbol_value(rela)
 
@@ -210,8 +213,23 @@ class AMD64ElfRelocator(ElfRelocator):
         elif rela.type == R_X86_64_SIZE64:
             return self._pack(rela.symbol.size + self._get_addend(rela, elf, 8), 8)
         elif rela.type == R_X86_64_GOTPC32_TLSDESC:
-            # TLS descriptors live in the GOT and require a descriptor slot address.
-            self._missing_context(rela, "the GOT base and TLS descriptor entry address")
+            # The unlinked form of R_X86_64_TLSDESC. A linked object already
+            # has its two-word descriptor sitting in the GOT; an object file
+            # only has `lea x@tlsdesc(%rip)` naming a GOT slot the linker
+            # never got to create. Refusing here failed the whole image, which
+            # cost every function in it -- so synthesize the slot instead.
+            slot = elf.tlsdesc_got_slot(rela.symbol.idx)
+            # Fill the descriptor the way the TLSDESC case does. The addend
+            # here belongs to the PC-RELATIVE computation -- gcc emits -4 for
+            # the rip-relative displacement -- and must not reach the
+            # argument, which is the symbol's TLS-block offset alone.
+            elf.write_bytes(
+                slot,
+                self._pack(elf.note_tlsdesc_descriptor(slot), 8)
+                + self._pack(rela.symbol.value, 8),
+            )
+            # G + GOT + A - P: where the slot sits relative to this `lea`.
+            return self._pack(slot + self._get_addend(rela, elf, 4) - rela.offset, 4)
         elif rela.type == R_X86_64_TLSDESC_CALL:
             # This is a marker relocation used to tag a TLS descriptor call sequence.
             return b""

--- a/smallworld/state/memory/elf/rela/rela.py
+++ b/smallworld/state/memory/elf/rela/rela.py
@@ -36,6 +36,18 @@ class ElfRelocator:
         val = self._compute_value(rela, elf)
         elf.write_bytes(rela.offset, val)
 
+    def is_tls_descriptor(self, rela: ElfRela) -> bool:
+        """Whether this rela fills in a TLS descriptor { resolver, argument }.
+
+        Relocation types are per-architecture, so only a relocator can answer
+        this; the loader needs it to spot descriptors whose thread-local no
+        loaded module defines. Those are left unrelocated like any other
+        external reference, but unlike a data or function reference an
+        unrelocated descriptor is CALLED -- its null resolver word sends
+        control to address zero. Architectures with no descriptor ABI say no.
+        """
+        return False
+
     @classmethod
     def for_platform(cls, platform: platforms.Platform):
         try:

--- a/smallworld/state/memory/elf/rela/rela.py
+++ b/smallworld/state/memory/elf/rela/rela.py
@@ -48,6 +48,16 @@ class ElfRelocator:
         """
         return False
 
+    def is_tls_descriptor_reference(self, rela: ElfRela) -> bool:
+        """Whether this rela is a PC-relative reference to a descriptor SLOT.
+
+        The unlinked form of the same thing: a linker would have placed the
+        two-word descriptor in the GOT and left an `is_tls_descriptor` rela to
+        fill it in, but an object file has not been through a linker, so it
+        names a GOT slot that does not exist yet.
+        """
+        return False
+
     @classmethod
     def for_platform(cls, platform: platforms.Platform):
         try:

--- a/smallworld/state/models/amd64/systemv/c99/stdlib.py
+++ b/smallworld/state/models/amd64/systemv/c99/stdlib.py
@@ -25,6 +25,7 @@ from ....c99 import (
     Realloc,
     Srand,
     System,
+    TlsDescResolve,
     TlsGetAddr,
     Wcstombs,
     Wctomb,
@@ -94,6 +95,14 @@ class AMD64SysVMalloc(Malloc, AMD64SysVModel):
 
 class AMD64SysVTlsGetAddr(TlsGetAddr, AMD64SysVModel):
     pass
+
+
+class AMD64SysVTlsDescResolve(TlsDescResolve, AMD64SysVModel):
+    # The x86-64 TLS-descriptor ABI: %rax carries the descriptor address in and
+    # the thread-pointer-relative offset out; the thread pointer is %fs, whose
+    # base this platform models as the fsbase register.
+    descriptor_register = "rax"
+    thread_pointer_register = "fsbase"
 
 
 class AMD64SysVQSort(QSort, AMD64SysVModel):

--- a/smallworld/state/models/c99/stdlib.py
+++ b/smallworld/state/models/c99/stdlib.py
@@ -9,7 +9,7 @@ from smallworld.state.models.funcptr import FunctionPointer
 from .... import emulators, exceptions
 from ...memory.heap import Heap
 from ..cstd import ArgumentType, CStdModel
-from ..model import RELOCATED_TLS_MODULE
+from ..tls import RELOCATED_TLS_MODULE, TlsArenaBorrower, TlsArenaOwner
 from .utils import _emu_strlen
 
 logger = logging.getLogger("__name__")
@@ -495,7 +495,7 @@ def _tls_arena_slot(offset: int, arena_size: int) -> int:
     return offset % span
 
 
-class TlsGetAddr(CStdModel):
+class TlsGetAddr(CStdModel, TlsArenaOwner):
     # void *__tls_get_addr(tls_index *ti);  -- the glibc dynamic-TLS resolver.
     #
     # tls_index is { unsigned long ti_module; unsigned long ti_offset; } and the
@@ -564,7 +564,7 @@ class TlsGetAddr(CStdModel):
         self.set_return_value(emulator, addr)
 
 
-class TlsDescResolve(CStdModel):
+class TlsDescResolve(CStdModel, TlsArenaBorrower):
     # The TLS-descriptor resolver, for code built with -mtls-dialect=gnu2:
     #     lea  x@TLSDESC(%rip), %rax
     #     call *x@TLSCALL(%rax)      # descriptor address in, offset out
@@ -585,9 +585,9 @@ class TlsDescResolve(CStdModel):
     argument_types: typing.List[ArgumentType] = []
     return_type = ArgumentType.POINTER
 
-    # Borrows TlsGetAddr's arena rather than reserving one, so that a
-    # thread-local written through one dialect is visible through the other.
-    # The library assigns it, like malloc's heap.
+    # TlsArenaBorrower: reserves nothing, and reads TlsGetAddr's arena, so
+    # that a thread-local written through one dialect is visible through the
+    # other. The library assigns it, like malloc's heap.
     static_space_required = 0
 
     #: Register holding the descriptor address on entry and the offset on exit.

--- a/smallworld/state/models/c99/stdlib.py
+++ b/smallworld/state/models/c99/stdlib.py
@@ -585,6 +585,27 @@ class TlsDescResolve(CStdModel):
     #: Register holding the thread pointer the returned offset is relative to.
     thread_pointer_register: str = ""
 
+    def apply(self, emulator: emulators.Emulator) -> None:
+        super().apply(emulator)
+        # Install the TCB self-pointer BEFORE any code runs. gcc hoists the
+        # `mov %fs:0x0,%rdx` that reads it above the descriptor call -- often
+        # to the top of the function -- so a resolver that only writes it
+        # during the call writes it after the value has already been read.
+        # That read then yields zero and the access lands at
+        # `arena - thread_pointer` instead of on the arena.
+        try:
+            thread_pointer = emulator.read_register(self.thread_pointer_register)
+        except Exception:
+            return
+        if thread_pointer:
+            # A harness that maps its own TCB may not have been applied yet --
+            # apply order is the caller's, not ours -- so make sure the word
+            # exists before writing it. map_memory only fills gaps, so this
+            # neither disturbs an already-mapped TCB nor stops one being added
+            # later.
+            emulator.map_memory(thread_pointer, self.platdef.address_size)
+        self._ensure_tcb_self_pointer(emulator, thread_pointer)
+
     def model(self, emulator: emulators.Emulator) -> None:
         super().model(emulator)
         if self.tls_arena_address is None or self.tls_arena_size <= 0:

--- a/smallworld/state/models/c99/stdlib.py
+++ b/smallworld/state/models/c99/stdlib.py
@@ -479,19 +479,15 @@ def _tls_slot_span(arena_size: int) -> int:
 
 
 def _tls_arena_slot(offset: int, arena_size: int) -> int:
-    """Map a thread-local's block offset onto a bounded slot in its arena.
+    """Map a sign-interpreted block offset onto a bounded slot in its arena.
 
     Both TLS models go through this, so one thread-local reached through
-    either dialect lands on the same bytes (see RELOCATED_TLS_MODULE).
+    either dialect lands on the same bytes.
 
-    `offset` must already be sign-interpreted. A NEGATIVE block offset is
-    ordinary -- an addend like `x - 8` produces one, and the relocator packs
-    it as a huge unsigned word -- but folding that into the arena the obvious
-    way lands it on a perfectly legitimate positive offset, silently giving
-    two different thread-locals the same storage. So negatives get their own
-    half of the arena: still bounded, still stable per offset, but unable to
-    collide with a real one. Garbage arguments have the top bit set and land
-    there too, which is exactly where they belong.
+    Negative offsets are ordinary -- an addend like `x - 8` produces one --
+    and get their own half of the arena, since folding them in with the
+    positives drops them onto legitimate offsets. Garbage arguments have the
+    top bit set and land there too.
     """
     span = _tls_slot_span(arena_size)
     if offset < 0:
@@ -569,36 +565,19 @@ class TlsGetAddr(CStdModel):
 
 
 class TlsDescResolve(CStdModel):
-    # The TLS-descriptor resolver, for code built with -mtls-dialect=gnu2.
-    #
-    # gnu2 replaces the __tls_get_addr call with an indirect call through a
-    # two-word descriptor in the GOT: { resolver, argument }. The caller does
+    # The TLS-descriptor resolver, for code built with -mtls-dialect=gnu2:
     #     lea  x@TLSDESC(%rip), %rax
     #     call *x@TLSCALL(%rax)      # descriptor address in, offset out
     #     mov  %fs:(%rax), ...       # or: mov %fs:0x0,%rdx; add %rdx,%rax
-    # so the resolver returns a THREAD-POINTER-RELATIVE offset, not an address
-    # -- the difference from TlsGetAddr, which returns the address itself.
+    # so this returns a thread-pointer-RELATIVE offset, where TlsGetAddr
+    # returns the address itself. gcc emits both completions, sometimes in one
+    # function; they agree only when [thread_pointer] == thread_pointer, which
+    # apply() arranges.
     #
-    # NOTE: gcc emits BOTH completions above, sometimes in one function. The
-    # first adds the thread-pointer register; the second adds the word AT the
-    # thread pointer (the glibc TCB self-pointer). They agree only when the
-    # harness has set up a TCB, i.e. when the word at [thread_pointer] equals
-    # thread_pointer. Nothing in smallworld does that today, so a harness must
-    # either leave the thread pointer at 0 (and map a zero word at address 0
-    # for the second form) or write a proper self-pointer; otherwise the
-    # second form lands the access at arena - thread_pointer.
-    #
-    # Storage is TlsGetAddr's arena for module 1 -- the module the relocator
-    # reports for every thread-local -- indexed by the descriptor's argument
-    # (the block offset), so repeated accesses to one thread-local see the same
-    # bytes and a garbage argument cannot escape the arena. The descriptor ABI
-    # has no module field, which is exactly why the two models can share: both
-    # dialects reduce to "block offset within the one module's block", so
-    # `gd_x` and `desc_x` naming the same thread-local land on the same bytes
-    # whichever dialect each translation unit was built with.
-    #
-    # The returned offset is tls_arena_address - thread_pointer, so the caller's
-    # thread-pointer-relative access lands back on the arena.
+    # Storage is TlsGetAddr's arena for the module the relocator reports. The
+    # descriptor ABI has no module field, which is why sharing works: both
+    # dialects reduce to a block offset within that one module's block, so a
+    # thread-local reached either way lands on the same bytes.
     name = "__tlsdesc_resolve"
     # Not a C function: the descriptor ABI passes its argument in a fixed
     # register rather than the usual argument registers, so there is nothing
@@ -606,13 +585,9 @@ class TlsDescResolve(CStdModel):
     argument_types: typing.List[ArgumentType] = []
     return_type = ArgumentType.POINTER
 
-    # No storage of its own: it shares TlsGetAddr's arena for module 1, which
-    # is the module the relocator reports for every thread-local (see
-    # R_X86_64_DTPMOD64). gcc picks a TLS dialect per translation unit, so one
-    # image can reach the SAME thread-local through both models; with separate
-    # pools a write through one is invisible to a read through the other.
-    # Sharing also stops every amd64 harness reserving a second 32 KiB pool it
-    # may never touch. Assigned by the library, like malloc's heap.
+    # Borrows TlsGetAddr's arena rather than reserving one, so that a
+    # thread-local written through one dialect is visible through the other.
+    # The library assigns it, like malloc's heap.
     static_space_required = 0
 
     #: Register holding the descriptor address on entry and the offset on exit.
@@ -622,22 +597,17 @@ class TlsDescResolve(CStdModel):
 
     def apply(self, emulator: emulators.Emulator) -> None:
         super().apply(emulator)
-        # Install the TCB self-pointer BEFORE any code runs. gcc hoists the
-        # `mov %fs:0x0,%rdx` that reads it above the descriptor call -- often
-        # to the top of the function -- so a resolver that only writes it
-        # during the call writes it after the value has already been read.
-        # That read then yields zero and the access lands at
-        # `arena - thread_pointer` instead of on the arena.
+        # Install the TCB self-pointer before any code runs: gcc hoists the
+        # `mov %fs:0x0,%rdx` that reads it above the descriptor call, so
+        # writing it during the call would be too late.
         try:
             thread_pointer = emulator.read_register(self.thread_pointer_register)
         except Exception:
             return
         if thread_pointer:
-            # A harness that maps its own TCB may not have been applied yet --
-            # apply order is the caller's, not ours -- so make sure the word
-            # exists before writing it. map_memory only fills gaps, so this
-            # neither disturbs an already-mapped TCB nor stops one being added
-            # later.
+            # A harness that maps its own TCB may not be applied yet, so
+            # make sure the word exists. map_memory only fills gaps, so an
+            # existing or later TCB is undisturbed.
             emulator.map_memory(thread_pointer, self.platdef.address_size)
         self._ensure_tcb_self_pointer(emulator, thread_pointer)
 
@@ -680,21 +650,13 @@ class TlsDescResolve(CStdModel):
     ) -> None:
         """Make the word at the thread pointer point at the thread pointer.
 
-        gcc finishes a descriptor call in one of two ways, and emits both --
-        sometimes within one function:
+        gcc completes a descriptor call either by adding the thread-pointer
+        register or by adding the word AT it, and emits both. glibc's TCB
+        starts with a self-pointer, which is what makes the two agree;
+        nothing else here sets one up, so the second form would otherwise
+        add zero and land the access somewhere unrelated but valid-looking.
 
-            add %fs_base, %rax          # thread-pointer REGISTER
-            mov %fs:0x0,%rdx; add %rdx  # the word AT the thread pointer
-
-        Real glibc keeps a TCB whose first word points at itself, which is
-        what makes the two agree. Nothing else in the harness sets one up, so
-        the second form would otherwise add zero (or whatever happens to be
-        there) and send the access somewhere unrelated -- silently, since a
-        wrong address is still a valid one. Writing the self-pointer here
-        costs one word and makes both forms land on the same storage.
-
-        Best effort: a thread pointer of zero, or one whose page is not
-        mapped, leaves it alone rather than failing the access.
+        Best effort: an unset or unmapped thread pointer is left alone.
         """
         if not thread_pointer:
             return

--- a/smallworld/state/models/c99/stdlib.py
+++ b/smallworld/state/models/c99/stdlib.py
@@ -525,18 +525,30 @@ class TlsDescResolve(CStdModel):
     # two-word descriptor in the GOT: { resolver, argument }. The caller does
     #     lea  x@TLSDESC(%rip), %rax
     #     call *x@TLSCALL(%rax)      # descriptor address in, offset out
-    #     mov  %fs:(%rax), ...
+    #     mov  %fs:(%rax), ...       # or: mov %fs:0x0,%rdx; add %rdx,%rax
     # so the resolver returns a THREAD-POINTER-RELATIVE offset, not an address
     # -- the difference from TlsGetAddr, which returns the address itself.
     #
-    # Storage follows TlsGetAddr exactly: a bounded pool of arenas in this
-    # model's own zeroed static buffer, indexed by the descriptor's argument,
+    # NOTE: gcc emits BOTH completions above, sometimes in one function. The
+    # first adds the thread-pointer register; the second adds the word AT the
+    # thread pointer (the glibc TCB self-pointer). They agree only when the
+    # harness has set up a TCB, i.e. when the word at [thread_pointer] equals
+    # thread_pointer. Nothing in smallworld does that today, so a harness must
+    # either leave the thread pointer at 0 (and map a zero word at address 0
+    # for the second form) or write a proper self-pointer; otherwise the
+    # second form lands the access at arena - thread_pointer.
+    #
+    # Storage is a single bounded pool in this model's own zeroed static
+    # buffer, indexed directly by the descriptor's argument (the block offset),
     # so repeated accesses to one thread-local see the same bytes and a garbage
-    # argument cannot escape the pool. The returned offset is then
-    # arena_address - thread_pointer, which lands the caller's %fs-relative
-    # access back on the arena. Reading the thread pointer rather than assuming
-    # it also keeps this correct when nothing has set one (it reads 0, and the
-    # offset degenerates to the arena address).
+    # argument cannot escape the pool. Unlike TlsGetAddr, which has two
+    # independent inputs (module, offset) and so needs per-module arenas, the
+    # argument here is a single linear offset: splitting it into arenas would
+    # only add aliasing, since the clamp would then apply at every internal
+    # arena boundary rather than once at the end of the pool.
+    #
+    # The returned offset is arena_address - thread_pointer, so the caller's
+    # thread-pointer-relative access lands back on the arena.
     name = "__tlsdesc_resolve"
     # Not a C function: the descriptor ABI passes its argument in a fixed
     # register rather than the usual argument registers, so there is nothing
@@ -544,10 +556,9 @@ class TlsDescResolve(CStdModel):
     argument_types: typing.List[ArgumentType] = []
     return_type = ArgumentType.POINTER
 
-    TLS_ARENA_SIZE = 0x1000  # bytes of scratch per arena
-    TLS_MAX_SLOTS = 8  # distinct arenas (extra descriptors alias in via %)
-    _TLS_HEADROOM = 0x40  # keep a wide access from a near-arena-end offset in-bounds
-    static_space_required = TLS_ARENA_SIZE * TLS_MAX_SLOTS
+    TLS_POOL_SIZE = 0x8000  # bytes of scratch shared by all thread-locals
+    _TLS_HEADROOM = 0x40  # keep a wide access from a near-pool-end offset in-bounds
+    static_space_required = TLS_POOL_SIZE
 
     #: Register holding the descriptor address on entry and the offset on exit.
     descriptor_register: str = ""
@@ -569,17 +580,22 @@ class TlsDescResolve(CStdModel):
         argument = self.read_integer(
             desc + self.platdef.address_size, ArgumentType.POINTER, emulator
         )
-        slot = (argument // self.TLS_ARENA_SIZE) % self.TLS_MAX_SLOTS
         off = min(
-            argument % self.TLS_ARENA_SIZE, self.TLS_ARENA_SIZE - self._TLS_HEADROOM
+            argument % self.TLS_POOL_SIZE, self.TLS_POOL_SIZE - self._TLS_HEADROOM
         )
-        addr = self.static_buffer_address + slot * self.TLS_ARENA_SIZE + off
-        thread_pointer = emulator.read_register(self.thread_pointer_register)
-        mask = (1 << (self.platdef.address_size * 8)) - 1
+        addr = self.static_buffer_address + off
+        try:
+            thread_pointer = emulator.read_register(self.thread_pointer_register)
+        except exceptions.UnsupportedRegisterError:
+            # Some backends (ghidra, triton) do not model segment bases at all.
+            # Treating the thread pointer as unset degrades to handing back the
+            # arena address itself, which is what happens on every backend when
+            # nothing has set one.
+            thread_pointer = 0
         # Wraps for a thread pointer above the arena, which is the normal
         # variant-II layout: the caller's add wraps back to the same address.
         emulator.write_register(
-            self.descriptor_register, (addr - thread_pointer) & mask
+            self.descriptor_register, (addr - thread_pointer) & self._long_inv_mask
         )
 
 

--- a/smallworld/state/models/c99/stdlib.py
+++ b/smallworld/state/models/c99/stdlib.py
@@ -518,6 +518,71 @@ class TlsGetAddr(CStdModel):
         self.set_return_value(emulator, addr)
 
 
+class TlsDescResolve(CStdModel):
+    # The TLS-descriptor resolver, for code built with -mtls-dialect=gnu2.
+    #
+    # gnu2 replaces the __tls_get_addr call with an indirect call through a
+    # two-word descriptor in the GOT: { resolver, argument }. The caller does
+    #     lea  x@TLSDESC(%rip), %rax
+    #     call *x@TLSCALL(%rax)      # descriptor address in, offset out
+    #     mov  %fs:(%rax), ...
+    # so the resolver returns a THREAD-POINTER-RELATIVE offset, not an address
+    # -- the difference from TlsGetAddr, which returns the address itself.
+    #
+    # Storage follows TlsGetAddr exactly: a bounded pool of arenas in this
+    # model's own zeroed static buffer, indexed by the descriptor's argument,
+    # so repeated accesses to one thread-local see the same bytes and a garbage
+    # argument cannot escape the pool. The returned offset is then
+    # arena_address - thread_pointer, which lands the caller's %fs-relative
+    # access back on the arena. Reading the thread pointer rather than assuming
+    # it also keeps this correct when nothing has set one (it reads 0, and the
+    # offset degenerates to the arena address).
+    name = "__tlsdesc_resolve"
+    # Not a C function: the descriptor ABI passes its argument in a fixed
+    # register rather than the usual argument registers, so there is nothing
+    # for the generic argument machinery to describe.
+    argument_types: typing.List[ArgumentType] = []
+    return_type = ArgumentType.POINTER
+
+    TLS_ARENA_SIZE = 0x1000  # bytes of scratch per arena
+    TLS_MAX_SLOTS = 8  # distinct arenas (extra descriptors alias in via %)
+    _TLS_HEADROOM = 0x40  # keep a wide access from a near-arena-end offset in-bounds
+    static_space_required = TLS_ARENA_SIZE * TLS_MAX_SLOTS
+
+    #: Register holding the descriptor address on entry and the offset on exit.
+    descriptor_register: str = ""
+    #: Register holding the thread pointer the returned offset is relative to.
+    thread_pointer_register: str = ""
+
+    def model(self, emulator: emulators.Emulator) -> None:
+        super().model(emulator)
+        if self.static_buffer_address is None:
+            raise exceptions.ConfigurationError(
+                "__tlsdesc_resolve needs its static buffer; none was reserved"
+            )
+        if not self.descriptor_register or not self.thread_pointer_register:
+            raise exceptions.ConfigurationError(
+                "__tlsdesc_resolve has no descriptor/thread-pointer register "
+                "for this platform"
+            )
+        desc = emulator.read_register(self.descriptor_register)
+        argument = self.read_integer(
+            desc + self.platdef.address_size, ArgumentType.POINTER, emulator
+        )
+        slot = (argument // self.TLS_ARENA_SIZE) % self.TLS_MAX_SLOTS
+        off = min(
+            argument % self.TLS_ARENA_SIZE, self.TLS_ARENA_SIZE - self._TLS_HEADROOM
+        )
+        addr = self.static_buffer_address + slot * self.TLS_ARENA_SIZE + off
+        thread_pointer = emulator.read_register(self.thread_pointer_register)
+        mask = (1 << (self.platdef.address_size * 8)) - 1
+        # Wraps for a thread pointer above the arena, which is the normal
+        # variant-II layout: the caller's add wraps back to the same address.
+        emulator.write_register(
+            self.descriptor_register, (addr - thread_pointer) & mask
+        )
+
+
 class Mblen(CStdModel):
     name = "mblen"
 
@@ -818,6 +883,7 @@ __all__ = [
     "Getenv",
     "Malloc",
     "TlsGetAddr",
+    "TlsDescResolve",
     "Mblen",
     "Mbstowcs",
     "Mbtowc",

--- a/smallworld/state/models/c99/stdlib.py
+++ b/smallworld/state/models/c99/stdlib.py
@@ -485,6 +485,11 @@ class TlsGetAddr(CStdModel):
 
     TLS_ARENA_SIZE = 0x1000  # bytes of scratch per module arena
     TLS_MAX_MODULES = 8  # distinct module arenas (extra modules alias in via %)
+    #: Where a module's PT_TLS initialization image belongs in the pool. The
+    #: relocator reports every module as id 1 (see R_X86_64_DTPMOD64), so the
+    #: image seeds that module's arena; without it every thread-local reads
+    #: zero rather than its initializer.
+    tls_image_offset = TLS_ARENA_SIZE * (1 % 8)
     _TLS_HEADROOM = 0x40  # keep a wide access from a near-arena-end offset in-bounds
     # Reserved once by the library, which sets self.static_buffer_address and maps
     # the (zeroed) region; sized to hold the whole arena pool.
@@ -559,6 +564,9 @@ class TlsDescResolve(CStdModel):
     TLS_POOL_SIZE = 0x8000  # bytes of scratch shared by all thread-locals
     _TLS_HEADROOM = 0x40  # keep a wide access from a near-pool-end offset in-bounds
     static_space_required = TLS_POOL_SIZE
+    #: The pool is indexed directly by a thread-local's block offset, so a
+    #: module's PT_TLS initialization image seeds it from the start.
+    tls_image_offset = 0
 
     #: Register holding the descriptor address on entry and the offset on exit.
     descriptor_register: str = ""
@@ -592,11 +600,48 @@ class TlsDescResolve(CStdModel):
             # arena address itself, which is what happens on every backend when
             # nothing has set one.
             thread_pointer = 0
+        self._ensure_tcb_self_pointer(emulator, thread_pointer)
         # Wraps for a thread pointer above the arena, which is the normal
         # variant-II layout: the caller's add wraps back to the same address.
         emulator.write_register(
             self.descriptor_register, (addr - thread_pointer) & self._long_inv_mask
         )
+
+    def _ensure_tcb_self_pointer(
+        self, emulator: emulators.Emulator, thread_pointer: int
+    ) -> None:
+        """Make the word at the thread pointer point at the thread pointer.
+
+        gcc finishes a descriptor call in one of two ways, and emits both --
+        sometimes within one function:
+
+            add %fs_base, %rax          # thread-pointer REGISTER
+            mov %fs:0x0,%rdx; add %rdx  # the word AT the thread pointer
+
+        Real glibc keeps a TCB whose first word points at itself, which is
+        what makes the two agree. Nothing else in the harness sets one up, so
+        the second form would otherwise add zero (or whatever happens to be
+        there) and send the access somewhere unrelated -- silently, since a
+        wrong address is still a valid one. Writing the self-pointer here
+        costs one word and makes both forms land on the same storage.
+
+        Best effort: a thread pointer of zero, or one whose page is not
+        mapped, leaves it alone rather than failing the access.
+        """
+        if not thread_pointer:
+            return
+        size = self.platdef.address_size
+        try:
+            if self.read_integer(thread_pointer, ArgumentType.POINTER, emulator) == (
+                thread_pointer
+            ):
+                return
+            emulator.write_memory(
+                thread_pointer,
+                thread_pointer.to_bytes(size, self.platdef.byteorder.value),
+            )
+        except Exception as e:
+            logger.debug(f"could not install a TCB self-pointer: {e!r}")
 
 
 class Mblen(CStdModel):

--- a/smallworld/state/models/c99/stdlib.py
+++ b/smallworld/state/models/c99/stdlib.py
@@ -462,6 +462,43 @@ class Malloc(CStdModel):
         self.set_return_value(emulator, res)
 
 
+#: Bytes kept clear at the end of each half-arena so that a wide access from
+#: the last reachable slot still lands on mapped storage.
+_TLS_HEADROOM = 0x40
+
+
+def _as_signed(value: int, size: int) -> int:
+    """Reinterpret an unsigned word of `size` bytes as two's-complement."""
+    limit = 1 << (size * 8 - 1)
+    return value - 2 * limit if value >= limit else value
+
+
+def _tls_slot_span(arena_size: int) -> int:
+    """How many distinct block offsets one half of an arena can hold."""
+    return max(1, arena_size // 2 - _TLS_HEADROOM)
+
+
+def _tls_arena_slot(offset: int, arena_size: int) -> int:
+    """Map a thread-local's block offset onto a bounded slot in its arena.
+
+    Both TLS models go through this, so one thread-local reached through
+    either dialect lands on the same bytes (see RELOCATED_TLS_MODULE).
+
+    `offset` must already be sign-interpreted. A NEGATIVE block offset is
+    ordinary -- an addend like `x - 8` produces one, and the relocator packs
+    it as a huge unsigned word -- but folding that into the arena the obvious
+    way lands it on a perfectly legitimate positive offset, silently giving
+    two different thread-locals the same storage. So negatives get their own
+    half of the arena: still bounded, still stable per offset, but unable to
+    collide with a real one. Garbage arguments have the top bit set and land
+    there too, which is exactly where they belong.
+    """
+    span = _tls_slot_span(arena_size)
+    if offset < 0:
+        return arena_size // 2 + ((-offset - 1) % span)
+    return offset % span
+
+
 class TlsGetAddr(CStdModel):
     # void *__tls_get_addr(tls_index *ti);  -- the glibc dynamic-TLS resolver.
     #
@@ -493,8 +530,7 @@ class TlsGetAddr(CStdModel):
     tls_image_offset = TLS_ARENA_SIZE * (RELOCATED_TLS_MODULE % TLS_MAX_MODULES)
     #: A thread-local can only ever be read within its own arena (the model
     #: clamps to one), so that -- not the whole pool -- is the room an image has.
-    tls_image_capacity = TLS_ARENA_SIZE
-    _TLS_HEADROOM = 0x40  # keep a wide access from a near-arena-end offset in-bounds
+    tls_image_capacity = _tls_slot_span(TLS_ARENA_SIZE)
     # Reserved once by the library, which sets self.static_buffer_address and maps
     # the (zeroed) region; sized to hold the whole arena pool.
     static_space_required = TLS_ARENA_SIZE * TLS_MAX_MODULES
@@ -522,11 +558,11 @@ class TlsGetAddr(CStdModel):
         module = self.read_integer(ti, ptr, emulator)
         offset = self.read_integer(ti + self.platdef.address_size, ptr, emulator)
         # Map (module, offset) into the bounded arena pool: pick a module arena
-        # (garbage/overflow modules alias via %), and index by offset within it,
-        # clamped so even a wide access from a near-end offset stays mapped.
+        # (garbage/overflow modules alias via %), then index by offset within
+        # it through the shared mapping the descriptor model also uses.
         slot = module % self.TLS_MAX_MODULES
-        off = min(
-            offset % self.TLS_ARENA_SIZE, self.TLS_ARENA_SIZE - self._TLS_HEADROOM
+        off = _tls_arena_slot(
+            _as_signed(offset, self.platdef.address_size), self.TLS_ARENA_SIZE
         )
         addr = self.static_buffer_address + slot * self.TLS_ARENA_SIZE + off
         self.set_return_value(emulator, addr)
@@ -578,7 +614,6 @@ class TlsDescResolve(CStdModel):
     # Sharing also stops every amd64 harness reserving a second 32 KiB pool it
     # may never touch. Assigned by the library, like malloc's heap.
     static_space_required = 0
-    _TLS_HEADROOM = 0x40  # keep a wide access from a near-arena-end offset in-bounds
 
     #: Register holding the descriptor address on entry and the offset on exit.
     descriptor_register: str = ""
@@ -621,9 +656,8 @@ class TlsDescResolve(CStdModel):
         argument = self.read_integer(
             desc + self.platdef.address_size, ArgumentType.POINTER, emulator
         )
-        off = min(
-            argument % self.tls_arena_size,
-            max(0, self.tls_arena_size - self._TLS_HEADROOM),
+        off = _tls_arena_slot(
+            _as_signed(argument, self.platdef.address_size), self.tls_arena_size
         )
         addr = self.tls_arena_address + off
         try:

--- a/smallworld/state/models/c99/stdlib.py
+++ b/smallworld/state/models/c99/stdlib.py
@@ -9,6 +9,7 @@ from smallworld.state.models.funcptr import FunctionPointer
 from .... import emulators, exceptions
 from ...memory.heap import Heap
 from ..cstd import ArgumentType, CStdModel
+from ..model import RELOCATED_TLS_MODULE
 from .utils import _emu_strlen
 
 logger = logging.getLogger("__name__")
@@ -489,7 +490,10 @@ class TlsGetAddr(CStdModel):
     #: relocator reports every module as id 1 (see R_X86_64_DTPMOD64), so the
     #: image seeds that module's arena; without it every thread-local reads
     #: zero rather than its initializer.
-    tls_image_offset = TLS_ARENA_SIZE * (1 % 8)
+    tls_image_offset = TLS_ARENA_SIZE * (RELOCATED_TLS_MODULE % TLS_MAX_MODULES)
+    #: A thread-local can only ever be read within its own arena (the model
+    #: clamps to one), so that -- not the whole pool -- is the room an image has.
+    tls_image_capacity = TLS_ARENA_SIZE
     _TLS_HEADROOM = 0x40  # keep a wide access from a near-arena-end offset in-bounds
     # Reserved once by the library, which sets self.static_buffer_address and maps
     # the (zeroed) region; sized to hold the whole arena pool.
@@ -500,6 +504,11 @@ class TlsGetAddr(CStdModel):
         # Kept for interface compatibility (the library assigns it, like
         # malloc/calloc), but TLS no longer draws from the heap.
         self.heap: typing.Optional[Heap] = None
+
+    @classmethod
+    def module_arena_offset(cls, module: int) -> int:
+        """Offset within the pool at which ``module``'s arena begins."""
+        return cls.TLS_ARENA_SIZE * (module % cls.TLS_MAX_MODULES)
 
     def model(self, emulator: emulators.Emulator) -> None:
         super().model(emulator)
@@ -543,16 +552,16 @@ class TlsDescResolve(CStdModel):
     # for the second form) or write a proper self-pointer; otherwise the
     # second form lands the access at arena - thread_pointer.
     #
-    # Storage is a single bounded pool in this model's own zeroed static
-    # buffer, indexed directly by the descriptor's argument (the block offset),
-    # so repeated accesses to one thread-local see the same bytes and a garbage
-    # argument cannot escape the pool. Unlike TlsGetAddr, which has two
-    # independent inputs (module, offset) and so needs per-module arenas, the
-    # argument here is a single linear offset: splitting it into arenas would
-    # only add aliasing, since the clamp would then apply at every internal
-    # arena boundary rather than once at the end of the pool.
+    # Storage is TlsGetAddr's arena for module 1 -- the module the relocator
+    # reports for every thread-local -- indexed by the descriptor's argument
+    # (the block offset), so repeated accesses to one thread-local see the same
+    # bytes and a garbage argument cannot escape the arena. The descriptor ABI
+    # has no module field, which is exactly why the two models can share: both
+    # dialects reduce to "block offset within the one module's block", so
+    # `gd_x` and `desc_x` naming the same thread-local land on the same bytes
+    # whichever dialect each translation unit was built with.
     #
-    # The returned offset is arena_address - thread_pointer, so the caller's
+    # The returned offset is tls_arena_address - thread_pointer, so the caller's
     # thread-pointer-relative access lands back on the arena.
     name = "__tlsdesc_resolve"
     # Not a C function: the descriptor ABI passes its argument in a fixed
@@ -561,12 +570,15 @@ class TlsDescResolve(CStdModel):
     argument_types: typing.List[ArgumentType] = []
     return_type = ArgumentType.POINTER
 
-    TLS_POOL_SIZE = 0x8000  # bytes of scratch shared by all thread-locals
-    _TLS_HEADROOM = 0x40  # keep a wide access from a near-pool-end offset in-bounds
-    static_space_required = TLS_POOL_SIZE
-    #: The pool is indexed directly by a thread-local's block offset, so a
-    #: module's PT_TLS initialization image seeds it from the start.
-    tls_image_offset = 0
+    # No storage of its own: it shares TlsGetAddr's arena for module 1, which
+    # is the module the relocator reports for every thread-local (see
+    # R_X86_64_DTPMOD64). gcc picks a TLS dialect per translation unit, so one
+    # image can reach the SAME thread-local through both models; with separate
+    # pools a write through one is invisible to a read through the other.
+    # Sharing also stops every amd64 harness reserving a second 32 KiB pool it
+    # may never touch. Assigned by the library, like malloc's heap.
+    static_space_required = 0
+    _TLS_HEADROOM = 0x40  # keep a wide access from a near-arena-end offset in-bounds
 
     #: Register holding the descriptor address on entry and the offset on exit.
     descriptor_register: str = ""
@@ -575,9 +587,9 @@ class TlsDescResolve(CStdModel):
 
     def model(self, emulator: emulators.Emulator) -> None:
         super().model(emulator)
-        if self.static_buffer_address is None:
+        if self.tls_arena_address is None or self.tls_arena_size <= 0:
             raise exceptions.ConfigurationError(
-                "__tlsdesc_resolve needs its static buffer; none was reserved"
+                "__tlsdesc_resolve needs the shared TLS arena; none was assigned"
             )
         if not self.descriptor_register or not self.thread_pointer_register:
             raise exceptions.ConfigurationError(
@@ -589,9 +601,10 @@ class TlsDescResolve(CStdModel):
             desc + self.platdef.address_size, ArgumentType.POINTER, emulator
         )
         off = min(
-            argument % self.TLS_POOL_SIZE, self.TLS_POOL_SIZE - self._TLS_HEADROOM
+            argument % self.tls_arena_size,
+            max(0, self.tls_arena_size - self._TLS_HEADROOM),
         )
-        addr = self.static_buffer_address + off
+        addr = self.tls_arena_address + off
         try:
             thread_pointer = emulator.read_register(self.thread_pointer_register)
         except exceptions.UnsupportedRegisterError:

--- a/smallworld/state/models/library.py
+++ b/smallworld/state/models/library.py
@@ -135,6 +135,14 @@ class ElfModelLibrary(Memory):
                 log.warning(f"Harness requires {model.name}, which is unsupported")
             elf.update_symbol_value(sym, model._address)
 
+        # TLS descriptors carry a resolver address rather than a symbol, so no
+        # relocation above can reach them; they are relocated at load with a
+        # null resolver and bound here, which is the first point at which the
+        # model has an address.
+        tlsdesc = self.models.get("__tlsdesc_resolve")
+        if tlsdesc is not None:
+            elf.bind_tlsdesc_resolver(tlsdesc._address)
+
     def apply(self, emulator: Emulator) -> None:
         super().apply(emulator)
         for _, model in self.models.items():

--- a/smallworld/state/models/library.py
+++ b/smallworld/state/models/library.py
@@ -9,7 +9,8 @@ from ..memory import Memory
 from ..memory.elf import ElfExecutable
 from ..state import BytesValue
 from .cstd import CStdModel
-from .model import RELOCATED_TLS_MODULE, Model
+from .model import Model
+from .tls import RELOCATED_TLS_MODULE, TlsArenaBorrower, TlsArenaOwner
 
 log = logging.getLogger(__name__)
 
@@ -158,38 +159,46 @@ class ElfModelLibrary(Memory):
             )
 
     def _share_tls_arena(self) -> None:
-        """Point the TLS-descriptor model at ``__tls_get_addr``'s storage.
+        """Hand every borrowing TLS model the owner's storage.
 
         gcc picks a TLS dialect per translation unit, so one image can reach
         the same thread-local through both models. Both reduce to an offset
         within the module the relocator reports, so sharing that module's
         arena keeps them consistent; separate pools silently disagree.
+
+        Which model owns the storage is a role, not a function name, so it is
+        asked for by role -- see `models/tls.py`.
         """
-        owner = self.models.get("__tls_get_addr")
-        borrower = self.models.get("__tlsdesc_resolve")
-        if owner is None or borrower is None:
+        arena: typing.Optional[int] = None
+        size = 0
+        for model in self.models.values():
+            if isinstance(model, TlsArenaOwner):
+                arena = model.tls_arena_address_for(RELOCATED_TLS_MODULE)
+                size = model.TLS_ARENA_SIZE
+                break
+        if arena is None:
+            # No owner in this library, or the owner reserved no buffer.
             return
-        arena_offset = getattr(owner, "module_arena_offset", None)
-        if owner.static_buffer_address is None or arena_offset is None:
-            return
-        borrower.tls_arena_address = owner.static_buffer_address + arena_offset(
-            RELOCATED_TLS_MODULE
-        )
-        borrower.tls_arena_size = owner.TLS_ARENA_SIZE  # type: ignore[attr-defined]
+        for model in self.models.values():
+            if isinstance(model, TlsArenaBorrower):
+                model.tls_arena_address = arena
+                model.tls_arena_size = size
 
     def _seed_tls_image(self, elf: ElfExecutable) -> None:
-        """Copy the image's PT_TLS initialization data into each TLS model's
-        storage, at the offset that model says the image belongs."""
+        """Copy the image's PT_TLS initialization data into the storage that
+        serves thread-locals, at the offset its owner says the image belongs."""
         image = elf.tls_image
         if not image:
             return
         for model in self.models.values():
-            offset = getattr(model, "tls_image_offset", None)
-            if offset is None or model.static_buffer_address is None:
+            if not isinstance(model, TlsArenaOwner):
                 continue
-            room = model.static_space_required - offset
-            if model.tls_image_capacity is not None:
-                room = min(room, model.tls_image_capacity)
+            if model.static_buffer_address is None:
+                continue
+            room = min(
+                model.static_space_required - model.tls_image_offset,
+                model.tls_image_capacity,
+            )
             if room <= 0:
                 continue
             if len(image) > room:
@@ -198,7 +207,7 @@ class ElfModelLibrary(Memory):
                     f"{room:#x} fit; thread-locals past the end read zero"
                 )
             chunk = image[:room]
-            base = model.static_buffer_address - self.address + offset
+            base = model.static_buffer_address - self.address + model.tls_image_offset
             self[base] = BytesValue(chunk, None)
 
     def apply(self, emulator: Emulator) -> None:

--- a/smallworld/state/models/library.py
+++ b/smallworld/state/models/library.py
@@ -137,16 +137,14 @@ class ElfModelLibrary(Memory):
                 log.warning(f"Harness requires {model.name}, which is unsupported")
             elf.update_symbol_value(sym, model._address)
 
-        # TLS descriptors carry a resolver address rather than a symbol, so no
-        # relocation above can reach them; they are relocated at load with a
-        # null resolver and bound here, which is the first point at which the
-        # model has an address.
-        # Seed thread-local storage from the image's PT_TLS initialization
-        # data. The models hand out storage but have no way to reach the ELF;
-        # this is the one place that holds both, and without it every
-        # thread-local reads zero instead of the value it was declared with.
+        # The models hand out TLS storage but cannot reach the ELF; this is
+        # the one place holding both, and without it every thread-local reads
+        # zero rather than its initializer.
         self._seed_tls_image(elf)
 
+        # Descriptors carry a resolver address rather than a symbol, so no
+        # relocation reaches them; they load with a null resolver and are
+        # bound here, the first point at which the model has an address.
         tlsdesc = self.models.get("__tlsdesc_resolve")
         if tlsdesc is not None:
             elf.bind_tlsdesc_resolver(tlsdesc._address)
@@ -162,12 +160,10 @@ class ElfModelLibrary(Memory):
     def _share_tls_arena(self) -> None:
         """Point the TLS-descriptor model at ``__tls_get_addr``'s storage.
 
-        gcc picks a TLS dialect per translation unit, so a single image can
-        reach the SAME thread-local through both models. Both dialects reduce
-        to an offset within the one module the relocator reports, so aiming the
-        descriptor model at that module's arena makes a write through one
-        dialect visible to a read through the other. Two independent pools --
-        which is what separate static buffers gave -- silently disagree.
+        gcc picks a TLS dialect per translation unit, so one image can reach
+        the same thread-local through both models. Both reduce to an offset
+        within the module the relocator reports, so sharing that module's
+        arena keeps them consistent; separate pools silently disagree.
         """
         owner = self.models.get("__tls_get_addr")
         borrower = self.models.get("__tlsdesc_resolve")

--- a/smallworld/state/models/library.py
+++ b/smallworld/state/models/library.py
@@ -142,6 +142,14 @@ class ElfModelLibrary(Memory):
         tlsdesc = self.models.get("__tlsdesc_resolve")
         if tlsdesc is not None:
             elf.bind_tlsdesc_resolver(tlsdesc._address)
+        elif elf.tlsdesc_descriptors:
+            # Silence here would surface much later as a call to address zero,
+            # with nothing tying it back to TLS.
+            log.warning(
+                f"{len(elf.tlsdesc_descriptors)} TLS descriptors need a resolver, "
+                f"but this library provides no __tlsdesc_resolve model; "
+                f"thread-local accesses will call address zero"
+            )
 
     def apply(self, emulator: Emulator) -> None:
         super().apply(emulator)

--- a/smallworld/state/models/library.py
+++ b/smallworld/state/models/library.py
@@ -139,6 +139,12 @@ class ElfModelLibrary(Memory):
         # relocation above can reach them; they are relocated at load with a
         # null resolver and bound here, which is the first point at which the
         # model has an address.
+        # Seed thread-local storage from the image's PT_TLS initialization
+        # data. The models hand out storage but have no way to reach the ELF;
+        # this is the one place that holds both, and without it every
+        # thread-local reads zero instead of the value it was declared with.
+        self._seed_tls_image(elf)
+
         tlsdesc = self.models.get("__tlsdesc_resolve")
         if tlsdesc is not None:
             elf.bind_tlsdesc_resolver(tlsdesc._address)
@@ -150,6 +156,28 @@ class ElfModelLibrary(Memory):
                 f"but this library provides no __tlsdesc_resolve model; "
                 f"thread-local accesses will call address zero"
             )
+
+    def _seed_tls_image(self, elf: ElfExecutable) -> None:
+        """Copy the image's PT_TLS initialization data into each TLS model's
+        storage, at the offset that model says the image belongs."""
+        image = elf.tls_image
+        if not image:
+            return
+        for model in self.models.values():
+            offset = getattr(model, "tls_image_offset", None)
+            if offset is None or model.static_buffer_address is None:
+                continue
+            room = model.static_space_required - offset
+            if room <= 0:
+                continue
+            if len(image) > room:
+                log.warning(
+                    f"{model.name}: TLS image is {len(image):#x} bytes but only "
+                    f"{room:#x} fit; thread-locals past the end read zero"
+                )
+            chunk = image[:room]
+            base = model.static_buffer_address - self.address + offset
+            self[base] = BytesValue(chunk, None)
 
     def apply(self, emulator: Emulator) -> None:
         super().apply(emulator)

--- a/smallworld/state/models/library.py
+++ b/smallworld/state/models/library.py
@@ -9,7 +9,7 @@ from ..memory import Memory
 from ..memory.elf import ElfExecutable
 from ..state import BytesValue
 from .cstd import CStdModel
-from .model import Model
+from .model import RELOCATED_TLS_MODULE, Model
 
 log = logging.getLogger(__name__)
 
@@ -90,6 +90,8 @@ class ElfModelLibrary(Memory):
                 )
                 data_offset += model.static_space_required
 
+        self._share_tls_arena()
+
     @property
     @abc.abstractmethod
     def variables(self) -> typing.List[typing.Tuple[str, int]]:
@@ -157,6 +159,28 @@ class ElfModelLibrary(Memory):
                 f"thread-local accesses will call address zero"
             )
 
+    def _share_tls_arena(self) -> None:
+        """Point the TLS-descriptor model at ``__tls_get_addr``'s storage.
+
+        gcc picks a TLS dialect per translation unit, so a single image can
+        reach the SAME thread-local through both models. Both dialects reduce
+        to an offset within the one module the relocator reports, so aiming the
+        descriptor model at that module's arena makes a write through one
+        dialect visible to a read through the other. Two independent pools --
+        which is what separate static buffers gave -- silently disagree.
+        """
+        owner = self.models.get("__tls_get_addr")
+        borrower = self.models.get("__tlsdesc_resolve")
+        if owner is None or borrower is None:
+            return
+        arena_offset = getattr(owner, "module_arena_offset", None)
+        if owner.static_buffer_address is None or arena_offset is None:
+            return
+        borrower.tls_arena_address = owner.static_buffer_address + arena_offset(
+            RELOCATED_TLS_MODULE
+        )
+        borrower.tls_arena_size = owner.TLS_ARENA_SIZE  # type: ignore[attr-defined]
+
     def _seed_tls_image(self, elf: ElfExecutable) -> None:
         """Copy the image's PT_TLS initialization data into each TLS model's
         storage, at the offset that model says the image belongs."""
@@ -168,6 +192,8 @@ class ElfModelLibrary(Memory):
             if offset is None or model.static_buffer_address is None:
                 continue
             room = model.static_space_required - offset
+            if model.tls_image_capacity is not None:
+                room = min(room, model.tls_image_capacity)
             if room <= 0:
                 continue
             if len(image) > room:

--- a/smallworld/state/models/model.py
+++ b/smallworld/state/models/model.py
@@ -153,6 +153,9 @@ class Model(Hook):
         pass
 
     static_space_required: int = 0
+    #: Offset into this model's static buffer where a module's PT_TLS
+    #: initialization image belongs, or None if the model wants no image.
+    tls_image_offset: typing.Optional[int] = None
 
     @classmethod
     def lookup(

--- a/smallworld/state/models/model.py
+++ b/smallworld/state/models/model.py
@@ -76,12 +76,6 @@ class PythonShellBreakpoint(Breakpoint):
         code.interact(local={"emulator": emulator})
 
 
-#: The module id the relocator reports for every thread-local (see
-#: R_X86_64_DTPMOD64). The harness loads one image, so there is one TLS block;
-#: this names which per-module arena that block's storage lives in.
-RELOCATED_TLS_MODULE = 1
-
-
 class Model(Hook):
     """A runtime function model implemented in Python.
 
@@ -159,17 +153,6 @@ class Model(Hook):
         pass
 
     static_space_required: int = 0
-    #: Offset into this model's static buffer where a module's PT_TLS
-    #: initialization image belongs, or None if the model wants no image.
-    tls_image_offset: typing.Optional[int] = None
-    #: How many bytes of that image the model can actually serve, if less than
-    #: the rest of its static buffer. Bounds the "image does not fit" warning.
-    tls_image_capacity: typing.Optional[int] = None
-    #: TLS storage owned by ANOTHER model, assigned by the library so both TLS
-    #: dialects reach one thread-local through the same bytes. Set on models
-    #: whose static_space_required is 0 because they borrow rather than reserve.
-    tls_arena_address: typing.Optional[int] = None
-    tls_arena_size: int = 0
 
     @classmethod
     def lookup(

--- a/smallworld/state/models/model.py
+++ b/smallworld/state/models/model.py
@@ -76,6 +76,12 @@ class PythonShellBreakpoint(Breakpoint):
         code.interact(local={"emulator": emulator})
 
 
+#: The module id the relocator reports for every thread-local (see
+#: R_X86_64_DTPMOD64). The harness loads one image, so there is one TLS block;
+#: this names which per-module arena that block's storage lives in.
+RELOCATED_TLS_MODULE = 1
+
+
 class Model(Hook):
     """A runtime function model implemented in Python.
 
@@ -156,6 +162,14 @@ class Model(Hook):
     #: Offset into this model's static buffer where a module's PT_TLS
     #: initialization image belongs, or None if the model wants no image.
     tls_image_offset: typing.Optional[int] = None
+    #: How many bytes of that image the model can actually serve, if less than
+    #: the rest of its static buffer. Bounds the "image does not fit" warning.
+    tls_image_capacity: typing.Optional[int] = None
+    #: TLS storage owned by ANOTHER model, assigned by the library so both TLS
+    #: dialects reach one thread-local through the same bytes. Set on models
+    #: whose static_space_required is 0 because they borrow rather than reserve.
+    tls_arena_address: typing.Optional[int] = None
+    tls_arena_size: int = 0
 
     @classmethod
     def lookup(

--- a/smallworld/state/models/tls.py
+++ b/smallworld/state/models/tls.py
@@ -1,0 +1,77 @@
+"""The contract between a model library and the models that serve
+thread-local storage.
+
+Two models reach a thread-local by entirely different routes -- ``__tls_get_addr``
+for the general-dynamic dialect, ``__tlsdesc_resolve`` for gnu2 descriptors --
+and gcc picks the dialect per translation unit, so one image can reach the
+*same* thread-local through both. They therefore have to hand out the same
+bytes, and the model library is the only thing positioned to arrange it: it
+holds the models and the loaded ELF, and neither can see the other.
+
+These are the roles it arranges between. A model opts into one by inheriting
+it, which is what lets the library find the participants by role rather than
+by hardcoded function name, and keeps ``Model`` itself about modelling an
+external function.
+"""
+
+import abc
+import typing
+
+#: The module id the relocator reports for every thread-local (see
+#: R_X86_64_DTPMOD64). The harness loads one image, so there is one TLS block;
+#: this names which per-module arena that block's storage lives in.
+RELOCATED_TLS_MODULE = 1
+
+
+class TlsArenaOwner(abc.ABC):
+    """A model whose static buffer is the storage thread-locals live in.
+
+    The owner reserves the whole pool and divides it into per-module arenas.
+    It also says where a module's PT_TLS initialization image belongs, since
+    only the model knows how it indexes its own storage -- and without the
+    image every thread-local reads zero instead of its initializer, which is
+    silent, zero being a plausible value.
+    """
+
+    #: Provided by ``Model``; declared here so this role stands on its own.
+    static_buffer_address: typing.Optional[int]
+    static_space_required: int
+
+    #: Bytes of storage each module's arena gets.
+    TLS_ARENA_SIZE: int
+    #: Offset into the pool at which a module's PT_TLS image belongs.
+    tls_image_offset: int
+    #: How much of that image this model can actually serve. A thread-local is
+    #: only ever read within its own arena, so the pool is not the bound.
+    tls_image_capacity: int
+
+    @classmethod
+    @abc.abstractmethod
+    def module_arena_offset(cls, module: int) -> int:
+        """Offset within the pool at which ``module``'s arena begins."""
+        raise NotImplementedError("This is an abstract method.")
+
+    def tls_arena_address_for(self, module: int) -> typing.Optional[int]:
+        """Where ``module``'s arena sits in memory, or None if none was
+        reserved."""
+        if self.static_buffer_address is None:
+            return None
+        return self.static_buffer_address + self.module_arena_offset(module)
+
+
+class TlsArenaBorrower:
+    """A model that serves thread-locals out of a :class:`TlsArenaOwner`'s
+    storage.
+
+    It reserves nothing itself -- its ``static_space_required`` is 0 -- and the
+    library assigns these once the owner's buffer has an address, the way it
+    assigns malloc's heap. Two separate pools would disagree silently: a write
+    through one dialect would be invisible to a read through the other.
+
+    State, not behaviour: how the borrower indexes the arena is its own
+    business, and is not the same computation the owner performs.
+    """
+
+    #: None until the library assigns one.
+    tls_arena_address: typing.Optional[int] = None
+    tls_arena_size: int = 0

--- a/smallworld/state/state.py
+++ b/smallworld/state/state.py
@@ -864,14 +864,10 @@ class Machine(StatefulSet):
                 emulator.add_constraint(expr)
 
         # Apply CPUs first. A StatefulSet iterates a set, so member order is
-        # arbitrary and varies between processes; anything whose apply() needs
-        # to READ a register would otherwise work or fail depending on where
-        # the CPU happened to land in that iteration. Model libraries do need
-        # it -- the TLS resolver reads the thread-pointer register to install
-        # the TCB self-pointer that thread-local accesses depend on -- and a
-        # bug that reproduces only in some orderings is the worst kind.
-        # Registers do not depend on anything else being applied, so going
-        # first is always safe.
+        # arbitrary and varies between processes; anything whose apply() reads
+        # a register -- the TLS resolver does -- would otherwise succeed or
+        # fail depending on where the CPU landed. Registers depend on nothing
+        # else, so going first is always safe.
         cpus = self.members(state.cpus.CPU)
         for cpu in cpus:
             logger.debug(f"applying CPU state {cpu} to emulator {emulator}")

--- a/smallworld/state/state.py
+++ b/smallworld/state/state.py
@@ -863,7 +863,26 @@ class Machine(StatefulSet):
             for expr in self._constraints:
                 emulator.add_constraint(expr)
 
-        return super().apply(emulator)
+        # Apply CPUs first. A StatefulSet iterates a set, so member order is
+        # arbitrary and varies between processes; anything whose apply() needs
+        # to READ a register would otherwise work or fail depending on where
+        # the CPU happened to land in that iteration. Model libraries do need
+        # it -- the TLS resolver reads the thread-pointer register to install
+        # the TCB self-pointer that thread-local accesses depend on -- and a
+        # bug that reproduces only in some orderings is the worst kind.
+        # Registers do not depend on anything else being applied, so going
+        # first is always safe.
+        cpus = self.members(state.cpus.CPU)
+        for cpu in cpus:
+            logger.debug(f"applying CPU state {cpu} to emulator {emulator}")
+            cpu.apply(emulator)
+        for stateful in self:
+            if stateful in cpus:
+                continue
+            logger.debug(
+                f"applying state {stateful} of type {type(stateful)} to emulator {emulator}"
+            )
+            stateful.apply(emulator)
 
     def extract(self, emulator: emulators.Emulator) -> None:
         self._exit_points = emulator.get_exit_points()

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -259,7 +259,8 @@ endef
 # Linux C template
 # Builds .elf and .so files from C source
 
-C_OBJ_SRCS := $(wildcard */*.o.c) $(wildcard */*/*.o.c)
+# Excludes the gnu2 objects below, for the same reason as C_SO_SRCS.
+C_OBJ_SRCS := $(filter-out %.gnu2.o.c,$(wildcard */*.o.c) $(wildcard */*/*.o.c))
 C_ELF_SRCS := $(wildcard */*.elf.c) $(wildcard */*/*.elf.c)
 # Excludes the gnu2 sources below: they build through their own rule, with an
 # extra flag, and would otherwise match this pattern too.
@@ -273,6 +274,9 @@ C_SO_SRCS := $(filter-out %.gnu2.so.c %.gnu.so.c,$(wildcard */*.so.c) $(wildcard
 # default, which differs by toolchain version: a fixture that quietly stopped
 # emitting R_X86_64_TLSDESC would keep passing while testing nothing.
 C_GNU2_SO_SRCS := $(wildcard */*.gnu2.so.c) $(wildcard */*/*.gnu2.so.c)
+# The same, unlinked: a .o carries R_X86_64_GOTPC32_TLSDESC naming a GOT
+# slot the linker never got to create, rather than R_X86_64_TLSDESC.
+C_GNU2_OBJ_SRCS := $(wildcard */*.gnu2.o.c) $(wildcard */*/*.gnu2.o.c)
 # The classic (general-dynamic) dialect, which reaches a thread-local through
 # __tls_get_addr. Recent gcc defaults to gnu2, so this too must be asked for
 # explicitly to be sure what the fixture contains.
@@ -291,6 +295,12 @@ $(1)_C_SOS := $$(patsubst %.so.c,%.$$($(1)_EXT).so,$$(C_SO_SRCS))
 
 %.$$($(1)_EXT).so : %.so.c
 	$$($(1)_CC) $$(GENERAL_CFLAGS) $$($(1)_CFLAGS) -fPIC -shared -o $$@ $$<
+
+$(1)_C_GNU2_OBJS := $$(if $$($(1)_GNU2_CFLAGS),$$(patsubst %.gnu2.o.c,%.gnu2.$$($(1)_EXT).o,$$(C_GNU2_OBJ_SRCS)))
+
+%.gnu2.$$($(1)_EXT).o : %.gnu2.o.c
+	$$(if $$($(1)_GNU2_CFLAGS),,$$(error no TLS-descriptor dialect flag for $(1); refusing to build $$@))
+	$$($(1)_CC) -c $$(GENERAL_CFLAGS) $$($(1)_CFLAGS) $$($(1)_GNU2_CFLAGS) -fPIC -o $$@ $$<
 
 $(1)_C_GNU2_SOS := $$(if $$($(1)_GNU2_CFLAGS),$$(patsubst %.gnu2.so.c,%.gnu2.$$($(1)_EXT).so,$$(C_GNU2_SO_SRCS)))
 
@@ -346,7 +356,7 @@ define GENERAL_TEMPLATE
 $(1)_TARGET := $$(call lc,$(1))
 
 .PHONY : $$($(1)_TARGET)
-$$($(1)_TARGET) : $$($(1)_ASM_BINS) $$($(1)_ASM_ELFS) $$($(1)_C_ELFS) $$($(1)_C_OBJS) $$($(1)_C_SOS) $$($(1)_C_GNU2_SOS) $$($(1)_C_GNU_SOS) $$($(1)_C_DLLS) $$($(1)_C_PES) 
+$$($(1)_TARGET) : $$($(1)_ASM_BINS) $$($(1)_ASM_ELFS) $$($(1)_C_ELFS) $$($(1)_C_OBJS) $$($(1)_C_GNU2_OBJS) $$($(1)_C_SOS) $$($(1)_C_GNU2_SOS) $$($(1)_C_GNU_SOS) $$($(1)_C_DLLS) $$($(1)_C_PES) 
 
 .PHONY : $$($(1)_TARGET)-clean
 $$($(1)_TARGET)-clean :

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -261,7 +261,17 @@ endef
 
 C_OBJ_SRCS := $(wildcard */*.o.c) $(wildcard */*/*.o.c)
 C_ELF_SRCS := $(wildcard */*.elf.c) $(wildcard */*/*.elf.c)
-C_SO_SRCS := $(wildcard */*.so.c) $(wildcard */*/*.so.c)
+# Excludes the gnu2 sources below: they build through their own rule, with an
+# extra flag, and would otherwise match this pattern too.
+C_SO_SRCS := $(filter-out %.gnu2.so.c,$(wildcard */*.so.c) $(wildcard */*/*.so.c))
+
+# TLS-descriptor shared objects. The dialect flag is x86-specific, so these
+# build for x86 only. It is passed EXPLICITLY rather than relying on the
+# compiler default, which differs by toolchain version: a fixture that quietly
+# stopped emitting R_X86_64_TLSDESC would keep passing while testing nothing.
+C_GNU2_SO_SRCS := $(wildcard */*.gnu2.so.c) $(wildcard */*/*.gnu2.so.c)
+AMD64_GNU2_CFLAGS := -mtls-dialect=gnu2
+I386_GNU2_CFLAGS := -mtls-dialect=gnu2
 
 define C_ELF_TEMPLATE
 
@@ -274,6 +284,11 @@ $(1)_C_SOS := $$(patsubst %.so.c,%.$$($(1)_EXT).so,$$(C_SO_SRCS))
 
 %.$$($(1)_EXT).so : %.so.c
 	$$($(1)_CC) $$(GENERAL_CFLAGS) $$($(1)_CFLAGS) -fPIC -shared -o $$@ $$<
+
+$(1)_C_GNU2_SOS := $$(if $$($(1)_GNU2_CFLAGS),$$(patsubst %.gnu2.so.c,%.gnu2.$$($(1)_EXT).so,$$(C_GNU2_SO_SRCS)))
+
+%.gnu2.$$($(1)_EXT).so : %.gnu2.so.c
+	$$($(1)_CC) $$(GENERAL_CFLAGS) $$($(1)_CFLAGS) $$($(1)_GNU2_CFLAGS) -fPIC -shared -o $$@ $$<
 
 %.$$($(1)_EXT).elf : %.elf.c
 	$$($(1)_CC) $$(GENERAL_CFLAGS) $$($(1)_CFLAGS) $$($(1)_ELF_CFLAGS) -o $$@ $$<
@@ -309,7 +324,7 @@ define GENERAL_TEMPLATE
 $(1)_TARGET := $$(call lc,$(1))
 
 .PHONY : $$($(1)_TARGET)
-$$($(1)_TARGET) : $$($(1)_ASM_BINS) $$($(1)_ASM_ELFS) $$($(1)_C_ELFS) $$($(1)_C_OBJS) $$($(1)_C_SOS) $$($(1)_C_DLLS) $$($(1)_C_PES) 
+$$($(1)_TARGET) : $$($(1)_ASM_BINS) $$($(1)_ASM_ELFS) $$($(1)_C_ELFS) $$($(1)_C_OBJS) $$($(1)_C_SOS) $$($(1)_C_GNU2_SOS) $$($(1)_C_DLLS) $$($(1)_C_PES) 
 
 .PHONY : $$($(1)_TARGET)-clean
 $$($(1)_TARGET)-clean :

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -263,7 +263,7 @@ C_OBJ_SRCS := $(wildcard */*.o.c) $(wildcard */*/*.o.c)
 C_ELF_SRCS := $(wildcard */*.elf.c) $(wildcard */*/*.elf.c)
 # Excludes the gnu2 sources below: they build through their own rule, with an
 # extra flag, and would otherwise match this pattern too.
-C_SO_SRCS := $(filter-out %.gnu2.so.c,$(wildcard */*.so.c) $(wildcard */*/*.so.c))
+C_SO_SRCS := $(filter-out %.gnu2.so.c %.gnu.so.c,$(wildcard */*.so.c) $(wildcard */*/*.so.c))
 
 # TLS-descriptor shared objects. Built only for the architectures whose
 # relocator and models understand TLS descriptors -- amd64 today; i386 emits
@@ -273,6 +273,11 @@ C_SO_SRCS := $(filter-out %.gnu2.so.c,$(wildcard */*.so.c) $(wildcard */*/*.so.c
 # default, which differs by toolchain version: a fixture that quietly stopped
 # emitting R_X86_64_TLSDESC would keep passing while testing nothing.
 C_GNU2_SO_SRCS := $(wildcard */*.gnu2.so.c) $(wildcard */*/*.gnu2.so.c)
+# The classic (general-dynamic) dialect, which reaches a thread-local through
+# __tls_get_addr. Recent gcc defaults to gnu2, so this too must be asked for
+# explicitly to be sure what the fixture contains.
+C_GNU_SO_SRCS := $(wildcard */*.gnu.so.c) $(wildcard */*/*.gnu.so.c)
+AMD64_GNU_CFLAGS := -mtls-dialect=gnu
 AMD64_GNU2_CFLAGS := -mtls-dialect=gnu2
 
 define C_ELF_TEMPLATE
@@ -296,6 +301,16 @@ $(1)_C_GNU2_SOS := $$(if $$($(1)_GNU2_CFLAGS),$$(patsubst %.gnu2.so.c,%.gnu2.$$(
 %.gnu2.$$($(1)_EXT).so : %.gnu2.so.c
 	$$(if $$($(1)_GNU2_CFLAGS),,$$(error no TLS-descriptor dialect flag for $(1); refusing to build $$@))
 	$$($(1)_CC) $$(GENERAL_CFLAGS) $$($(1)_CFLAGS) $$($(1)_GNU2_CFLAGS) -fPIC -shared -o $$@ $$<
+
+$(1)_C_GNU_SOS := $$(if $$($(1)_GNU_CFLAGS),$$(patsubst %.gnu.so.c,%.gnu.$$($(1)_EXT).so,$$(C_GNU_SO_SRCS)))
+
+# Refuse rather than silently drop the dialect flag: this rule also wins (by
+# shortest stem) over the generic %.so rule for an explicitly named target on
+# an architecture with no flag, and a fixture built without it would keep
+# passing while testing nothing.
+%.gnu.$$($(1)_EXT).so : %.gnu.so.c
+	$$(if $$($(1)_GNU_CFLAGS),,$$(error no general-dynamic dialect flag for $(1); refusing to build $$@))
+	$$($(1)_CC) $$(GENERAL_CFLAGS) $$($(1)_CFLAGS) $$($(1)_GNU_CFLAGS) -fPIC -shared -o $$@ $$<
 
 %.$$($(1)_EXT).elf : %.elf.c
 	$$($(1)_CC) $$(GENERAL_CFLAGS) $$($(1)_CFLAGS) $$($(1)_ELF_CFLAGS) -o $$@ $$<
@@ -331,7 +346,7 @@ define GENERAL_TEMPLATE
 $(1)_TARGET := $$(call lc,$(1))
 
 .PHONY : $$($(1)_TARGET)
-$$($(1)_TARGET) : $$($(1)_ASM_BINS) $$($(1)_ASM_ELFS) $$($(1)_C_ELFS) $$($(1)_C_OBJS) $$($(1)_C_SOS) $$($(1)_C_GNU2_SOS) $$($(1)_C_DLLS) $$($(1)_C_PES) 
+$$($(1)_TARGET) : $$($(1)_ASM_BINS) $$($(1)_ASM_ELFS) $$($(1)_C_ELFS) $$($(1)_C_OBJS) $$($(1)_C_SOS) $$($(1)_C_GNU2_SOS) $$($(1)_C_GNU_SOS) $$($(1)_C_DLLS) $$($(1)_C_PES) 
 
 .PHONY : $$($(1)_TARGET)-clean
 $$($(1)_TARGET)-clean :

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -265,13 +265,15 @@ C_ELF_SRCS := $(wildcard */*.elf.c) $(wildcard */*/*.elf.c)
 # extra flag, and would otherwise match this pattern too.
 C_SO_SRCS := $(filter-out %.gnu2.so.c,$(wildcard */*.so.c) $(wildcard */*/*.so.c))
 
-# TLS-descriptor shared objects. The dialect flag is x86-specific, so these
-# build for x86 only. It is passed EXPLICITLY rather than relying on the
-# compiler default, which differs by toolchain version: a fixture that quietly
-# stopped emitting R_X86_64_TLSDESC would keep passing while testing nothing.
+# TLS-descriptor shared objects. Built only for the architectures whose
+# relocator and models understand TLS descriptors -- amd64 today; i386 emits
+# R_386_TLS_DESC, which I386ElfRelocator does not handle, and there is no i386
+# resolver model, so an i386 fixture would be an artifact nothing can load.
+# The dialect flag is passed EXPLICITLY rather than relying on the compiler
+# default, which differs by toolchain version: a fixture that quietly stopped
+# emitting R_X86_64_TLSDESC would keep passing while testing nothing.
 C_GNU2_SO_SRCS := $(wildcard */*.gnu2.so.c) $(wildcard */*/*.gnu2.so.c)
 AMD64_GNU2_CFLAGS := -mtls-dialect=gnu2
-I386_GNU2_CFLAGS := -mtls-dialect=gnu2
 
 define C_ELF_TEMPLATE
 
@@ -287,7 +289,12 @@ $(1)_C_SOS := $$(patsubst %.so.c,%.$$($(1)_EXT).so,$$(C_SO_SRCS))
 
 $(1)_C_GNU2_SOS := $$(if $$($(1)_GNU2_CFLAGS),$$(patsubst %.gnu2.so.c,%.gnu2.$$($(1)_EXT).so,$$(C_GNU2_SO_SRCS)))
 
+# Refuse rather than silently drop the dialect flag: this rule also wins (by
+# shortest stem) over the generic %.so rule for an explicitly named target on
+# an architecture with no flag, and a fixture built without it would keep
+# passing while testing nothing.
 %.gnu2.$$($(1)_EXT).so : %.gnu2.so.c
+	$$(if $$($(1)_GNU2_CFLAGS),,$$(error no TLS-descriptor dialect flag for $(1); refusing to build $$@))
 	$$($(1)_CC) $$(GENERAL_CFLAGS) $$($(1)_CFLAGS) $$($(1)_GNU2_CFLAGS) -fPIC -shared -o $$@ $$<
 
 %.$$($(1)_EXT).elf : %.elf.c

--- a/tests/tlsdesc/tlsbss.gnu2.o.c
+++ b/tests/tlsdesc/tlsbss.gnu2.o.c
@@ -1,0 +1,21 @@
+/* The same uninitialized thread-locals, as an UNLINKED object.
+ *
+ * No linker has laid this TLS block out, so the loader has to: .tdata first,
+ * then .tbss padded to its 8-byte alignment, landing on the same offsets
+ * tlsbss.gnu2.so.c carries. Dropping the padding puts `wide` at offset 1,
+ * and .tbss occupies no file space at all, so its bytes exist only if
+ * something synthesizes them.
+ *
+ * Deliberately identical to tlsbss.gnu2.so.c so the two can be held to the
+ * same offsets and the same bump(5) == 8.
+ */
+
+__thread char lead = 3;
+__thread long long wide;
+__thread int tail;
+
+int bump(int n) {
+    wide += n;
+    tail = (int)wide + lead;
+    return tail;
+}

--- a/tests/tlsdesc/tlsbss.gnu2.so.c
+++ b/tests/tlsdesc/tlsbss.gnu2.so.c
@@ -1,0 +1,23 @@
+/* Uninitialized thread-locals: the .tbss half of a TLS block.
+ *
+ * Every other fixture here initializes all of its thread-locals, so the whole
+ * TLS block is .tdata and PT_TLS has filesz == memsz. That leaves the block's
+ * uninitialized half untested: the initialization image has to be zero-
+ * EXTENDED to memsz, or the bytes behind an uninitialized thread-local are
+ * not part of the block at all.
+ *
+ * `lead` is a single initialized byte and `wide` is 8-byte aligned, so the
+ * linker leaves 7 bytes of padding between them: lead=0, wide=8, tail=0x10.
+ * bump(5) is 8, and only if `lead` kept its initializer -- zeroed storage
+ * returns 5.
+ */
+
+__thread char lead = 3;
+__thread long long wide;
+__thread int tail;
+
+int bump(int n) {
+    wide += n;
+    tail = (int)wide + lead;
+    return tail;
+}

--- a/tests/tlsdesc/tlsdef.gnu2.so.c
+++ b/tests/tlsdesc/tlsdef.gnu2.so.c
@@ -1,0 +1,9 @@
+/* Defines a thread-local for tlsref.gnu2.so.c to import.
+ *
+ * `pad` comes first so `shared` sits at a non-zero block offset (4): an
+ * offset of 0 would survive being wrongly rebased in one of the two load
+ * orders, and the test could not tell the difference.
+ */
+
+__thread int pad = 1;
+__thread int shared = 42;

--- a/tests/tlsdesc/tlsdesc.gnu.so.c
+++ b/tests/tlsdesc/tlsdesc.gnu.so.c
@@ -1,0 +1,20 @@
+/* General-dynamic (classic gnu dialect) TLS fixture.
+ *
+ * Built with -mtls-dialect=gnu, the older ABI in which the compiler reaches a
+ * thread-local by calling __tls_get_addr with a {module, offset} pair:
+ *
+ *     lea  x@TLSGD(%rip), %rdi
+ *     call __tls_get_addr        # returns the ADDRESS, no thread pointer needed
+ *
+ * Two thread-locals, so the R_X86_64_DTPOFF64 relocations carry DIFFERENT
+ * block offsets and a test can tell them apart -- collapsing them is exactly
+ * what rebasing the symbol value by the load address used to do.
+ */
+
+__thread int first = 7;
+__thread long second = 11;
+
+int bump(int n) {
+    first += n;
+    return first + (int)second;
+}

--- a/tests/tlsdesc/tlsdesc.gnu2.o.c
+++ b/tests/tlsdesc/tlsdesc.gnu2.o.c
@@ -1,0 +1,24 @@
+/* TLS-descriptor fixture as an UNLINKED object.
+ *
+ * The .so fixtures carry R_X86_64_TLSDESC: the linker has already placed the
+ * two-word descriptor in the GOT, and the relocation just fills it in. A .o
+ * has not been through a linker, so it carries the earlier form instead:
+ *
+ *     lea  x@tlsdesc(%rip), %rax     # R_X86_64_GOTPC32_TLSDESC
+ *     call *x@tlscall(%rax)          # R_X86_64_TLSDESC_CALL
+ *
+ * where the relocation names a GOT slot that does not exist yet. Loading this
+ * therefore requires synthesizing the descriptor the linker would have made.
+ *
+ * Deliberately the same shape as tlsdesc.gnu2.so.c -- two thread-locals with
+ * different block offsets, and bump(5) == 23 -- so the object and the shared
+ * object can be held to the same answer.
+ */
+
+__thread int first = 7;
+__thread long second = 11;
+
+int bump(int n) {
+    first += n;
+    return first + (int)second;
+}

--- a/tests/tlsdesc/tlsdesc.gnu2.so.c
+++ b/tests/tlsdesc/tlsdesc.gnu2.so.c
@@ -1,0 +1,22 @@
+/* TLS-descriptor (gnu2 dialect) fixture.
+ *
+ * Built with -mtls-dialect=gnu2, which makes the compiler reach a thread-local
+ * through a two-word descriptor in the GOT and an indirect call, rather than
+ * the older __tls_get_addr call:
+ *
+ *     lea  x@TLSDESC(%rip), %rax
+ *     call *x@TLSCALL(%rax)
+ *     mov  %fs:(%rax), ...
+ *
+ * Two thread-locals, so the R_X86_64_TLSDESC relocations carry DIFFERENT
+ * block offsets and a test can tell them apart -- collapsing them is exactly
+ * what rebasing the symbol value by the load address used to do.
+ */
+
+__thread int first = 7;
+__thread long second = 11;
+
+int bump(int n) {
+    first += n;
+    return first + (int)second;
+}

--- a/tests/tlsdesc/tlsref.gnu2.so.c
+++ b/tests/tlsdesc/tlsref.gnu2.so.c
@@ -1,0 +1,11 @@
+/* Imports a thread-local defined in another module.
+ *
+ * Cross-module is the case link_elf gets wrong: a TLS symbol's value is an
+ * offset within its DEFINER's block, so resolving it must carry the offset
+ * across unchanged. Rebasing leaves the delta between the two load
+ * addresses, which is an offset into nothing.
+ */
+
+extern __thread int shared;
+
+int readshared(void) { return shared; }

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -4951,12 +4951,23 @@ class TlsDescFixtureTests(unittest.TestCase):
     def setUp(self):
         if not os.path.exists(self.SO):
             self.skipTest(f"{self.SO} not built (run `make amd64` in tests/)")
+        # Constructing a POSIXLibc instantiates every model, which populates
+        # the FileDescriptorManager/ProcInfoManager quasi-singletons; reset
+        # them the way ModelTestCase does so they never leak between tests.
+        FileDescriptorManager._singletons.clear()
+        ProcInfoManager._singleton = None
+        logging.disable(logging.ERROR)
         self.platform = platforms.Platform(
             architecture=platforms.Architecture.X86_64,
             byteorder=platforms.Byteorder.LITTLE,
         )
         with open(self.SO, "rb") as f:
             self.elf = ElfExecutable(f, platform=self.platform, user_base=0x100000)
+
+    def tearDown(self):
+        FileDescriptorManager._singletons.clear()
+        ProcInfoManager._singleton = None
+        logging.disable(logging.NOTSET)
 
     def _descriptor(self, address):
         raw = self.elf.read_bytes(address, 16)
@@ -4968,13 +4979,13 @@ class TlsDescFixtureTests(unittest.TestCase):
     def test_image_loads(self):
         # Refusing the relocation raised here, which cost every function in
         # the image rather than only the ones using a thread-local.
-        self.assertTrue(self.elf._tlsdesc_descriptors, "no TLS descriptors found")
+        self.assertTrue(self.elf.tlsdesc_descriptors, "no TLS descriptors found")
 
     def test_arguments_are_distinct_block_offsets(self):
         # The fixture has two thread-locals, so the two descriptors must carry
         # different offsets. Rebasing the symbol value by the load address
         # turned both into large addresses and lost the distinction.
-        args = sorted(self._descriptor(d)[1] for d in self.elf._tlsdesc_descriptors)
+        args = sorted(self._descriptor(d)[1] for d in self.elf.tlsdesc_descriptors)
         self.assertEqual(len(args), 2)
         self.assertNotEqual(args[0], args[1])
         for arg in args:
@@ -4983,39 +4994,55 @@ class TlsDescFixtureTests(unittest.TestCase):
             )
 
     def test_resolver_is_null_until_linked_then_bound(self):
-        for d in self.elf._tlsdesc_descriptors:
+        # Guard the loops below: with no descriptors they assert nothing, and
+        # "no descriptors were recorded" is the condition this test exists to
+        # detect.
+        self.assertEqual(len(self.elf.tlsdesc_descriptors), 2)
+        for d in self.elf.tlsdesc_descriptors:
             self.assertEqual(self._descriptor(d)[0], 0, "resolver bound too early")
 
         libc = POSIXLibc(0x900000, self.platform, platforms.ABI.SYSTEMV)
         libc.link(self.elf)
         model = libc.models.get("__tlsdesc_resolve")
         self.assertIsNotNone(model, "library provides no __tlsdesc_resolve model")
-        for d in self.elf._tlsdesc_descriptors:
+        for d in self.elf.tlsdesc_descriptors:
             self.assertEqual(self._descriptor(d)[0], model._address)
 
-    def test_each_thread_local_gets_its_own_storage(self):
-        # The point of carrying the offset through: two thread-locals must not
-        # land on the same bytes.
+    def test_library_reserves_the_resolvers_static_buffer(self):
+        # The library must hand the model a buffer inside its own region;
+        # without it the resolver raises on its first call.
         libc = POSIXLibc(0x900000, self.platform, platforms.ABI.SYSTEMV)
         libc.link(self.elf)
-        model = libc.models.get("__tlsdesc_resolve")
-        model.static_buffer_address = 0x60000
+        model = libc.models["__tlsdesc_resolve"]
+        self.assertIsNotNone(model.static_buffer_address)
+        self.assertGreaterEqual(model.static_buffer_address, libc.address)
+        self.assertLessEqual(
+            model.static_buffer_address + model.static_space_required,
+            libc.address + libc.get_capacity(),
+        )
 
-        emu = emulators.UnicornEmulator(self.platform)
-        emu.map_memory(0x60000, model.static_space_required)
-        emu.map_memory(0x4000, 0x100)
+    def test_binding_survives_re_relocation(self):
+        # update_symbol_value re-relocates every rela of a symbol, and
+        # link_elf does exactly that. A relocator that hardcoded a null
+        # resolver word would silently unbind the descriptors here, and an
+        # un-deduped descriptor list would grow on every pass.
+        libc = POSIXLibc(0x900000, self.platform, platforms.ABI.SYSTEMV)
+        libc.link(self.elf)
+        model = libc.models["__tlsdesc_resolve"]
 
-        offsets = []
-        for descriptor in self.elf._tlsdesc_descriptors:
-            _, argument = self._descriptor(descriptor)
-            emu.write_memory(
-                0x4000, (0).to_bytes(8, "little") + argument.to_bytes(8, "little")
+        before = self.elf.tlsdesc_descriptors
+        for name in ("first", "second"):
+            self.elf.update_symbol_value(
+                name, self.elf.get_symbol_value(name, rebase=False), rebase=False
             )
-            emu.write_register("rax", 0x4000)
-            emu.write_register("fsbase", 0)
-            model.model(emu)
-            offsets.append(emu.read_register("rax"))
-        self.assertEqual(len(set(offsets)), 2, "thread-locals share storage")
+
+        self.assertEqual(self.elf.tlsdesc_descriptors, before, "descriptors duplicated")
+        for d in self.elf.tlsdesc_descriptors:
+            self.assertEqual(
+                self._descriptor(d)[0],
+                model._address,
+                "resolver unbound by re-relocation",
+            )
 
 
 class TlsDescResolveModelTests(ModelTestCase):
@@ -5028,13 +5055,15 @@ class TlsDescResolveModelTests(ModelTestCase):
 
     DESC = 0x4000
     ARENA = 0x60000
-    ARENA_SIZE = 0x8000
 
     def setUp(self):
         super().setUp()
         self.emu.map_memory(self.DESC, 0x100)
         self.model = self.lookup("__tlsdesc_resolve")
         self.model.static_buffer_address = self.ARENA
+        # Derived, not restated: shrinking the pool must shrink the bound the
+        # out-of-pool tests below check against.
+        self.ARENA_SIZE = self.model.static_space_required
 
     def _resolve(self, argument, thread_pointer=0):
         """Call the resolver the way gnu2 code does: descriptor in %rax."""
@@ -5238,8 +5267,18 @@ def _make_symbol(value: int, baseaddr: int) -> ElfSymbol:
 
 
 class _FakeElf:
-    def __init__(self, address: int):
+    #: Stands in for the resolver ElfExecutable would have bound, if any.
+    tlsdesc_resolver = 0
+
+    def __init__(self, address: int = 0):
         self.address = address
+        self.noted: list = []
+
+    def note_tlsdesc_descriptor(self, address: int) -> int:
+        # Mirrors ElfExecutable: dedup, and hand back the bound resolver.
+        if address not in self.noted:
+            self.noted.append(address)
+        return self.tlsdesc_resolver
 
 
 class AMD64StackInitTests(unittest.TestCase):
@@ -5289,15 +5328,6 @@ class AMD64TlsDescRelocatorTests(unittest.TestCase):
     thread-local: one unresolvable relocation made the whole ELF unloadable.
     """
 
-    class _Elf:
-        """Minimal stand-in; the relocator only records descriptors on it."""
-
-        def __init__(self):
-            self.noted = []
-
-        def note_tlsdesc_descriptor(self, address):
-            self.noted.append(address)
-
     def _rela(self, value, addend):
         return ElfRela(
             is_rela=True,
@@ -5309,7 +5339,7 @@ class AMD64TlsDescRelocatorTests(unittest.TestCase):
 
     def test_writes_descriptor_and_records_it(self):
         relocator = AMD64ElfRelocator()
-        elf = self._Elf()
+        elf = _FakeElf()
         val = relocator._compute_value(self._rela(0, 0x10), elf)
         self.assertEqual(len(val), 16, "descriptor is two words")
         resolver = int.from_bytes(val[:8], "little")
@@ -5319,12 +5349,22 @@ class AMD64TlsDescRelocatorTests(unittest.TestCase):
         self.assertEqual(argument, 0x10)
         self.assertEqual(elf.noted, [0x2000], "descriptor must be recorded for binding")
 
+    def test_writes_the_bound_resolver_when_one_exists(self):
+        # Relocation is not one-shot: update_symbol_value re-runs it for every
+        # rela of a symbol. Hardcoding a null resolver here would silently
+        # unbind descriptors that the model library had already bound.
+        relocator = AMD64ElfRelocator()
+        elf = _FakeElf()
+        elf.tlsdesc_resolver = 0x900144
+        val = relocator._compute_value(self._rela(0, 0x10), elf)
+        self.assertEqual(int.from_bytes(val[:8], "little"), 0x900144)
+
     def test_argument_is_block_relative_not_rebased(self):
         # A TLS symbol's st_value is an offset within the TLS block. Rebasing
         # it by the load address turns adjacent thread-locals into addresses
         # and loses the distinction the resolver indexes on.
         relocator = AMD64ElfRelocator()
-        val = relocator._compute_value(self._rela(0x8, 0x4), self._Elf())
+        val = relocator._compute_value(self._rela(0x8, 0x4), _FakeElf())
         self.assertEqual(int.from_bytes(val[8:], "little"), 0xC)
 
 

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -5045,6 +5045,56 @@ class TlsDescFixtureTests(unittest.TestCase):
             )
 
 
+class TlsCrossModuleTests(unittest.TestCase):
+    """A thread-local resolved from another module keeps its block offset.
+
+    A TLS symbol's value is an offset within its DEFINER's block, so linking
+    must carry it across unchanged. Rebasing it -- adding the definer's load
+    address and subtracting the referencer's -- leaves the delta between the
+    two images, which indexes nothing: thread-locals in modules loaded far
+    apart collapse onto the same storage, and a definer loaded BELOW the
+    referencer yields a negative offset.
+    """
+
+    HERE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tlsdesc")
+    OFFSET = 0x4  # `shared` sits after `pad` in the definer's block
+
+    def _link(self, ref_base, def_base):
+        ref_path = os.path.join(self.HERE, "tlsref.gnu2.amd64.so")
+        def_path = os.path.join(self.HERE, "tlsdef.gnu2.amd64.so")
+        for path in (ref_path, def_path):
+            if not os.path.exists(path):
+                self.skipTest(f"{path} not built (run `make amd64` in tests/)")
+        plat = platforms.Platform(
+            architecture=platforms.Architecture.X86_64,
+            byteorder=platforms.Byteorder.LITTLE,
+        )
+        with open(ref_path, "rb") as f:
+            ref = ElfExecutable(f, platform=plat, user_base=ref_base)
+        with open(def_path, "rb") as f:
+            dfn = ElfExecutable(f, platform=plat, user_base=def_base)
+        ref.link_elf(dfn)
+        self.assertTrue(ref.tlsdesc_descriptors, "no descriptor to check")
+        return [
+            int.from_bytes(ref.read_bytes(d, 16)[8:], "little")
+            for d in ref.tlsdesc_descriptors
+        ]
+
+    def test_offset_survives_a_definer_loaded_above(self):
+        for argument in self._link(0x100000, 0x800000):
+            self.assertEqual(argument, self.OFFSET)
+
+    def test_offset_survives_a_definer_loaded_below(self):
+        # The order that used to produce a negative offset.
+        for argument in self._link(0x800000, 0x100000):
+            self.assertEqual(argument, self.OFFSET)
+
+    def test_offset_does_not_depend_on_the_gap_between_modules(self):
+        near = self._link(0x100000, 0x108000)
+        far = self._link(0x100000, 0x900000)
+        self.assertEqual(near, far)
+
+
 class TlsEndToEndTests(unittest.TestCase):
     """Emulate a real thread-local access and check the VALUE.
 

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -5005,15 +5005,11 @@ class TlsDialectAgreementTests(ModelTestCase):
 class TlsDescFixtureTests(unittest.TestCase):
     """End-to-end over a real gnu2-dialect object (tests/tlsdesc).
 
-    The unit tests above drive the pieces with synthetic inputs; this one uses
-    an image a compiler actually produced, so it catches the parts no
-    hand-built rela can: that the relocation is found at all, and that the
-    descriptor argument is the symbol's TLS-block offset rather than something
-    rebased by the load address.
-
-    NOT covered here: executing the indirect call itself. That needs the image
-    mapped into a machine with the model library applied, and is worth adding
-    if the resolver's runtime behaviour ever changes.
+    The tests above drive the pieces with synthetic inputs; this uses an image
+    a compiler produced, catching what no hand-built rela can: that the
+    relocation is found at all, and that the argument is the symbol's block
+    offset rather than something rebased by the load address. Executing the
+    call is TlsEndToEndTests' job.
     """
 
     SO = os.path.join(
@@ -5215,14 +5211,11 @@ class TlsDescObjectFileTests(unittest.TestCase):
 class TlsUndefinedThreadLocalTests(unittest.TestCase):
     """A thread-local no loaded module defines must not become a call to zero.
 
-    The loader deliberately leaves relocations against undefined symbols for
-    `link_elf`, which is right for data and function references: an
-    unrelocated one reads or calls null and the caller notices. A TLS
-    descriptor is different -- its first word is a resolver that gnu2 code
-    calls INDIRECTLY, so leaving it null transfers control to address zero.
-    Worse, nothing recorded the descriptor, so binding a resolver later could
-    not reach it and no warning mentioned TLS at all: the image loaded clean
-    and jumped to zero.
+    Relocations against undefined symbols are left for `link_elf`, which is
+    right for data and function references. A descriptor's first word is a
+    resolver called indirectly, so a null one jumps to address zero -- and an
+    unrecorded descriptor could not be bound later either, so the image
+    loaded clean and jumped to zero with no warning.
     """
 
     HERE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tlsdesc")
@@ -5311,15 +5304,10 @@ class TlsUndefinedThreadLocalTests(unittest.TestCase):
 class MachineApplyOrderTests(unittest.TestCase):
     """A Machine applies its CPUs before anything else.
 
-    Machine is a StatefulSet, so iteration order follows a set -- arbitrary,
-    and different between processes. Anything whose apply() READS a register
-    therefore used to see it or not depending on where the CPU happened to
-    land, which is how a TLS execution test passed on its own and failed in
-    the full suite: the resolver installs the TCB self-pointer from the
-    thread-pointer register at apply time.
-
-    Insertion order cannot force the bad case (set order comes from hashes),
-    so this uses many probes: without the guarantee, some land before the CPU.
+    Machine is a StatefulSet, so member order is arbitrary and varies between
+    processes; anything whose apply() reads a register used to see it or not
+    depending on where the CPU landed. Insertion order cannot force the bad
+    case, so this uses many probes -- without the guarantee, some land first.
     """
 
     PROBES = 50
@@ -5412,19 +5400,14 @@ class TlsCrossModuleTests(unittest.TestCase):
 
 
 class TlsEndToEndTests(unittest.TestCase):
-    """Emulate a real thread-local access and check the VALUE.
+    """Emulate a real thread-local access and check the VALUE, not addresses.
 
-    Everything else in these TLS tests checks a relocation, an address or a
-    binding. This one runs the code: `bump(n)` does `first += n; return first
-    + second` over `__thread int first = 7; __thread long second = 11`, so a
-    correct answer requires the whole chain -- the image loads, the resolver
-    hands out storage, the thread pointer resolves, AND the storage was seeded
-    from PT_TLS. Zeroed storage silently returns n instead of n + 18, which is
-    exactly what this used to do.
-
-    Both dialects, because they reach thread-locals by completely different
-    routes: gnu2 through a TLS descriptor and a thread pointer, gnu through
-    __tls_get_addr, which returns an address and needs no thread pointer.
+    `bump(n)` does `first += n; return first + second` over `first = 7,
+    second = 11`, so n + 18 requires the whole chain: the image loads, the
+    resolver hands out storage, the thread pointer resolves, and the storage
+    was seeded from PT_TLS. Zeroed storage silently returns n, which is what
+    this used to do. Run for both dialects, which reach thread-locals by
+    entirely different routes.
     """
 
     BASE, LIBC, TCB, RET = 0x100000, 0x900000, 0x600000, 0x7FFF0000

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -5119,6 +5119,155 @@ class TlsDescFixtureTests(unittest.TestCase):
             )
 
 
+class TlsUndefinedThreadLocalTests(unittest.TestCase):
+    """A thread-local no loaded module defines must not become a call to zero.
+
+    The loader deliberately leaves relocations against undefined symbols for
+    `link_elf`, which is right for data and function references: an
+    unrelocated one reads or calls null and the caller notices. A TLS
+    descriptor is different -- its first word is a resolver that gnu2 code
+    calls INDIRECTLY, so leaving it null transfers control to address zero.
+    Worse, nothing recorded the descriptor, so binding a resolver later could
+    not reach it and no warning mentioned TLS at all: the image loaded clean
+    and jumped to zero.
+    """
+
+    HERE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tlsdesc")
+    BASE, LIBC, TCB, RET = 0x100000, 0x900000, 0x600000, 0x7FFF0000
+
+    def setUp(self):
+        path = os.path.join(self.HERE, "tlsref.gnu2.amd64.so")
+        if not os.path.exists(path):
+            self.skipTest(f"{path} not built (run `make amd64` in tests/)")
+        FileDescriptorManager._singletons.clear()
+        ProcInfoManager._singleton = None
+        self.plat = platforms.Platform(
+            architecture=platforms.Architecture.X86_64,
+            byteorder=platforms.Byteorder.LITTLE,
+        )
+        self.path = path
+
+    def tearDown(self):
+        FileDescriptorManager._singletons.clear()
+        ProcInfoManager._singleton = None
+
+    def _load(self):
+        # tlsref imports `shared` from tlsdef; loading it ALONE is the case
+        # under test -- the definer is deliberately absent.
+        with open(self.path, "rb") as f:
+            return ElfExecutable(f, platform=self.plat, user_base=self.BASE)
+
+    def _descriptor(self, elf, address):
+        raw = elf.read_bytes(address, 16)
+        return int.from_bytes(raw[:8], "little"), int.from_bytes(raw[8:], "little")
+
+    def test_descriptor_is_recorded_without_a_definer(self):
+        elf = self._load()
+        self.assertTrue(
+            elf.tlsdesc_descriptors,
+            "descriptor for an undefined thread-local was never recorded",
+        )
+
+    def test_resolver_is_bound_so_the_call_is_not_to_zero(self):
+        elf = self._load()
+        libc = POSIXLibc(self.LIBC, self.plat, platforms.ABI.SYSTEMV)
+        libc.link(elf)
+        model = libc.models["__tlsdesc_resolve"]
+        for d in elf.tlsdesc_descriptors:
+            resolver, _ = self._descriptor(elf, d)
+            self.assertEqual(resolver, model._address)
+            self.assertNotEqual(resolver, 0, "descriptor still calls address zero")
+
+    def test_warns_naming_the_unresolved_thread_local(self):
+        # Silence would be the worst outcome: the access is bounded but wrong,
+        # and nothing else in the run says the word TLS.
+        with self.assertLogs("smallworld.state.memory.elf.elf", "WARNING") as caught:
+            self._load()
+        self.assertTrue(
+            any("shared" in line for line in caught.output),
+            f"warning does not name the unresolved thread-local: {caught.output}",
+        )
+
+    def test_reaches_the_resolver_instead_of_faulting(self):
+        # The point of all of the above: execute the descriptor call. Before,
+        # this jumped to address 0.
+        machine = state.Machine()
+        cpu = state.cpus.CPU.for_platform(self.plat)
+        elf = self._load()
+        libc = POSIXLibc(self.LIBC, self.plat, platforms.ABI.SYSTEMV)
+        libc.link(elf)
+        machine.add(elf)
+        machine.add(libc)
+        machine.add(cpu)
+        stack = state.memory.stack.Stack.for_platform(self.plat, 0x7FF00000, 0x10000)
+        stack.push_integer(self.RET, 8, "return address")
+        machine.add(stack)
+        machine.add(state.memory.Memory(self.TCB, 0x1000))
+        fn = elf._syms_by_name["readshared"][0]
+        cpu.rip.set(fn.value + fn.baseaddr)
+        cpu.rsp.set(stack.get_pointer())
+        cpu.fsbase.set(self.TCB)
+        machine.add_exit_point(self.RET)
+        emu = emulators.UnicornEmulator(self.plat)
+        machine.emulate(emu)
+        # The block offset is unknown, so the value is whatever the shared
+        # slot holds (zero) -- but it RAN, which is the whole point.
+        self.assertEqual(emu.read_register("eax"), 0)
+
+
+class MachineApplyOrderTests(unittest.TestCase):
+    """A Machine applies its CPUs before anything else.
+
+    Machine is a StatefulSet, so iteration order follows a set -- arbitrary,
+    and different between processes. Anything whose apply() READS a register
+    therefore used to see it or not depending on where the CPU happened to
+    land, which is how a TLS execution test passed on its own and failed in
+    the full suite: the resolver installs the TCB self-pointer from the
+    thread-pointer register at apply time.
+
+    Insertion order cannot force the bad case (set order comes from hashes),
+    so this uses many probes: without the guarantee, some land before the CPU.
+    """
+
+    PROBES = 50
+    SENTINEL = 0x1234
+
+    class _RegisterProbe(state.Stateful):
+        """Records what a register held when this member was applied."""
+
+        def __init__(self):
+            self.seen = None
+
+        def apply(self, emulator):
+            self.seen = emulator.read_register("rax")
+
+        def extract(self, emulator):
+            pass
+
+    def test_cpu_applies_before_other_members(self):
+        plat = platforms.Platform(
+            architecture=platforms.Architecture.X86_64,
+            byteorder=platforms.Byteorder.LITTLE,
+        )
+        machine = state.Machine()
+        probes = [self._RegisterProbe() for _ in range(self.PROBES)]
+        for probe in probes:
+            machine.add(probe)
+        cpu = state.cpus.CPU.for_platform(plat)
+        cpu.rax.set(self.SENTINEL)
+        machine.add(cpu)
+
+        machine.apply(emulators.UnicornEmulator(plat))
+
+        late = sum(1 for p in probes if p.seen != self.SENTINEL)
+        self.assertEqual(
+            late,
+            0,
+            f"{late}/{self.PROBES} members were applied before the CPU, so a "
+            f"member that reads a register sees a stale value",
+        )
+
+
 class TlsCrossModuleTests(unittest.TestCase):
     """A thread-local resolved from another module keeps its block offset.
 

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -5045,6 +5045,67 @@ class TlsDescFixtureTests(unittest.TestCase):
             )
 
 
+class TlsEndToEndTests(unittest.TestCase):
+    """Emulate a real thread-local access and check the VALUE.
+
+    Everything else in these TLS tests checks a relocation, an address or a
+    binding. This one runs the code: `bump(n)` does `first += n; return first
+    + second` over `__thread int first = 7; __thread long second = 11`, so a
+    correct answer requires the whole chain -- the image loads, the resolver
+    hands out storage, the thread pointer resolves, AND the storage was seeded
+    from PT_TLS. Zeroed storage silently returns n instead of n + 18, which is
+    exactly what this used to do.
+
+    Both dialects, because they reach thread-locals by completely different
+    routes: gnu2 through a TLS descriptor and a thread pointer, gnu through
+    __tls_get_addr, which returns an address and needs no thread pointer.
+    """
+
+    BASE, LIBC, TCB, RET = 0x100000, 0x900000, 0x600000, 0x7FFF0000
+
+    def _run(self, name):
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tlsdesc", name)
+        if not os.path.exists(path):
+            self.skipTest(f"{path} not built (run `make amd64` in tests/)")
+        plat = platforms.Platform(
+            architecture=platforms.Architecture.X86_64,
+            byteorder=platforms.Byteorder.LITTLE,
+        )
+        machine = state.Machine()
+        cpu = state.cpus.CPU.for_platform(plat)
+        with open(path, "rb") as f:
+            elf = ElfExecutable(f, platform=plat, user_base=self.BASE)
+        libc = POSIXLibc(self.LIBC, plat, platforms.ABI.SYSTEMV)
+        libc.link(elf)
+        machine.add(elf)
+        machine.add(libc)
+        machine.add(cpu)
+
+        stack = state.memory.stack.Stack.for_platform(plat, 0x7FF00000, 0x10000)
+        stack.push_integer(self.RET, 8, "return address")
+        machine.add(stack)
+        # Standing in for the TCB glibc would allocate. Left zeroed on purpose:
+        # the model is responsible for making the self-pointer consistent.
+        machine.add(state.memory.Memory(self.TCB, 0x1000))
+
+        bump = elf._syms_by_name["bump"][0]
+        cpu.rip.set(bump.value + bump.baseaddr)
+        cpu.rsp.set(stack.get_pointer())
+        cpu.edi.set(5)
+        cpu.fsbase.set(self.TCB)
+        machine.add_exit_point(self.RET)
+
+        emu = emulators.UnicornEmulator(plat)
+        machine.emulate(emu)
+        return emu.read_register("eax")
+
+    def test_gnu2_dialect_reads_its_initializers(self):
+        self.assertEqual(self._run("tlsdesc.gnu2.amd64.so"), 23)
+
+    def test_gnu_dialect_reads_its_initializers(self):
+        self.assertEqual(self._run("tlsdesc.gnu.amd64.so"), 23)
+
+
 class TlsDescResolveModelTests(ModelTestCase):
     """c99/stdlib.py TlsDescResolve: the gnu2 TLS-descriptor resolver.
 

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -5126,6 +5126,92 @@ class TlsDescFixtureTests(unittest.TestCase):
             )
 
 
+class TlsDescObjectFileTests(unittest.TestCase):
+    """An unlinked object reaches thread-locals through a GOT that has no GOT.
+
+    A linked image carries R_X86_64_TLSDESC: the linker already placed the
+    two-word descriptor in the GOT and the relocation only fills it in. An
+    object file carries R_X86_64_GOTPC32_TLSDESC instead, naming a GOT slot
+    the linker never got to create. Refusing it failed the entire image, so
+    every function in the object was lost, not just the TLS ones.
+    """
+
+    HERE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tlsdesc")
+    OBJ = "tlsdesc.gnu2.amd64.o"
+    SO = "tlsdesc.gnu2.amd64.so"
+    BASE = 0x100000
+
+    def setUp(self):
+        self.path = os.path.join(self.HERE, self.OBJ)
+        if not os.path.exists(self.path):
+            self.skipTest(f"{self.path} not built (run `make amd64` in tests/)")
+        FileDescriptorManager._singletons.clear()
+        ProcInfoManager._singleton = None
+        self.plat = platforms.Platform(
+            architecture=platforms.Architecture.X86_64,
+            byteorder=platforms.Byteorder.LITTLE,
+        )
+
+    def tearDown(self):
+        FileDescriptorManager._singletons.clear()
+        ProcInfoManager._singleton = None
+
+    def _load(self, name):
+        with open(os.path.join(self.HERE, name), "rb") as f:
+            return ElfExecutable(f, platform=self.plat, user_base=self.BASE)
+
+    def _descriptor(self, elf, address):
+        raw = elf.read_bytes(address, 16)
+        return int.from_bytes(raw[:8], "little"), int.from_bytes(raw[8:], "little")
+
+    def test_object_file_loads(self):
+        self.assertIsNotNone(self._load(self.OBJ))
+
+    def test_arguments_are_block_offsets_not_image_offsets(self):
+        # The descriptor argument is a TLS-block offset. Rebasing it by the
+        # section's position in the image -- which is what happened to every
+        # STT_TLS symbol in an object file -- turned 0 and 8 into 0x2000 and
+        # 0x2008, pointing outside the block entirely.
+        elf = self._load(self.OBJ)
+        args = sorted(self._descriptor(elf, d)[1] for d in elf.tlsdesc_descriptors)
+        self.assertEqual(args, [0x0, 0x8])
+
+    def test_matches_the_linked_object(self):
+        # Same source, two forms: they must describe the same thread-locals.
+        obj, so = self._load(self.OBJ), self._load(self.SO)
+        self.assertEqual(
+            sorted(self._descriptor(obj, d)[1] for d in obj.tlsdesc_descriptors),
+            sorted(self._descriptor(so, d)[1] for d in so.tlsdesc_descriptors),
+        )
+        self.assertEqual(obj.tls_image, so.tls_image)
+
+    def test_one_slot_per_symbol(self):
+        # `first` is referenced from two call sites. A real GOT gives it one
+        # entry; allocating per relocation would give it two, and a write
+        # through one would be invisible through the other.
+        elf = self._load(self.OBJ)
+        self.assertEqual(len(elf.tlsdesc_descriptors), 2)
+        self.assertEqual(
+            len(set(elf.tlsdesc_descriptors)), len(elf.tlsdesc_descriptors)
+        )
+
+    def test_synthetic_slots_are_inside_the_image(self):
+        # The slots are laid out past the loaded sections, so the image must
+        # have grown to cover them or they will not be mapped.
+        elf = self._load(self.OBJ)
+        for d in elf.tlsdesc_descriptors:
+            self.assertGreaterEqual(d, elf.address)
+            self.assertLessEqual(d + 16, elf.address + elf.get_capacity())
+
+    def test_resolver_binds_into_the_synthetic_slots(self):
+        elf = self._load(self.OBJ)
+        libc = POSIXLibc(0x900000, self.plat, platforms.ABI.SYSTEMV)
+        libc.link(elf)
+        model = libc.models["__tlsdesc_resolve"]
+        for d in elf.tlsdesc_descriptors:
+            self.assertEqual(self._descriptor(elf, d)[0], model._address)
+
+
 class TlsUndefinedThreadLocalTests(unittest.TestCase):
     """A thread-local no loaded module defines must not become a call to zero.
 
@@ -5384,6 +5470,12 @@ class TlsEndToEndTests(unittest.TestCase):
 
     def test_gnu_dialect_reads_its_initializers(self):
         self.assertEqual(self._run("tlsdesc.gnu.amd64.so"), 23)
+
+    def test_gnu2_object_file_reads_its_initializers(self):
+        # Same source, never linked: the descriptors are synthesized and the
+        # TLS image comes from the .tdata section rather than a PT_TLS header,
+        # so agreeing with the shared object is the whole point.
+        self.assertEqual(self._run("tlsdesc.gnu2.amd64.o"), 23)
 
 
 class TlsDescResolveModelTests(ModelTestCase):

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -119,13 +119,18 @@ from smallworld.state.models.mips64el.systemv.systemv import (
     MIPS64ELSysVCallingContext,
 )
 from smallworld.state.models.mips.systemv.systemv import MIPSSysVCallingContext
-from smallworld.state.models.model import RELOCATED_TLS_MODULE, Model
+from smallworld.state.models.model import Model
 from smallworld.state.models.posix import POSIXLibc
 from smallworld.state.models.posix.filedesc import SockaddrIn, SocketIO
 from smallworld.state.models.posix.filedesc.sockaddr import SockaddrIn6
 from smallworld.state.models.posix.procinfo import ProcInfoManager
 from smallworld.state.models.returnconstant import ReturnConstant
 from smallworld.state.models.riscv64.systemv.systemv import RiscV64SysVCallingContext
+from smallworld.state.models.tls import (
+    RELOCATED_TLS_MODULE,
+    TlsArenaBorrower,
+    TlsArenaOwner,
+)
 
 logging.getLogger("angr").setLevel(logging.ERROR)
 logging.getLogger("claripy").setLevel(logging.ERROR)
@@ -4950,6 +4955,51 @@ class TlsGetAddrModelTests(ModelTestCase):
             self.assertTrue(
                 arena <= addr < arena + self.model.TLS_ARENA_SIZE, hex(offset)
             )
+
+
+class TlsArenaRoleTests(ModelTestCase):
+    """models/tls.py: the library finds TLS storage by role, not by name.
+
+    Which model hands out thread-local storage, and which borrows it, is not
+    something a function name says -- and it is the library, holding both the
+    models and the ELF, that has to pair them up. Declaring the roles is what
+    lets it do that without knowing either model's name.
+    """
+
+    def test_tls_get_addr_owns_the_arena(self):
+        owner = self.lookup("__tls_get_addr")
+        self.assertIsInstance(owner, TlsArenaOwner)
+        # An owner reserves the pool it divides into per-module arenas.
+        self.assertEqual(
+            owner.static_space_required, owner.TLS_ARENA_SIZE * owner.TLS_MAX_MODULES
+        )
+
+    def test_tlsdesc_resolve_borrows_it(self):
+        borrower = self.lookup("__tlsdesc_resolve")
+        self.assertIsInstance(borrower, TlsArenaBorrower)
+        # A borrower reserves nothing and starts with nothing assigned.
+        self.assertEqual(borrower.static_space_required, 0)
+        self.assertIsNone(borrower.tls_arena_address)
+
+    def test_owner_reports_no_arena_until_a_buffer_is_reserved(self):
+        # The library assigns static_buffer_address; before that there is no
+        # address to hand a borrower, and saying so is what stops the library
+        # pointing one at offset-from-None.
+        owner = self.lookup("__tls_get_addr")
+        self.assertIsNone(owner.tls_arena_address_for(RELOCATED_TLS_MODULE))
+        owner.static_buffer_address = 0x60000
+        self.assertEqual(
+            owner.tls_arena_address_for(RELOCATED_TLS_MODULE),
+            0x60000 + owner.module_arena_offset(RELOCATED_TLS_MODULE),
+        )
+
+    def test_an_ordinary_model_holds_no_tls_state(self):
+        # The point of the roles: a model of an unrelated function carries no
+        # TLS fields at all.
+        malloc = self.lookup("malloc")
+        self.assertNotIsInstance(malloc, (TlsArenaOwner, TlsArenaBorrower))
+        self.assertFalse(hasattr(malloc, "tls_arena_address"))
+        self.assertFalse(hasattr(malloc, "tls_image_offset"))
 
 
 class TlsDialectAgreementTests(ModelTestCase):

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -4928,6 +4928,29 @@ class TlsGetAddrModelTests(ModelTestCase):
         other = self.call(self.model, self.TI2)
         self.assertNotEqual(other, first)
 
+    def test_offsets_stay_inside_the_modules_own_arena(self):
+        # The per-module arenas are adjacent, so an offset that overran its
+        # own would land on another module's thread-locals rather than
+        # somewhere obviously wrong. Garbage offsets are ordinary here: the
+        # tls_index is guest memory, and a negative one is just an addend.
+        self.model.static_buffer_address = 0x60000
+        arena = 0x60000 + self.model.module_arena_offset(1)
+        for offset in (
+            0x0,
+            0x10,
+            self.model.TLS_ARENA_SIZE - 8,
+            (1 << 64) - 8,
+            1 << 63,
+            0xDEADBEEFDEADBEEF,
+        ):
+            self.emu.write_memory(
+                self.TI1, (1).to_bytes(8, "little") + offset.to_bytes(8, "little")
+            )
+            addr = self.call(self.model, self.TI1)
+            self.assertTrue(
+                arena <= addr < arena + self.model.TLS_ARENA_SIZE, hex(offset)
+            )
+
 
 class TlsDialectAgreementTests(ModelTestCase):
     """Both TLS dialects must reach one thread-local through the same bytes.
@@ -5208,6 +5231,176 @@ class TlsDescObjectFileTests(unittest.TestCase):
             self.assertEqual(self._descriptor(elf, d)[0], model._address)
 
 
+class TlsUninitializedBlockTests(unittest.TestCase):
+    """The uninitialized half of a TLS block is still part of the block.
+
+    Every other fixture here initializes all of its thread-locals, so its
+    whole block is .tdata and PT_TLS has filesz == memsz. `tlsbss` adds an
+    uninitialized `long long` and `int`, which puts two things under test: a
+    linked image's initialization image has to be zero-EXTENDED to memsz, or
+    the storage behind an uninitialized thread-local is not part of the image
+    at all; and an object file, which no linker laid out, has to place .tbss
+    itself -- honouring an alignment that no other fixture exercises, since
+    dropping the padding moves every thread-local after the first.
+    """
+
+    HERE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tlsdesc")
+    OBJ = "tlsbss.gnu2.amd64.o"
+    SO = "tlsbss.gnu2.amd64.so"
+    #: What the linker computed: one initialized byte, seven bytes of padding
+    #: for 8-byte-aligned `wide`, then `tail`.
+    OFFSETS = {"lead": 0x0, "wide": 0x8, "tail": 0x10}
+    #: memsz: 8 bytes of .tdata plus padding, 12 of .tbss. filesz is 1.
+    BLOCK_SIZE = 0x14
+
+    def setUp(self):
+        for name in (self.OBJ, self.SO):
+            if not os.path.exists(os.path.join(self.HERE, name)):
+                self.skipTest(f"{name} not built (run `make amd64` in tests/)")
+        self.plat = platforms.Platform(
+            architecture=platforms.Architecture.X86_64,
+            byteorder=platforms.Byteorder.LITTLE,
+        )
+
+    def _load(self, name):
+        with open(os.path.join(self.HERE, name), "rb") as f:
+            return ElfExecutable(f, platform=self.plat, user_base=0x100000)
+
+    def test_image_is_zero_extended_to_the_whole_block(self):
+        # The file holds exactly one byte of TLS: `lead`. Everything after it
+        # is .tbss, which occupies no file space, so an image cut off at
+        # filesz cannot seed -- or even reach -- `wide` and `tail`.
+        image = self._load(self.SO).tls_image
+        self.assertEqual(len(image), self.BLOCK_SIZE)
+        self.assertEqual(image[0], 3, "lead lost its initializer")
+        self.assertEqual(image[1:], b"\0" * (self.BLOCK_SIZE - 1))
+
+    def test_object_file_lays_tbss_out_where_the_linker_did(self):
+        # Dropping the alignment padding puts `wide` at offset 1 instead of 8
+        # and slides `tail` with it.
+        obj = self._load(self.OBJ)
+        for name, offset in self.OFFSETS.items():
+            self.assertEqual(obj.get_symbol_value(name, rebase=False), offset, name)
+
+    def test_object_file_matches_the_linked_block(self):
+        # Same source, two forms; the linker's answer is the reference.
+        obj, so = self._load(self.OBJ), self._load(self.SO)
+        self.assertEqual(obj.tls_image, so.tls_image)
+        for name in self.OFFSETS:
+            self.assertEqual(
+                obj.get_symbol_value(name, rebase=False),
+                so.get_symbol_value(name, rebase=False),
+                name,
+            )
+
+    def test_descriptors_carry_every_thread_locals_offset(self):
+        # Three thread-locals, three distinct block offsets, in both forms.
+        for name in (self.OBJ, self.SO):
+            elf = self._load(name)
+            args = sorted(
+                int.from_bytes(elf.read_bytes(d, 16)[8:], "little")
+                for d in elf.tlsdesc_descriptors
+            )
+            self.assertEqual(args, sorted(self.OFFSETS.values()), name)
+
+
+class TlsImageSeedingTests(unittest.TestCase):
+    """The model library is what puts a module's PT_TLS image into storage.
+
+    The models hand out thread-local storage but cannot see the ELF; the
+    library is the one place holding both. Skip this and every thread-local
+    reads zero instead of its initializer, which is silent -- zero is a
+    plausible value for a `__thread int`.
+    """
+
+    HERE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tlsdesc")
+    SO = "tlsbss.gnu2.amd64.so"
+    LIBC = 0x900000
+
+    def setUp(self):
+        self.path = os.path.join(self.HERE, self.SO)
+        if not os.path.exists(self.path):
+            self.skipTest(f"{self.path} not built (run `make amd64` in tests/)")
+        FileDescriptorManager._singletons.clear()
+        ProcInfoManager._singleton = None
+        self.plat = platforms.Platform(
+            architecture=platforms.Architecture.X86_64,
+            byteorder=platforms.Byteorder.LITTLE,
+        )
+
+    def tearDown(self):
+        FileDescriptorManager._singletons.clear()
+        ProcInfoManager._singleton = None
+
+    def _load(self):
+        with open(self.path, "rb") as f:
+            return ElfExecutable(f, platform=self.plat, user_base=0x100000)
+
+    def _libc(self):
+        return POSIXLibc(self.LIBC, self.plat, platforms.ABI.SYSTEMV)
+
+    @staticmethod
+    def _arena(libc):
+        gd = libc.models["__tls_get_addr"]
+        return gd.static_buffer_address + gd.module_arena_offset(RELOCATED_TLS_MODULE)
+
+    @staticmethod
+    def _arena_bytes(libc, size):
+        # Through to_bytes(), not read_bytes(): the seed lands on top of the
+        # zeroed static buffer the library already reserved, and only the
+        # flattened image resolves the overlap the way apply() does.
+        start = TlsImageSeedingTests._arena(libc) - libc.address
+        return libc.to_bytes()[start : start + size]
+
+    def test_image_lands_where_both_dialects_look_for_it(self):
+        elf, libc = self._load(), self._libc()
+        libc.link(elf)
+        arena = self._arena(libc)
+        self.assertEqual(
+            libc.models["__tlsdesc_resolve"].tls_arena_address,
+            arena,
+            "the resolver reads somewhere the image was not seeded",
+        )
+        self.assertEqual(
+            self._arena_bytes(libc, len(elf.tls_image)),
+            elf.tls_image,
+            "the initialization image is not in the arena",
+        )
+
+    def test_oversized_image_is_truncated_with_a_warning(self):
+        # A module whose block is bigger than one arena cannot be served
+        # whole. The part that fits must still be correct, and the shortfall
+        # has to be said out loud: the thread-locals past the end read zero,
+        # which looks exactly like an uninitialized one.
+        elf, libc = self._load(), self._libc()
+        libc.link(elf)
+        capacity = libc.models["__tls_get_addr"].tls_image_capacity
+        oversized = bytes(range(256)) * (capacity // 256 + 2)
+        elf._tls_image = oversized
+        elf._tls_size = len(oversized)
+
+        with self.assertLogs("smallworld.state.models.library", "WARNING") as caught:
+            libc._seed_tls_image(elf)
+        self.assertTrue(
+            any("TLS image" in line for line in caught.output), caught.output
+        )
+        self.assertEqual(self._arena_bytes(libc, capacity), oversized[:capacity])
+
+    def test_missing_resolver_model_is_reported(self):
+        # A library with no __tlsdesc_resolve model leaves every descriptor's
+        # resolver word null, and the next thread-local access calls address
+        # zero. Nothing else in such a run would mention TLS.
+        elf, libc = self._load(), self._libc()
+        del libc.models["__tlsdesc_resolve"]
+        with self.assertLogs("smallworld.state.models.library", "WARNING") as caught:
+            libc.link(elf)
+        self.assertTrue(
+            any("__tlsdesc_resolve" in line for line in caught.output), caught.output
+        )
+        for d in elf.tlsdesc_descriptors:
+            self.assertEqual(int.from_bytes(elf.read_bytes(d, 8), "little"), 0)
+
+
 class TlsUndefinedThreadLocalTests(unittest.TestCase):
     """A thread-local no loaded module defines must not become a call to zero.
 
@@ -5460,6 +5653,16 @@ class TlsEndToEndTests(unittest.TestCase):
         # so agreeing with the shared object is the whole point.
         self.assertEqual(self._run("tlsdesc.gnu2.amd64.o"), 23)
 
+    def test_uninitialized_thread_locals_keep_the_initialized_one(self):
+        # tlsbss's bump(n) is `wide += n; return (int)wide + lead` over
+        # lead = 3 and an UNINITIALIZED wide, so 8 needs the .tbss half of
+        # the block to be reachable and zero while .tdata is still seeded.
+        self.assertEqual(self._run("tlsbss.gnu2.amd64.so"), 8)
+
+    def test_uninitialized_thread_locals_in_an_object_file(self):
+        # The same, with .tbss laid out by the loader rather than a linker.
+        self.assertEqual(self._run("tlsbss.gnu2.amd64.o"), 8)
+
 
 class TlsDescResolveModelTests(ModelTestCase):
     """c99/stdlib.py TlsDescResolve: the gnu2 TLS-descriptor resolver.
@@ -5541,6 +5744,77 @@ class TlsDescResolveModelTests(ModelTestCase):
         # pool; that is the whole point of indexing rather than allocating.
         offset = self._resolve(0xDEADBEEFDEADBEEF)
         self.assertTrue(self.ARENA <= offset < self.ARENA + self.ARENA_SIZE)
+
+    def test_requires_platform_registers(self):
+        # The descriptor ABI names its registers per architecture. A platform
+        # for which they were never filled in has to say so, rather than
+        # reading a register called "" and returning nonsense.
+        self.model.descriptor_register = ""
+        with self.assertRaises(exceptions.ConfigurationError):
+            self._resolve(0x10)
+
+    def test_degrades_when_the_backend_has_no_thread_pointer(self):
+        # ghidra and triton do not model segment bases, so asking for fsbase
+        # raises. That must degrade to handing back the arena address -- what
+        # every backend does when nothing has set a thread pointer -- rather
+        # than propagating out of a thread-local read.
+        real = self.emu.read_register
+
+        def read_register(name):
+            if name == "fsbase":
+                raise exceptions.UnsupportedRegisterError("no segment bases")
+            return real(name)
+
+        self.emu.read_register = read_register  # type: ignore[method-assign]
+        self.emu.write_memory(
+            self.DESC, (0).to_bytes(8, "little") + (0x10).to_bytes(8, "little")
+        )
+        self.emu.write_register("rax", self.DESC)
+        self.model.model(self.emu)
+        self.assertEqual(self.emu.read_register("rax"), self.ARENA + 0x10)
+
+
+class TlsDescResolveApplyTests(ModelTestCase):
+    """The resolver installs the TCB self-pointer at apply time, not call time.
+
+    gcc completes a descriptor call either by adding %fs directly or by adding
+    the word AT %fs:0, and hoists the load of that word above the call. glibc's
+    TCB starts with a self-pointer, which is what makes the two forms agree;
+    writing one during the call would already be too late.
+
+    Needs a real emulator: the mock one cannot hook functions, which
+    Model.apply insists on.
+    """
+
+    TCB = 0x600000
+
+    def test_apply_installs_the_tcb_self_pointer(self):
+        model = self.lookup("__tlsdesc_resolve")
+        emu = emulators.UnicornEmulator(MODELS_AMD64)
+        emu.write_register("fsbase", self.TCB)
+
+        model.apply(emu)
+
+        # apply() maps the word itself: a harness that maps its own TCB may
+        # not have been applied yet.
+        self.assertEqual(
+            int.from_bytes(emu.read_memory(self.TCB, 8), "little"), self.TCB
+        )
+
+    def test_apply_tolerates_a_backend_with_no_thread_pointer(self):
+        # Best effort: a backend that cannot report a thread pointer gets no
+        # self-pointer, but applying the model must still succeed.
+        model = self.lookup("__tlsdesc_resolve")
+        emu = emulators.UnicornEmulator(MODELS_AMD64)
+        real = emu.read_register
+
+        def read_register(name):
+            if name == "fsbase":
+                raise exceptions.UnsupportedRegisterError("no segment bases")
+            return real(name)
+
+        emu.read_register = read_register  # type: ignore[method-assign]
+        model.apply(emu)
 
 
 class ErrnoLocationModelTests(ModelTestCase):
@@ -5804,6 +6078,94 @@ class AMD64TlsDescRelocatorTests(unittest.TestCase):
         relocator = AMD64ElfRelocator()
         val = relocator._compute_value(self._rela(0x8, 0x4), _FakeElf())
         self.assertEqual(int.from_bytes(val[8:], "little"), 0xC)
+
+
+class AMD64TlsBlockOffsetRelocationTests(unittest.TestCase):
+    """DTPOFF relocations write a TLS-BLOCK offset, not an address.
+
+    These are the offset half of what general-dynamic (`-mtls-dialect=gnu`)
+    code hands __tls_get_addr, and what debug info uses to describe where a
+    thread-local lives. Refusing them made any image containing one
+    unloadable; resolving them like an ordinary data symbol -- by adding the
+    load base -- would hand the resolver an address to index its arena with.
+    """
+
+    #: A load address the result must NOT pick up.
+    BASE = 0x400000
+
+    def _value(self, type_, value, addend, size):
+        rela = ElfRela(
+            is_rela=True,
+            offset=0x2000,
+            type=type_,
+            symbol=_make_symbol(value=value, baseaddr=self.BASE),
+            addend=addend,
+        )
+        return AMD64ElfRelocator()._compute_value(rela, _FakeElf()), size
+
+    def test_dtpoff64_is_the_block_offset(self):
+        val, size = self._value(17, 0x8, 0, 8)  # R_X86_64_DTPOFF64
+        self.assertEqual(val, (0x8).to_bytes(size, "little"))
+
+    def test_dtpoff64_adds_the_addend(self):
+        # An addend reaches into a thread-local: `&x.field`, or `x - 8`.
+        val, size = self._value(17, 0x8, 0x4, 8)
+        self.assertEqual(val, (0xC).to_bytes(size, "little"))
+
+    def test_dtpoff32_is_the_same_offset_in_four_bytes(self):
+        val, size = self._value(21, 0x8, 0x4, 4)  # R_X86_64_DTPOFF32
+        self.assertEqual(val, (0xC).to_bytes(size, "little"))
+
+    def test_dtpoff32_truncates_rather_than_overflowing(self):
+        # A negative offset is legal and must come out as a wrapped 32-bit
+        # word, not an OverflowError from int.to_bytes.
+        val, _ = self._value(21, 0x0, -8, 4)
+        self.assertEqual(val, (0xFFFFFFF8).to_bytes(4, "little"))
+
+
+class ElfRelocatorTlsDescriptorQueryTests(unittest.TestCase):
+    """Only a relocator can say which of its relocation types is a descriptor.
+
+    The loader sweeps for descriptors whose thread-local nothing defines and
+    asks the relocator, type by type. An architecture with a descriptor ABI
+    this loader does not implement -- i386's R_386_TLS_DESC, for one -- has to
+    answer no, so the sweep leaves it alone instead of relocating it as
+    something it is not.
+    """
+
+    def _rela(self, type_):
+        return ElfRela(
+            is_rela=True,
+            offset=0x2000,
+            type=type_,
+            symbol=_make_symbol(value=0, baseaddr=0),
+            addend=0,
+        )
+
+    def test_amd64_tells_the_two_descriptor_forms_apart(self):
+        relocator = AMD64ElfRelocator()
+        linked = self._rela(36)  # R_X86_64_TLSDESC
+        unlinked = self._rela(34)  # R_X86_64_GOTPC32_TLSDESC
+        marker = self._rela(35)  # R_X86_64_TLSDESC_CALL
+
+        self.assertTrue(relocator.is_tls_descriptor(linked))
+        self.assertTrue(relocator.is_tls_descriptor_reference(unlinked))
+        # The questions are distinct: the linked form is not the unlinked one,
+        # and the call marker -- which relocates to nothing -- is neither.
+        self.assertFalse(relocator.is_tls_descriptor(unlinked))
+        self.assertFalse(relocator.is_tls_descriptor_reference(linked))
+        self.assertFalse(relocator.is_tls_descriptor(marker))
+        self.assertFalse(relocator.is_tls_descriptor_reference(marker))
+
+    def test_an_unimplemented_descriptor_abi_answers_no(self):
+        relocator = I386ElfRelocator()
+        # R_386_TLS_GOTDESC, R_386_TLS_DESC_CALL, R_386_TLS_DESC: i386 has
+        # descriptors, this loader has no i386 resolver model for them.
+        for type_ in (39, 40, 41):
+            self.assertFalse(relocator.is_tls_descriptor(self._rela(type_)), type_)
+            self.assertFalse(
+                relocator.is_tls_descriptor_reference(self._rela(type_)), type_
+            )
 
 
 class I386RelocatorTests(unittest.TestCase):

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -102,6 +102,7 @@ from smallworld.state.models.aarch64.systemv.systemv import AArch64SysVCallingCo
 from smallworld.state.models.amd64.systemv.systemv import AMD64SysVCallingContext
 from smallworld.state.models.c99.libc import C99Libc
 from smallworld.state.models.c99.stdio import Freopen, Vsprintf, Vsscanf
+from smallworld.state.models.c99.stdlib import TlsGetAddr
 from smallworld.state.models.c99.utils import _emu_memcmp, _emu_strncmp, _emu_strnlen
 from smallworld.state.models.cstd import ArgumentType
 from smallworld.state.models.defaultmmio import (
@@ -118,7 +119,7 @@ from smallworld.state.models.mips64el.systemv.systemv import (
     MIPS64ELSysVCallingContext,
 )
 from smallworld.state.models.mips.systemv.systemv import MIPSSysVCallingContext
-from smallworld.state.models.model import Model
+from smallworld.state.models.model import RELOCATED_TLS_MODULE, Model
 from smallworld.state.models.posix import POSIXLibc
 from smallworld.state.models.posix.filedesc import SockaddrIn, SocketIO
 from smallworld.state.models.posix.filedesc.sockaddr import SockaddrIn6
@@ -4928,6 +4929,72 @@ class TlsGetAddrModelTests(ModelTestCase):
         self.assertNotEqual(other, first)
 
 
+class TlsDialectAgreementTests(ModelTestCase):
+    """Both TLS dialects must reach one thread-local through the same bytes.
+
+    gcc picks a TLS dialect per translation unit, so a single image can hold
+    a general-dynamic `__tls_get_addr` reference and a gnu2 descriptor
+    reference to the SAME `__thread` variable. When the two models kept
+    separate pools this passed every test in isolation and still corrupted:
+    the write through one dialect was invisible to the read through the other.
+    """
+
+    DESC = 0x4000
+    TI = 0x4020
+    BLOCK_OFFSET = 0x10
+
+    def setUp(self):
+        super().setUp()
+        self.emu.map_memory(0x4000, 0x100)
+        self.gd = self.lookup("__tls_get_addr")
+        self.desc = self.lookup("__tlsdesc_resolve")
+        # Stand in for the library: one pool, the descriptor model aimed at
+        # the arena of the module the relocator reports.
+        self.gd.static_buffer_address = 0x60000
+        self.desc.tls_arena_address = 0x60000 + self.gd.module_arena_offset(
+            RELOCATED_TLS_MODULE
+        )
+        self.desc.tls_arena_size = self.gd.TLS_ARENA_SIZE
+
+    def _via_tls_get_addr(self, offset):
+        self.emu.write_memory(
+            self.TI,
+            RELOCATED_TLS_MODULE.to_bytes(8, "little") + offset.to_bytes(8, "little"),
+        )
+        return self.call(self.gd, self.TI)
+
+    def _via_descriptor(self, offset, thread_pointer=0):
+        self.emu.write_memory(
+            self.DESC, (0).to_bytes(8, "little") + offset.to_bytes(8, "little")
+        )
+        self.emu.write_register("rax", self.DESC)
+        self.emu.write_register("fsbase", thread_pointer)
+        self.desc.model(self.emu)
+        # gnu2 returns a thread-pointer-relative offset; the caller adds the
+        # thread pointer to get the address.
+        return (thread_pointer + self.emu.read_register("rax")) & ((1 << 64) - 1)
+
+    def test_both_dialects_reach_the_same_storage(self):
+        self.assertEqual(
+            self._via_descriptor(self.BLOCK_OFFSET),
+            self._via_tls_get_addr(self.BLOCK_OFFSET),
+        )
+
+    def test_agreement_holds_with_a_thread_pointer(self):
+        # The address the descriptor path lands on must not depend on where
+        # the thread pointer happens to sit.
+        expected = self._via_tls_get_addr(self.BLOCK_OFFSET)
+        for tp in (0, 0x60000 + 0x50000, 0x7FFF0000):
+            self.assertEqual(self._via_descriptor(self.BLOCK_OFFSET, tp), expected, tp)
+
+    def test_distinct_thread_locals_stay_distinct_across_dialects(self):
+        # Sharing storage must not collapse different thread-locals together.
+        self.assertNotEqual(
+            self._via_descriptor(self.BLOCK_OFFSET),
+            self._via_tls_get_addr(self.BLOCK_OFFSET + 8),
+        )
+
+
 class TlsDescFixtureTests(unittest.TestCase):
     """End-to-end over a real gnu2-dialect object (tests/tlsdesc).
 
@@ -5008,16 +5075,23 @@ class TlsDescFixtureTests(unittest.TestCase):
         for d in self.elf.tlsdesc_descriptors:
             self.assertEqual(self._descriptor(d)[0], model._address)
 
-    def test_library_reserves_the_resolvers_static_buffer(self):
-        # The library must hand the model a buffer inside its own region;
-        # without it the resolver raises on its first call.
+    def test_library_shares_tls_get_addrs_arena(self):
+        # The resolver owns no storage: the library must aim it at
+        # __tls_get_addr's arena for the module the relocator reports, or the
+        # two dialects read and write different bytes for one thread-local.
         libc = POSIXLibc(0x900000, self.platform, platforms.ABI.SYSTEMV)
         libc.link(self.elf)
-        model = libc.models["__tlsdesc_resolve"]
-        self.assertIsNotNone(model.static_buffer_address)
-        self.assertGreaterEqual(model.static_buffer_address, libc.address)
+        desc = libc.models["__tlsdesc_resolve"]
+        gd = libc.models["__tls_get_addr"]
+        self.assertEqual(desc.static_space_required, 0, "reserved a second pool")
+        self.assertEqual(
+            desc.tls_arena_address,
+            gd.static_buffer_address + gd.module_arena_offset(RELOCATED_TLS_MODULE),
+        )
+        self.assertEqual(desc.tls_arena_size, gd.TLS_ARENA_SIZE)
+        self.assertGreaterEqual(desc.tls_arena_address, libc.address)
         self.assertLessEqual(
-            model.static_buffer_address + model.static_space_required,
+            desc.tls_arena_address + desc.tls_arena_size,
             libc.address + libc.get_capacity(),
         )
 
@@ -5171,10 +5245,11 @@ class TlsDescResolveModelTests(ModelTestCase):
         super().setUp()
         self.emu.map_memory(self.DESC, 0x100)
         self.model = self.lookup("__tlsdesc_resolve")
-        self.model.static_buffer_address = self.ARENA
-        # Derived, not restated: shrinking the pool must shrink the bound the
-        # out-of-pool tests below check against.
-        self.ARENA_SIZE = self.model.static_space_required
+        # The library normally assigns this from __tls_get_addr's pool; the
+        # model owns no storage of its own.
+        self.ARENA_SIZE = TlsGetAddr.TLS_ARENA_SIZE
+        self.model.tls_arena_address = self.ARENA
+        self.model.tls_arena_size = self.ARENA_SIZE
 
     def _resolve(self, argument, thread_pointer=0):
         """Call the resolver the way gnu2 code does: descriptor in %rax."""
@@ -5187,8 +5262,8 @@ class TlsDescResolveModelTests(ModelTestCase):
         self.model.model(self.emu)
         return self.emu.read_register("rax")
 
-    def test_requires_static_buffer(self):
-        self.model.static_buffer_address = None
+    def test_requires_shared_arena(self):
+        self.model.tls_arena_address = None
         with self.assertRaises(exceptions.ConfigurationError):
             self._resolve(0)
 

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -91,6 +91,7 @@ from smallworld.hinting.hints import (
 from smallworld.instructions import Instruction, RegisterOperand
 from smallworld.instructions.bsid import BSIDMemoryReferenceOperand
 from smallworld.state.memory.code import Executable
+from smallworld.state.memory.elf.rela.amd64 import AMD64ElfRelocator
 from smallworld.state.memory.elf.rela.i386 import I386ElfRelocator
 from smallworld.state.memory.elf.structs import ElfRela, ElfSymbol
 from smallworld.state.memory.heap import BumpAllocator
@@ -4925,6 +4926,64 @@ class TlsGetAddrModelTests(ModelTestCase):
         self.assertNotEqual(other, first)
 
 
+class TlsDescResolveModelTests(ModelTestCase):
+    """c99/stdlib.py TlsDescResolve: the gnu2 TLS-descriptor resolver.
+
+    Unlike __tls_get_addr it returns a THREAD-POINTER-RELATIVE offset, because
+    the caller finishes the access with %fs:(%rax); the tests check the offset
+    lands back inside the arena for both a zero and a non-zero thread pointer.
+    """
+
+    DESC = 0x4000
+    ARENA = 0x60000
+    ARENA_SIZE = 0x8000
+
+    def setUp(self):
+        super().setUp()
+        self.emu.map_memory(self.DESC, 0x100)
+        self.model = self.lookup("__tlsdesc_resolve")
+        self.model.static_buffer_address = self.ARENA
+
+    def _resolve(self, argument, thread_pointer=0):
+        """Call the resolver the way gnu2 code does: descriptor in %rax."""
+        self.emu.write_memory(
+            self.DESC,
+            (0).to_bytes(8, "little") + argument.to_bytes(8, "little"),
+        )
+        self.emu.write_register("rax", self.DESC)
+        self.emu.write_register("fsbase", thread_pointer)
+        self.model.model(self.emu)
+        return self.emu.read_register("rax")
+
+    def test_requires_static_buffer(self):
+        self.model.static_buffer_address = None
+        with self.assertRaises(exceptions.ConfigurationError):
+            self._resolve(0)
+
+    def test_offset_lands_in_the_arena(self):
+        # With no thread pointer set the offset IS the address.
+        offset = self._resolve(0x10)
+        self.assertTrue(self.ARENA <= offset < self.ARENA + self.ARENA_SIZE)
+
+    def test_offset_is_thread_pointer_relative(self):
+        # The real layout puts the thread pointer above the block, so the
+        # offset is negative and wraps; the caller's add wraps it back.
+        tp = self.ARENA + 0x50000
+        offset = self._resolve(0x10, thread_pointer=tp)
+        self.assertEqual((tp + offset) & ((1 << 64) - 1), self._resolve(0x10))
+
+    def test_stable_and_distinct_storage(self):
+        first = self._resolve(0x10)
+        self.assertEqual(self._resolve(0x10), first)
+        self.assertNotEqual(self._resolve(0x20), first)
+
+    def test_garbage_argument_stays_bounded(self):
+        # A descriptor holding nonsense must not send the access out of the
+        # pool; that is the whole point of indexing rather than allocating.
+        offset = self._resolve(0xDEADBEEFDEADBEEF)
+        self.assertTrue(self.ARENA <= offset < self.ARENA + self.ARENA_SIZE)
+
+
 class ErrnoLocationModelTests(ModelTestCase):
     """posix/unistd.py ErrnoLocation: returns its static buffer address."""
 
@@ -5129,6 +5188,52 @@ class AMD64StackInitTests(unittest.TestCase):
         argv = [b"foo\0", b"barbaz\0"]  # 11 string bytes
         s = AMD64Stack.initialize_stack(argv, 0x71000000, 0x1000)
         self.assertEqual(s.get_pointer() % 16, 0)
+
+
+class AMD64TlsDescRelocatorTests(unittest.TestCase):
+    """R_X86_64_TLSDESC writes a descriptor instead of refusing to load.
+
+    Refusing cost every function in the image, not just the ones using a
+    thread-local: one unresolvable relocation made the whole ELF unloadable.
+    """
+
+    class _Elf:
+        """Minimal stand-in; the relocator only records descriptors on it."""
+
+        def __init__(self):
+            self.noted = []
+
+        def note_tlsdesc_descriptor(self, address):
+            self.noted.append(address)
+
+    def _rela(self, value, addend):
+        return ElfRela(
+            is_rela=True,
+            offset=0x2000,
+            type=36,  # R_X86_64_TLSDESC
+            symbol=_make_symbol(value=value, baseaddr=0x400000),
+            addend=addend,
+        )
+
+    def test_writes_descriptor_and_records_it(self):
+        relocator = AMD64ElfRelocator()
+        elf = self._Elf()
+        val = relocator._compute_value(self._rela(0, 0x10), elf)
+        self.assertEqual(len(val), 16, "descriptor is two words")
+        resolver = int.from_bytes(val[:8], "little")
+        argument = int.from_bytes(val[8:], "little")
+        # Resolver is left null; Library.link binds it once a model exists.
+        self.assertEqual(resolver, 0)
+        self.assertEqual(argument, 0x10)
+        self.assertEqual(elf.noted, [0x2000], "descriptor must be recorded for binding")
+
+    def test_argument_is_block_relative_not_rebased(self):
+        # A TLS symbol's st_value is an offset within the TLS block. Rebasing
+        # it by the load address turns adjacent thread-locals into addresses
+        # and loses the distinction the resolver indexes on.
+        relocator = AMD64ElfRelocator()
+        val = relocator._compute_value(self._rela(0x8, 0x4), self._Elf())
+        self.assertEqual(int.from_bytes(val[8:], "little"), 0xC)
 
 
 class I386RelocatorTests(unittest.TestCase):

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -4987,6 +4987,13 @@ class TlsDialectAgreementTests(ModelTestCase):
         for tp in (0, 0x60000 + 0x50000, 0x7FFF0000):
             self.assertEqual(self._via_descriptor(self.BLOCK_OFFSET, tp), expected, tp)
 
+    def test_negative_block_offsets_agree_across_dialects(self):
+        # A negative offset is folded specially; both models must fold it the
+        # SAME way or the split reintroduces the disagreement it was added to
+        # prevent.
+        neg = (1 << 64) - 8
+        self.assertEqual(self._via_descriptor(neg), self._via_tls_get_addr(neg))
+
     def test_distinct_thread_locals_stay_distinct_across_dialects(self):
         # Sharing storage must not collapse different thread-locals together.
         self.assertNotEqual(
@@ -5432,6 +5439,27 @@ class TlsDescResolveModelTests(ModelTestCase):
         first = self._resolve(0x10)
         self.assertEqual(self._resolve(0x10), first)
         self.assertNotEqual(self._resolve(0x20), first)
+
+    def test_negative_offset_does_not_alias_a_real_one(self):
+        # An addend like `x - 8` yields a negative block offset, which the
+        # relocator packs as a huge unsigned word. Folding that into the arena
+        # the obvious way put it on top of the legitimate offset 0xff8 -- two
+        # different thread-locals sharing storage, silently.
+        negative = self._resolve((1 << 64) - 8)
+        self.assertNotEqual(negative, self._resolve(0xFF8))
+        self.assertNotEqual(negative, self._resolve(0x8))
+
+    def test_negative_offsets_are_stable_and_distinct(self):
+        first = self._resolve((1 << 64) - 8)
+        self.assertEqual(self._resolve((1 << 64) - 8), first)
+        self.assertNotEqual(self._resolve((1 << 64) - 16), first)
+
+    def test_negative_offset_stays_bounded(self):
+        for raw in ((1 << 64) - 8, (1 << 64) - 0x100000, 1 << 63):
+            offset = self._resolve(raw)
+            self.assertTrue(
+                self.ARENA <= offset < self.ARENA + self.ARENA_SIZE, hex(raw)
+            )
 
     def test_garbage_argument_stays_bounded(self):
         # A descriptor holding nonsense must not send the access out of the

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -91,6 +91,7 @@ from smallworld.hinting.hints import (
 from smallworld.instructions import Instruction, RegisterOperand
 from smallworld.instructions.bsid import BSIDMemoryReferenceOperand
 from smallworld.state.memory.code import Executable
+from smallworld.state.memory.elf import ElfExecutable
 from smallworld.state.memory.elf.rela.amd64 import AMD64ElfRelocator
 from smallworld.state.memory.elf.rela.i386 import I386ElfRelocator
 from smallworld.state.memory.elf.structs import ElfRela, ElfSymbol
@@ -118,6 +119,7 @@ from smallworld.state.models.mips64el.systemv.systemv import (
 )
 from smallworld.state.models.mips.systemv.systemv import MIPSSysVCallingContext
 from smallworld.state.models.model import Model
+from smallworld.state.models.posix import POSIXLibc
 from smallworld.state.models.posix.filedesc import SockaddrIn, SocketIO
 from smallworld.state.models.posix.filedesc.sockaddr import SockaddrIn6
 from smallworld.state.models.posix.procinfo import ProcInfoManager
@@ -4924,6 +4926,96 @@ class TlsGetAddrModelTests(ModelTestCase):
 
         other = self.call(self.model, self.TI2)
         self.assertNotEqual(other, first)
+
+
+class TlsDescFixtureTests(unittest.TestCase):
+    """End-to-end over a real gnu2-dialect object (tests/tlsdesc).
+
+    The unit tests above drive the pieces with synthetic inputs; this one uses
+    an image a compiler actually produced, so it catches the parts no
+    hand-built rela can: that the relocation is found at all, and that the
+    descriptor argument is the symbol's TLS-block offset rather than something
+    rebased by the load address.
+
+    NOT covered here: executing the indirect call itself. That needs the image
+    mapped into a machine with the model library applied, and is worth adding
+    if the resolver's runtime behaviour ever changes.
+    """
+
+    SO = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "tlsdesc",
+        "tlsdesc.gnu2.amd64.so",
+    )
+
+    def setUp(self):
+        if not os.path.exists(self.SO):
+            self.skipTest(f"{self.SO} not built (run `make amd64` in tests/)")
+        self.platform = platforms.Platform(
+            architecture=platforms.Architecture.X86_64,
+            byteorder=platforms.Byteorder.LITTLE,
+        )
+        with open(self.SO, "rb") as f:
+            self.elf = ElfExecutable(f, platform=self.platform, user_base=0x100000)
+
+    def _descriptor(self, address):
+        raw = self.elf.read_bytes(address, 16)
+        return (
+            int.from_bytes(raw[:8], "little"),
+            int.from_bytes(raw[8:], "little"),
+        )
+
+    def test_image_loads(self):
+        # Refusing the relocation raised here, which cost every function in
+        # the image rather than only the ones using a thread-local.
+        self.assertTrue(self.elf._tlsdesc_descriptors, "no TLS descriptors found")
+
+    def test_arguments_are_distinct_block_offsets(self):
+        # The fixture has two thread-locals, so the two descriptors must carry
+        # different offsets. Rebasing the symbol value by the load address
+        # turned both into large addresses and lost the distinction.
+        args = sorted(self._descriptor(d)[1] for d in self.elf._tlsdesc_descriptors)
+        self.assertEqual(len(args), 2)
+        self.assertNotEqual(args[0], args[1])
+        for arg in args:
+            self.assertLess(
+                arg, 0x1000, "argument looks like an address, not an offset"
+            )
+
+    def test_resolver_is_null_until_linked_then_bound(self):
+        for d in self.elf._tlsdesc_descriptors:
+            self.assertEqual(self._descriptor(d)[0], 0, "resolver bound too early")
+
+        libc = POSIXLibc(0x900000, self.platform, platforms.ABI.SYSTEMV)
+        libc.link(self.elf)
+        model = libc.models.get("__tlsdesc_resolve")
+        self.assertIsNotNone(model, "library provides no __tlsdesc_resolve model")
+        for d in self.elf._tlsdesc_descriptors:
+            self.assertEqual(self._descriptor(d)[0], model._address)
+
+    def test_each_thread_local_gets_its_own_storage(self):
+        # The point of carrying the offset through: two thread-locals must not
+        # land on the same bytes.
+        libc = POSIXLibc(0x900000, self.platform, platforms.ABI.SYSTEMV)
+        libc.link(self.elf)
+        model = libc.models.get("__tlsdesc_resolve")
+        model.static_buffer_address = 0x60000
+
+        emu = emulators.UnicornEmulator(self.platform)
+        emu.map_memory(0x60000, model.static_space_required)
+        emu.map_memory(0x4000, 0x100)
+
+        offsets = []
+        for descriptor in self.elf._tlsdesc_descriptors:
+            _, argument = self._descriptor(descriptor)
+            emu.write_memory(
+                0x4000, (0).to_bytes(8, "little") + argument.to_bytes(8, "little")
+            )
+            emu.write_register("rax", 0x4000)
+            emu.write_register("fsbase", 0)
+            model.model(emu)
+            offsets.append(emu.read_register("rax"))
+        self.assertEqual(len(set(offsets)), 2, "thread-locals share storage")
 
 
 class TlsDescResolveModelTests(ModelTestCase):


### PR DESCRIPTION
R_X86_64_TLSDESC refused to relocate, and because that raised during ELF load it cost every function in the image rather than only the ones using a thread-local — on a 500-function corpus of ordinary Linux binaries, 7 such relocations across two of them made 100 functions unloadable, and the fix here largely resolves that. SmallWorld already modelled the older TLS ABI via TlsGetAddr but not the descriptor form that recent gcc emits by default, so TlsDescResolve is its counterpart on the same bounded-arena storage, differing in that it returns a thread-pointer-relative offset rather than an address (the caller finishes with %fs:(%rax)); the resolver has no address at load time, so the relocation writes the argument with a null resolver and records the descriptor for Library.link to bind.
  
The second commit adds a two-thread-local gnu2 fixture under tests/tlsdesc, built with an explicit -mtls-dialect=gnu2 so it cannot silently stop emitting the relocation, asserting the image loads, the descriptors carry distinct block-relative offsets, and each thread-local gets its own storage.
